### PR TITLE
feat: add git pre-receive hook for ACL enforcement

### DIFF
--- a/cli/schist/pre_receive.py
+++ b/cli/schist/pre_receive.py
@@ -81,20 +81,22 @@ def get_changed_files(oldrev: str, newrev: str) -> list[str]:
         # New branch — diff all files in the new ref against empty tree
         # Use git diff-tree against the empty tree hash
         result = subprocess.run(
-            ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", newrev],
+            ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", "-z", newrev],
             capture_output=True,
             text=True,
             check=True,
+            timeout=30,
         )
     else:
         result = subprocess.run(
-            ["git", "diff", "--name-only", oldrev, newrev],
+            ["git", "diff", "--name-only", "-z", oldrev, newrev],
             capture_output=True,
             text=True,
             check=True,
+            timeout=30,
         )
 
-    return [f for f in result.stdout.strip().split("\n") if f]
+    return [f for f in result.stdout.strip("\0").split("\0") if f]
 
 
 def check_push(
@@ -113,17 +115,15 @@ def check_push(
         scope = derive_scope(filepath)
 
         if scope == "":
-            # Root-level file — only wildcard writers can modify
-            if not acl.can_write(identity, "__root__"):
-                # can_write with a non-matching scope; check if they have "*"
-                entry = acl.access.get(identity)
-                if entry is None or "*" not in entry.write:
-                    violations.append(Violation(
-                        identity=identity,
-                        filepath=filepath,
-                        scope="(root)",
-                        refname=refname,
-                    ))
+            # Root-level file — only wildcard ("*") writers can modify
+            entry = acl.access.get(identity)
+            if entry is None or "*" not in entry.write:
+                violations.append(Violation(
+                    identity=identity,
+                    filepath=filepath,
+                    scope="(root)",
+                    refname=refname,
+                ))
         else:
             if not acl.can_write(identity, scope):
                 violations.append(Violation(
@@ -177,22 +177,26 @@ def log_rejection(
 
 
 def find_vault_yaml() -> Path | None:
-    """Locate vault.yaml in the repository being pushed to.
+    """Locate vault.yaml on the filesystem for non-bare repos.
 
-    In a bare repo (typical for pre-receive), vault.yaml is accessed via
-    git show HEAD:vault.yaml. For non-bare repos, check the working tree.
+    In a bare repo (typical for pre-receive), returns None so the caller
+    falls through to git show HEAD:vault.yaml instead.
     """
     git_dir = os.environ.get("GIT_DIR", ".")
 
-    # Try working tree first (non-bare repo)
-    work_tree = Path(git_dir).parent / "vault.yaml"
-    if work_tree.is_file():
-        return work_tree
+    # Check for a working tree (non-bare repo: GIT_DIR is <repo>/.git)
+    work_tree = os.environ.get("GIT_WORK_TREE")
+    if work_tree:
+        candidate = Path(work_tree) / "vault.yaml"
+        if candidate.is_file():
+            return candidate
 
-    # Bare repo — check if vault.yaml exists at HEAD
-    bare_path = Path(git_dir) / "vault.yaml"
-    if bare_path.is_file():
-        return bare_path
+    # Heuristic: if GIT_DIR ends with .git, parent is the working tree
+    git_path = Path(git_dir)
+    if git_path.name == ".git":
+        candidate = git_path.parent / "vault.yaml"
+        if candidate.is_file():
+            return candidate
 
     return None
 
@@ -205,9 +209,10 @@ def extract_vault_yaml_from_git() -> str | None:
             capture_output=True,
             text=True,
             check=True,
+            timeout=10,
         )
         return result.stdout
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return None
 
 

--- a/cli/schist/pre_receive.py
+++ b/cli/schist/pre_receive.py
@@ -1,0 +1,318 @@
+"""Git pre-receive hook for enforcing vault.yaml ACL on pushes.
+
+Validates that each pushed file is within the pusher's write scope.
+Identity is resolved from environment variables (SCHIST_IDENTITY or GL_USER).
+
+Usage as a git hook:
+    GIT_DIR/hooks/pre-receive calls this module's main().
+    stdin provides lines of: oldrev newrev refname
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from schist.acl import VaultACL, parse_vault_yaml
+
+logger = logging.getLogger("schist.pre_receive")
+
+# SHA representing a zero ref (new branch or deleted branch)
+ZERO_SHA = "0" * 40
+
+
+@dataclass
+class Violation:
+    """A single ACL violation: a file the identity cannot write."""
+
+    identity: str
+    filepath: str
+    scope: str
+    refname: str
+
+
+def resolve_identity() -> str | None:
+    """Resolve the pushing identity from environment variables.
+
+    Priority:
+    1. SCHIST_IDENTITY — explicit schist identity
+    2. GL_USER — gitolite compatibility
+    """
+    return os.environ.get("SCHIST_IDENTITY") or os.environ.get("GL_USER") or None
+
+
+def derive_scope(filepath: str) -> str:
+    """Derive the ACL scope from a file path.
+
+    For scope_convention=subdirectory:
+    - research/mario/note.md  → research/mario
+    - research/note.md        → research
+    - vault.yaml              → (root) — empty string means root-level file
+
+    The returned scope is the directory portion of the path, normalized
+    to prevent path traversal attacks (e.g. research/mario/../hbcd/).
+    Root-level files return empty string, which requires "*" write access.
+    """
+    # normpath resolves ".." segments without touching the filesystem
+    normalized = os.path.normpath(filepath)
+    parent = str(Path(normalized).parent)
+    if parent == ".":
+        return ""
+    return parent
+
+
+def get_changed_files(oldrev: str, newrev: str) -> list[str]:
+    """Get list of files changed between two revisions.
+
+    Handles special cases:
+    - New branch (oldrev is zero): diff against empty tree
+    - Deleted branch (newrev is zero): no files to check
+    """
+    if newrev == ZERO_SHA:
+        # Branch deletion — nothing to check
+        return []
+
+    if oldrev == ZERO_SHA:
+        # New branch — diff all files in the new ref against empty tree
+        # Use git diff-tree against the empty tree hash
+        result = subprocess.run(
+            ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", newrev],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    else:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", oldrev, newrev],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    return [f for f in result.stdout.strip().split("\n") if f]
+
+
+def check_push(
+    identity: str,
+    changed_files: list[str],
+    acl: VaultACL,
+    refname: str,
+) -> list[Violation]:
+    """Check all changed files against the identity's write ACL.
+
+    Returns a list of Violation objects for any out-of-scope writes.
+    """
+    violations: list[Violation] = []
+
+    for filepath in changed_files:
+        scope = derive_scope(filepath)
+
+        if scope == "":
+            # Root-level file — only wildcard writers can modify
+            if not acl.can_write(identity, "__root__"):
+                # can_write with a non-matching scope; check if they have "*"
+                entry = acl.access.get(identity)
+                if entry is None or "*" not in entry.write:
+                    violations.append(Violation(
+                        identity=identity,
+                        filepath=filepath,
+                        scope="(root)",
+                        refname=refname,
+                    ))
+        else:
+            if not acl.can_write(identity, scope):
+                violations.append(Violation(
+                    identity=identity,
+                    filepath=filepath,
+                    scope=scope,
+                    refname=refname,
+                ))
+
+    return violations
+
+
+def format_rejection(violations: list[Violation]) -> str:
+    """Format a human-readable rejection message."""
+    lines = [
+        "REJECTED: push contains out-of-scope writes",
+        f"Identity: {violations[0].identity}",
+        "",
+        "Violations:",
+    ]
+    for v in violations:
+        lines.append(f"  - {v.filepath} (scope: {v.scope})")
+    lines.append("")
+    lines.append("Check vault.yaml access rules for your identity.")
+    return "\n".join(lines)
+
+
+def log_rejection(
+    violations: list[Violation],
+    log_path: Path | None = None,
+) -> None:
+    """Append rejection details to the audit log."""
+    if log_path is None:
+        # Default: alongside the hook in GIT_DIR/hooks/
+        git_dir = os.environ.get("GIT_DIR", ".")
+        log_path = Path(git_dir) / "hooks" / "rejected-pushes.log"
+
+    timestamp = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+    identity = violations[0].identity
+    refname = violations[0].refname
+    files = ", ".join(v.filepath for v in violations)
+
+    entry = f"[{timestamp}] REJECTED identity={identity} ref={refname} files=[{files}]\n"
+
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "a") as f:
+            f.write(entry)
+    except OSError as e:
+        logger.warning("Failed to write rejection log: %s", e)
+
+
+def find_vault_yaml() -> Path | None:
+    """Locate vault.yaml in the repository being pushed to.
+
+    In a bare repo (typical for pre-receive), vault.yaml is accessed via
+    git show HEAD:vault.yaml. For non-bare repos, check the working tree.
+    """
+    git_dir = os.environ.get("GIT_DIR", ".")
+
+    # Try working tree first (non-bare repo)
+    work_tree = Path(git_dir).parent / "vault.yaml"
+    if work_tree.is_file():
+        return work_tree
+
+    # Bare repo — check if vault.yaml exists at HEAD
+    bare_path = Path(git_dir) / "vault.yaml"
+    if bare_path.is_file():
+        return bare_path
+
+    return None
+
+
+def extract_vault_yaml_from_git() -> str | None:
+    """Extract vault.yaml content from HEAD in a bare repository."""
+    try:
+        result = subprocess.run(
+            ["git", "show", "HEAD:vault.yaml"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout
+    except subprocess.CalledProcessError:
+        return None
+
+
+def load_acl() -> VaultACL | None:
+    """Load vault.yaml ACL, trying filesystem first, then git show."""
+    path = find_vault_yaml()
+    if path is not None:
+        return parse_vault_yaml(path)
+
+    # Bare repo fallback: extract from git
+    content = extract_vault_yaml_from_git()
+    if content is not None:
+        import yaml
+
+        from schist.acl import parse_vault_data
+
+        data = yaml.safe_load(content)
+        return parse_vault_data(data)
+
+    return None
+
+
+def main(
+    stdin: list[str] | None = None,
+    acl: VaultACL | None = None,
+    identity: str | None = None,
+    log_path: Path | None = None,
+) -> int:
+    """Pre-receive hook entry point.
+
+    Args:
+        stdin: Lines from stdin (oldrev newrev refname). None reads sys.stdin.
+        acl: Pre-loaded VaultACL. None loads from vault.yaml.
+        identity: Override identity. None resolves from environment.
+        log_path: Override rejection log path.
+
+    Returns:
+        0 if push is allowed, 1 if rejected.
+    """
+    # Resolve identity
+    if identity is None:
+        identity = resolve_identity()
+    if identity is None:
+        print("REJECTED: cannot determine push identity", file=sys.stderr)
+        print(
+            "Set SCHIST_IDENTITY or GL_USER environment variable.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Load ACL
+    if acl is None:
+        try:
+            acl = load_acl()
+        except Exception as e:
+            print(f"REJECTED: failed to load vault.yaml: {e}", file=sys.stderr)
+            return 1
+
+    if acl is None:
+        # No vault.yaml — allow push (vault.yaml is optional per spec)
+        return 0
+
+    # Verify identity is a known participant
+    if acl.get_participant(identity) is None:
+        print(
+            f"REJECTED: unknown identity '{identity}' — "
+            "not listed in vault.yaml participants",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Read push refs from stdin
+    if stdin is None:
+        stdin = sys.stdin.read().strip().split("\n")
+
+    all_violations: list[Violation] = []
+
+    for line in stdin:
+        line = line.strip()
+        if not line:
+            continue
+
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+
+        oldrev, newrev, refname = parts[0], parts[1], parts[2]
+
+        try:
+            changed_files = get_changed_files(oldrev, newrev)
+        except subprocess.CalledProcessError as e:
+            print(f"ERROR: failed to diff {oldrev}..{newrev}: {e}", file=sys.stderr)
+            return 1
+
+        violations = check_push(identity, changed_files, acl, refname)
+        all_violations.extend(violations)
+
+    if all_violations:
+        msg = format_rejection(all_violations)
+        print(msg, file=sys.stderr)
+        log_rejection(all_violations, log_path=log_path)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cli/tests/test_pre_receive.py
+++ b/cli/tests/test_pre_receive.py
@@ -420,7 +420,7 @@ class TestGetChangedFiles:
     def test_normal_diff(self):
         from schist.pre_receive import get_changed_files
 
-        mock_result = type("Result", (), {"stdout": "a.md\nb.md\n", "returncode": 0})()
+        mock_result = type("Result", (), {"stdout": "a.md\0b.md\0", "returncode": 0})()
         with patch("subprocess.run", return_value=mock_result):
             result = get_changed_files("aaa", "bbb")
         assert result == ["a.md", "b.md"]
@@ -428,7 +428,7 @@ class TestGetChangedFiles:
     def test_new_branch_uses_diff_tree(self):
         from schist.pre_receive import ZERO_SHA, get_changed_files
 
-        mock_result = type("Result", (), {"stdout": "new-file.md\n", "returncode": 0})()
+        mock_result = type("Result", (), {"stdout": "new-file.md\0", "returncode": 0})()
         with patch("subprocess.run", return_value=mock_result) as mock_run:
             result = get_changed_files(ZERO_SHA, "abc123")
         assert result == ["new-file.md"]

--- a/cli/tests/test_pre_receive.py
+++ b/cli/tests/test_pre_receive.py
@@ -1,0 +1,480 @@
+"""Tests for the git pre-receive hook ACL enforcement."""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from schist.acl import VaultACL, parse_vault_data
+from schist.pre_receive import (
+    Violation,
+    check_push,
+    derive_scope,
+    format_rejection,
+    log_rejection,
+    main,
+    resolve_identity,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+VAULT_DATA = {
+    "name": "test-vault",
+    "vault_version": 1,
+    "scope_convention": "subdirectory",
+    "participants": [
+        {"name": "admin", "type": "agent"},
+        {"name": "cluster-mario", "type": "spoke", "transport": "git-only"},
+        {"name": "cluster-hbcd", "type": "spoke", "transport": "git-only"},
+        {"name": "researcher", "type": "agent"},
+        {"name": "narrow-writer", "type": "agent"},
+    ],
+    "access": {
+        "admin": {"read": ["*"], "write": ["*"]},
+        "cluster-mario": {"read": ["*"], "write": ["research/mario"]},
+        "cluster-hbcd": {"read": ["*"], "write": ["research/hbcd"]},
+        "researcher": {"read": ["*"], "write": ["research"]},
+        "narrow-writer": {"read": ["*"], "write": ["ops"]},
+    },
+}
+
+
+@pytest.fixture()
+def acl() -> VaultACL:
+    return parse_vault_data(VAULT_DATA)
+
+
+# ---------------------------------------------------------------------------
+# derive_scope
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveScope:
+    def test_nested_file(self):
+        assert derive_scope("research/mario/2026-04-01-findings.md") == "research/mario"
+
+    def test_single_dir(self):
+        assert derive_scope("research/note.md") == "research"
+
+    def test_deeply_nested(self):
+        assert derive_scope("a/b/c/d/file.txt") == "a/b/c/d"
+
+    def test_root_level_file(self):
+        assert derive_scope("vault.yaml") == ""
+
+    def test_root_level_readme(self):
+        assert derive_scope("README.md") == ""
+
+    def test_dir_with_dotfile(self):
+        assert derive_scope("ops/.gitkeep") == "ops"
+
+
+# ---------------------------------------------------------------------------
+# resolve_identity
+# ---------------------------------------------------------------------------
+
+
+class TestResolveIdentity:
+    def test_schist_identity_takes_priority(self):
+        with patch.dict("os.environ", {"SCHIST_IDENTITY": "cluster-mario", "GL_USER": "gitolite-user"}):
+            assert resolve_identity() == "cluster-mario"
+
+    def test_gl_user_fallback(self):
+        env = {"GL_USER": "cluster-hbcd"}
+        with patch.dict("os.environ", env, clear=True):
+            assert resolve_identity() == "cluster-hbcd"
+
+    def test_none_when_no_env(self):
+        with patch.dict("os.environ", {}, clear=True):
+            assert resolve_identity() is None
+
+    def test_empty_schist_identity_falls_through(self):
+        with patch.dict("os.environ", {"SCHIST_IDENTITY": "", "GL_USER": "fallback"}):
+            assert resolve_identity() == "fallback"
+
+
+# ---------------------------------------------------------------------------
+# check_push — core ACL enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPush:
+    def test_in_scope_write_allowed(self, acl):
+        files = ["research/mario/note.md", "research/mario/sub/deep.md"]
+        violations = check_push("cluster-mario", files, acl, "refs/heads/main")
+        assert violations == []
+
+    def test_out_of_scope_write_rejected(self, acl):
+        files = ["security/secrets.md"]
+        violations = check_push("cluster-mario", files, acl, "refs/heads/main")
+        assert len(violations) == 1
+        assert violations[0].filepath == "security/secrets.md"
+        assert violations[0].scope == "security"
+        assert violations[0].identity == "cluster-mario"
+
+    def test_mixed_in_and_out_of_scope(self, acl):
+        files = [
+            "research/mario/ok.md",
+            "security/bad.md",
+            "ops/also-bad.md",
+        ]
+        violations = check_push("cluster-mario", files, acl, "refs/heads/main")
+        assert len(violations) == 2
+        bad_files = {v.filepath for v in violations}
+        assert bad_files == {"security/bad.md", "ops/also-bad.md"}
+
+    def test_admin_wildcard_allows_everything(self, acl):
+        files = [
+            "research/mario/note.md",
+            "security/audit.md",
+            "ops/deploy.md",
+            "vault.yaml",  # root-level
+        ]
+        violations = check_push("admin", files, acl, "refs/heads/main")
+        assert violations == []
+
+    def test_root_file_rejected_for_non_wildcard(self, acl):
+        files = ["vault.yaml"]
+        violations = check_push("cluster-mario", files, acl, "refs/heads/main")
+        assert len(violations) == 1
+        assert violations[0].scope == "(root)"
+
+    def test_root_file_allowed_for_wildcard_writer(self, acl):
+        files = ["vault.yaml", "README.md"]
+        violations = check_push("admin", files, acl, "refs/heads/main")
+        assert violations == []
+
+    def test_parent_scope_grants_child_write(self, acl):
+        """researcher has write:[research] — should cover research/mario/."""
+        files = ["research/mario/note.md", "research/hbcd/data.md"]
+        violations = check_push("researcher", files, acl, "refs/heads/main")
+        assert violations == []
+
+    def test_child_scope_does_not_grant_parent(self, acl):
+        """cluster-mario has write:[research/mario] — cannot write research/."""
+        files = ["research/top-level-note.md"]
+        violations = check_push("cluster-mario", files, acl, "refs/heads/main")
+        assert len(violations) == 1
+        assert violations[0].scope == "research"
+
+    def test_sibling_scope_rejected(self, acl):
+        """cluster-mario cannot write research/hbcd/."""
+        files = ["research/hbcd/stolen.md"]
+        violations = check_push("cluster-mario", files, acl, "refs/heads/main")
+        assert len(violations) == 1
+
+    def test_empty_file_list(self, acl):
+        violations = check_push("cluster-mario", [], acl, "refs/heads/main")
+        assert violations == []
+
+    def test_similar_prefix_no_false_match(self, acl):
+        """research-extra/ should NOT match scope 'research'."""
+        files = ["research-extra/note.md"]
+        violations = check_push("researcher", files, acl, "refs/heads/main")
+        assert len(violations) == 1
+
+    def test_refname_preserved_in_violation(self, acl):
+        files = ["security/bad.md"]
+        violations = check_push("cluster-mario", files, acl, "refs/heads/feature")
+        assert violations[0].refname == "refs/heads/feature"
+
+
+# ---------------------------------------------------------------------------
+# format_rejection
+# ---------------------------------------------------------------------------
+
+
+class TestFormatRejection:
+    def test_single_violation(self):
+        violations = [Violation("cluster-mario", "security/bad.md", "security", "refs/heads/main")]
+        msg = format_rejection(violations)
+        assert "REJECTED" in msg
+        assert "cluster-mario" in msg
+        assert "security/bad.md" in msg
+
+    def test_multiple_violations(self):
+        violations = [
+            Violation("cluster-mario", "security/a.md", "security", "refs/heads/main"),
+            Violation("cluster-mario", "ops/b.md", "ops", "refs/heads/main"),
+        ]
+        msg = format_rejection(violations)
+        assert "security/a.md" in msg
+        assert "ops/b.md" in msg
+
+    def test_includes_scope_in_parens(self):
+        violations = [Violation("x", "a/b.md", "a", "refs/heads/main")]
+        msg = format_rejection(violations)
+        assert "(scope: a)" in msg
+
+
+# ---------------------------------------------------------------------------
+# log_rejection
+# ---------------------------------------------------------------------------
+
+
+class TestLogRejection:
+    def test_creates_log_entry(self, tmp_path):
+        log_path = tmp_path / "rejected-pushes.log"
+        violations = [
+            Violation("cluster-mario", "security/bad.md", "security", "refs/heads/main"),
+        ]
+        log_rejection(violations, log_path=log_path)
+
+        content = log_path.read_text()
+        assert "REJECTED" in content
+        assert "cluster-mario" in content
+        assert "security/bad.md" in content
+        assert "refs/heads/main" in content
+
+    def test_appends_to_existing_log(self, tmp_path):
+        log_path = tmp_path / "rejected-pushes.log"
+        log_path.write_text("[previous entry]\n")
+
+        violations = [Violation("x", "a.md", "a", "refs/heads/main")]
+        log_rejection(violations, log_path=log_path)
+
+        content = log_path.read_text()
+        assert "[previous entry]" in content
+        assert "REJECTED" in content
+
+    def test_creates_parent_dirs(self, tmp_path):
+        log_path = tmp_path / "deep" / "nested" / "rejected-pushes.log"
+        violations = [Violation("x", "a.md", "a", "refs/heads/main")]
+        log_rejection(violations, log_path=log_path)
+        assert log_path.exists()
+
+    def test_multiple_files_in_entry(self, tmp_path):
+        log_path = tmp_path / "rejected-pushes.log"
+        violations = [
+            Violation("mario", "a.md", "a", "refs/heads/main"),
+            Violation("mario", "b.md", "b", "refs/heads/main"),
+        ]
+        log_rejection(violations, log_path=log_path)
+        content = log_path.read_text()
+        assert "a.md, b.md" in content
+
+    def test_iso_timestamp_in_log(self, tmp_path):
+        log_path = tmp_path / "rejected-pushes.log"
+        violations = [Violation("x", "a.md", "a", "refs/heads/main")]
+        log_rejection(violations, log_path=log_path)
+        content = log_path.read_text()
+        # Should contain ISO 8601 timestamp with timezone
+        assert "+00:00" in content or "Z" in content
+
+
+# ---------------------------------------------------------------------------
+# main() integration — mocked git subprocess
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    """Integration tests for the main() entry point with mocked git."""
+
+    def _run(
+        self,
+        acl: VaultACL,
+        identity: str,
+        stdin_lines: list[str],
+        changed_files: list[str],
+        log_path: Path | None = None,
+    ) -> int:
+        """Helper to run main() with mocked get_changed_files."""
+        with patch("schist.pre_receive.get_changed_files", return_value=changed_files):
+            return main(
+                stdin=stdin_lines,
+                acl=acl,
+                identity=identity,
+                log_path=log_path,
+            )
+
+    def test_allow_in_scope_push(self, acl):
+        stdin = ["abc123 def456 refs/heads/main"]
+        rc = self._run(acl, "cluster-mario", stdin, ["research/mario/note.md"])
+        assert rc == 0
+
+    def test_reject_out_of_scope_push(self, acl, tmp_path, capsys):
+        log_path = tmp_path / "rejected-pushes.log"
+        stdin = ["abc123 def456 refs/heads/main"]
+        rc = self._run(
+            acl, "cluster-mario", stdin,
+            ["security/bad.md"],
+            log_path=log_path,
+        )
+        assert rc == 1
+        stderr = capsys.readouterr().err
+        assert "REJECTED" in stderr
+        assert log_path.exists()
+
+    def test_no_identity_rejects(self, acl, capsys):
+        rc = main(stdin=["abc def refs/heads/main"], acl=acl, identity=None)
+        # identity=None and no env vars → should reject
+        with patch.dict("os.environ", {}, clear=True):
+            rc = main(stdin=["abc def refs/heads/main"], acl=acl)
+        assert rc == 1
+        stderr = capsys.readouterr().err
+        assert "cannot determine push identity" in stderr
+
+    def test_unknown_identity_rejects(self, acl, capsys):
+        stdin = ["abc123 def456 refs/heads/main"]
+        with patch("schist.pre_receive.get_changed_files", return_value=[]):
+            rc = main(stdin=stdin, acl=acl, identity="unknown-agent")
+        assert rc == 1
+        stderr = capsys.readouterr().err
+        assert "unknown identity" in stderr
+
+    def test_no_vault_yaml_allows_push(self):
+        """If no vault.yaml exists, push is allowed (vault.yaml is optional)."""
+        with patch("schist.pre_receive.load_acl", return_value=None):
+            rc = main(
+                stdin=["abc def refs/heads/main"],
+                identity="anyone",
+            )
+        assert rc == 0
+
+    def test_empty_stdin(self, acl):
+        rc = self._run(acl, "admin", [""], [])
+        assert rc == 0
+
+    def test_multiple_refs(self, acl, tmp_path):
+        """Multiple ref updates in a single push."""
+        stdin = [
+            "aaa bbb refs/heads/main",
+            "ccc ddd refs/heads/feature",
+        ]
+        # Both refs change only in-scope files
+        with patch("schist.pre_receive.get_changed_files", return_value=["research/mario/note.md"]):
+            rc = main(stdin=stdin, acl=acl, identity="cluster-mario")
+        assert rc == 0
+
+    def test_multiple_refs_one_bad(self, acl, tmp_path, capsys):
+        """One ref is fine, another has out-of-scope files."""
+        log_path = tmp_path / "rejected-pushes.log"
+        call_count = [0]
+        files_per_call = [
+            ["research/mario/ok.md"],
+            ["security/bad.md"],
+        ]
+
+        def mock_changed_files(oldrev, newrev):
+            idx = call_count[0]
+            call_count[0] += 1
+            return files_per_call[idx]
+
+        stdin = [
+            "aaa bbb refs/heads/main",
+            "ccc ddd refs/heads/feature",
+        ]
+        with patch("schist.pre_receive.get_changed_files", side_effect=mock_changed_files):
+            rc = main(stdin=stdin, acl=acl, identity="cluster-mario", log_path=log_path)
+        assert rc == 1
+
+    def test_deleted_branch_allowed(self, acl):
+        """Deleting a branch (newrev=0*40) should always be allowed."""
+        zero = "0" * 40
+        stdin = [f"abc123 {zero} refs/heads/old-branch"]
+        with patch("schist.pre_receive.get_changed_files", return_value=[]):
+            rc = main(stdin=stdin, acl=acl, identity="cluster-mario")
+        assert rc == 0
+
+    def test_admin_can_push_anything(self, acl):
+        stdin = ["abc def refs/heads/main"]
+        files = [
+            "vault.yaml",
+            "research/mario/a.md",
+            "security/audit.md",
+            "ops/deploy.yaml",
+        ]
+        rc = self._run(acl, "admin", stdin, files)
+        assert rc == 0
+
+    def test_narrow_writer_blocked_outside_scope(self, acl, capsys):
+        stdin = ["abc def refs/heads/main"]
+        files = ["research/mario/note.md"]
+        rc = self._run(acl, "narrow-writer", stdin, files)
+        assert rc == 1
+
+    def test_narrow_writer_allowed_in_scope(self, acl):
+        stdin = ["abc def refs/heads/main"]
+        files = ["ops/status.md", "ops/sub/deep.md"]
+        rc = self._run(acl, "narrow-writer", stdin, files)
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# get_changed_files — subprocess mocking
+# ---------------------------------------------------------------------------
+
+
+class TestGetChangedFiles:
+    def test_deleted_branch_returns_empty(self):
+        from schist.pre_receive import ZERO_SHA, get_changed_files
+
+        result = get_changed_files("abc123", ZERO_SHA)
+        assert result == []
+
+    def test_normal_diff(self):
+        from schist.pre_receive import get_changed_files
+
+        mock_result = type("Result", (), {"stdout": "a.md\nb.md\n", "returncode": 0})()
+        with patch("subprocess.run", return_value=mock_result):
+            result = get_changed_files("aaa", "bbb")
+        assert result == ["a.md", "b.md"]
+
+    def test_new_branch_uses_diff_tree(self):
+        from schist.pre_receive import ZERO_SHA, get_changed_files
+
+        mock_result = type("Result", (), {"stdout": "new-file.md\n", "returncode": 0})()
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            result = get_changed_files(ZERO_SHA, "abc123")
+        assert result == ["new-file.md"]
+        # Should use diff-tree for new branches
+        cmd = mock_run.call_args[0][0]
+        assert "diff-tree" in cmd
+
+    def test_empty_diff_returns_empty(self):
+        from schist.pre_receive import get_changed_files
+
+        mock_result = type("Result", (), {"stdout": "", "returncode": 0})()
+        with patch("subprocess.run", return_value=mock_result):
+            result = get_changed_files("aaa", "bbb")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_file_in_scope_subdir_with_dots(self, acl):
+        """Files with dots in directory names should work."""
+        files = ["research/mario/2026.04.01/note.md"]
+        violations = check_push("cluster-mario", files, acl, "refs/heads/main")
+        assert violations == []
+
+    def test_gitkeep_in_scope(self, acl):
+        files = ["research/mario/.gitkeep"]
+        violations = check_push("cluster-mario", files, acl, "refs/heads/main")
+        assert violations == []
+
+    def test_path_traversal_attempt(self, acl):
+        """Path traversal in file path is checked against derived scope."""
+        # derive_scope normalizes via Path, but the scope check should still work
+        files = ["research/mario/../hbcd/stolen.md"]
+        violations = check_push("cluster-mario", files, acl, "refs/heads/main")
+        # Path("research/mario/../hbcd/stolen.md").parent resolves to "research/hbcd"
+        # cluster-mario cannot write research/hbcd
+        assert len(violations) == 1
+
+    def test_vault_yaml_load_failure_rejects(self, capsys):
+        """If vault.yaml fails to parse, push is rejected."""
+        with patch("schist.pre_receive.load_acl", side_effect=Exception("parse error")):
+            rc = main(stdin=["abc def refs/heads/main"], identity="anyone")
+        assert rc == 1
+        stderr = capsys.readouterr().err
+        assert "failed to load vault.yaml" in stderr

--- a/hooks/pre-receive
+++ b/hooks/pre-receive
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Git pre-receive hook — enforces vault.yaml ACL on pushes.
+
+Install into a bare repo:
+    cp hooks/pre-receive <bare-repo>/hooks/pre-receive
+    chmod +x <bare-repo>/hooks/pre-receive
+
+Requires:
+    - schist package installed (pip install -e cli/)
+    - SCHIST_IDENTITY env var set (or GL_USER for gitolite)
+"""
+
+import sys
+
+from schist.pre_receive import main
+
+sys.exit(main())


### PR DESCRIPTION
## Summary

- **Pre-receive hook** (`cli/schist/pre_receive.py`) that validates pushed files against `vault.yaml` ACL rules at push time, rejecting out-of-scope writes before they land in the repository
- **Identity resolution** from environment variables (`SCHIST_IDENTITY` or `GL_USER` for gitolite compatibility), with clear rejection messages when identity cannot be determined or is not a known participant
- **Scope derivation** from file paths using the subdirectory convention — parent scope grants child write access, path traversal attempts are normalized, and root-level files require wildcard (`*`) write access
- **Rejection logging** with audit trail to `rejected-pushes.log` including ISO 8601 timestamps, identity, ref, and affected files
- **Shell wrapper** (`hooks/pre-receive`) for easy installation into bare repositories

## Test coverage

50 tests across 7 test classes covering:
- Scope derivation (nested, root-level, dotfiles)
- Identity resolution (priority, fallback, missing)
- Core ACL enforcement (in-scope, out-of-scope, mixed, wildcard, parent/child/sibling scopes)
- Rejection formatting and audit logging
- Integration tests with mocked git subprocess (multi-ref pushes, branch deletion, unknown identity, missing vault.yaml)
- Edge cases (path traversal, dot-containing directories, similar prefix matching)

## Test plan

- [x] All 50 tests pass (`python -m pytest cli/tests/test_pre_receive.py -v`)
- [ ] Manual integration test: install hook in a bare repo, push in-scope and out-of-scope files
- [ ] Verify rejection log format and audit trail

🤖 Generated with [Claude Code](https://claude.com/claude-code)