### PR TITLE
feat: add hub+spoke sync CLI

### DIFF
--- a/cli/schist/__main__.py
+++ b/cli/schist/__main__.py
@@ -77,7 +77,7 @@ def main():
 
     # init --spoke: vault doesn't exist yet, special path
     if args.command == 'init' and getattr(args, 'spoke', False):
-        vault_path = args.vault or os.path.basename(args.hub or 'vault').replace('.git', '')
+        vault_path = args.vault or os.path.basename(args.hub or 'vault').removesuffix('.git')
         db_path = args.db or os.path.join(vault_path, '.schist', 'schist.db')
         sync.init_spoke(args, vault_path, db_path)
         sys.exit(0)

--- a/cli/schist/__main__.py
+++ b/cli/schist/__main__.py
@@ -5,7 +5,7 @@ import argparse
 import os
 import sys
 
-from . import commands
+from . import commands, sync
 
 
 def main():
@@ -55,11 +55,32 @@ def main():
     p_schema = sub.add_parser('schema', help='Print or validate schema')
     p_schema.add_argument('--validate', action='store_true')
 
+    # init
+    p_init = sub.add_parser('init', help='Initialize a vault')
+    p_init.add_argument('--spoke', action='store_true', help='Initialize as spoke vault')
+    p_init.add_argument('--hub', help='Hub repository URL')
+    p_init.add_argument('--scope', help='Scope to sync (directory path)')
+    p_init.add_argument('--identity', default=os.environ.get('SCHIST_IDENTITY'),
+                        help='Spoke identity (or set SCHIST_IDENTITY)')
+
+    # sync
+    p_sync = sub.add_parser('sync', help='Sync spoke vault with hub')
+    sync_sub = p_sync.add_subparsers(dest='sync_action')
+    sync_sub.add_parser('pull', help='Pull updates from hub')
+    sync_sub.add_parser('push', help='Push local changes to hub')
+
     args = parser.parse_args()
 
     if not args.command:
         parser.print_help()
         sys.exit(1)
+
+    # init --spoke: vault doesn't exist yet, special path
+    if args.command == 'init' and getattr(args, 'spoke', False):
+        vault_path = args.vault or os.path.basename(args.hub or 'vault').replace('.git', '')
+        db_path = args.db or os.path.join(vault_path, '.schist', 'schist.db')
+        sync.init_spoke(args, vault_path, db_path)
+        sys.exit(0)
 
     vault_path = args.vault
     if not vault_path:
@@ -67,6 +88,17 @@ def main():
         sys.exit(1)
 
     db_path = args.db or os.path.join(vault_path, '.schist', 'schist.db')
+
+    # sync sub-dispatch
+    if args.command == 'sync':
+        if args.sync_action == 'pull':
+            sync.sync_pull(args, vault_path, db_path)
+        elif args.sync_action == 'push':
+            sync.sync_push(args, vault_path, db_path)
+        else:
+            print('Usage: schist sync {pull|push}', file=sys.stderr)
+            sys.exit(1)
+        sys.exit(0)
 
     dispatch = {
         'add': commands.add,

--- a/cli/schist/git_ops.py
+++ b/cli/schist/git_ops.py
@@ -88,6 +88,11 @@ def pull_rebase(vault_path: str) -> tuple[bool, str]:
             return False, output.strip()
         return True, output.strip()
     except subprocess.TimeoutExpired:
+        # Abort any in-progress rebase to restore clean state
+        subprocess.run(
+            ['git', 'rebase', '--abort'],
+            cwd=vault_path, capture_output=True, text=True,
+        )
         return False, "Pull timed out after 60s"
     except subprocess.CalledProcessError as e:
         return False, (e.stdout or '') + (e.stderr or '')
@@ -119,28 +124,35 @@ def has_uncommitted_changes(vault_path: str) -> bool:
 
 
 def has_unpushed_commits(vault_path: str) -> bool:
-    """Check if local branch is ahead of origin."""
+    """Check if local branch is ahead of origin.
+
+    Returns True if there are unpushed commits, or if the check fails
+    (erring on the side of attempting a push).
+    """
     branch = current_branch(vault_path)
+    if not branch:
+        return True  # Detached HEAD — let push attempt and report the real error
     result = subprocess.run(
         ['git', 'rev-list', f'origin/{branch}..HEAD', '--count'],
         cwd=vault_path, capture_output=True, text=True,
     )
+    if result.returncode != 0:
+        return True  # Can't determine — assume yes so push is attempted
     try:
         return int(result.stdout.strip()) > 0
     except ValueError:
-        return False
+        return True
 
 
 def stage_scope_files(vault_path: str, scope: str) -> tuple[bool, str]:
-    """Stage all files within the scope directory."""
+    """Stage all files within the scope directory.
+
+    Only stages files under the scope path. Root-level files (vault.yaml,
+    schist.yaml) are NOT staged — spokes should not modify those.
+    """
     try:
         result = subprocess.run(
             ['git', 'add', scope + '/'],
-            cwd=vault_path, capture_output=True, text=True,
-        )
-        # Also stage root-level files that may have changed
-        subprocess.run(
-            ['git', 'add', '*.yaml', '*.md'],
             cwd=vault_path, capture_output=True, text=True,
         )
         output = result.stdout + result.stderr

--- a/cli/schist/git_ops.py
+++ b/cli/schist/git_ops.py
@@ -28,3 +28,122 @@ def current_branch(vault_path: str) -> str:
         cwd=vault_path, capture_output=True, text=True,
     )
     return result.stdout.strip()
+
+
+def clone_shallow(hub_url: str, dest: str, depth: int = 1) -> tuple[bool, str]:
+    """Shallow clone from hub with no checkout (for sparse-checkout setup)."""
+    try:
+        result = subprocess.run(
+            ['git', 'clone', f'--depth={depth}', '--no-checkout', hub_url, dest],
+            capture_output=True, text=True, timeout=120,
+        )
+        output = result.stdout + result.stderr
+        return result.returncode == 0, output.strip()
+    except subprocess.TimeoutExpired:
+        return False, "Clone timed out after 120s"
+    except subprocess.CalledProcessError as e:
+        return False, (e.stdout or '') + (e.stderr or '')
+
+
+def setup_sparse_checkout(vault_path: str, scope: str) -> tuple[bool, str]:
+    """Enable sparse-checkout cone mode and set scope directories.
+
+    Cone mode includes all root-level files automatically, so vault.yaml
+    and other root configs are always available.
+    """
+    try:
+        subprocess.run(
+            ['git', 'sparse-checkout', 'init', '--cone'],
+            cwd=vault_path, check=True, capture_output=True, text=True,
+        )
+        subprocess.run(
+            ['git', 'sparse-checkout', 'set', scope],
+            cwd=vault_path, check=True, capture_output=True, text=True,
+        )
+        result = subprocess.run(
+            ['git', 'checkout'],
+            cwd=vault_path, capture_output=True, text=True,
+        )
+        output = result.stdout + result.stderr
+        return result.returncode == 0, output.strip()
+    except subprocess.CalledProcessError as e:
+        return False, (e.stdout or '') + (e.stderr or '')
+
+
+def pull_rebase(vault_path: str) -> tuple[bool, str]:
+    """Pull with rebase from origin. Aborts rebase on conflict."""
+    try:
+        branch = current_branch(vault_path)
+        result = subprocess.run(
+            ['git', 'pull', '--rebase', 'origin', branch],
+            cwd=vault_path, capture_output=True, text=True, timeout=60,
+        )
+        output = result.stdout + result.stderr
+        if result.returncode != 0:
+            # Abort the failed rebase to restore clean state
+            subprocess.run(
+                ['git', 'rebase', '--abort'],
+                cwd=vault_path, capture_output=True, text=True,
+            )
+            return False, output.strip()
+        return True, output.strip()
+    except subprocess.TimeoutExpired:
+        return False, "Pull timed out after 60s"
+    except subprocess.CalledProcessError as e:
+        return False, (e.stdout or '') + (e.stderr or '')
+
+
+def push(vault_path: str) -> tuple[bool, str]:
+    """Push current branch to origin."""
+    try:
+        branch = current_branch(vault_path)
+        result = subprocess.run(
+            ['git', 'push', 'origin', branch],
+            cwd=vault_path, capture_output=True, text=True, timeout=60,
+        )
+        output = result.stdout + result.stderr
+        return result.returncode == 0, output.strip()
+    except subprocess.TimeoutExpired:
+        return False, "Push timed out after 60s"
+    except subprocess.CalledProcessError as e:
+        return False, (e.stdout or '') + (e.stderr or '')
+
+
+def has_uncommitted_changes(vault_path: str) -> bool:
+    """Check for staged or unstaged changes."""
+    result = subprocess.run(
+        ['git', 'status', '--porcelain'],
+        cwd=vault_path, capture_output=True, text=True,
+    )
+    return bool(result.stdout.strip())
+
+
+def has_unpushed_commits(vault_path: str) -> bool:
+    """Check if local branch is ahead of origin."""
+    branch = current_branch(vault_path)
+    result = subprocess.run(
+        ['git', 'rev-list', f'origin/{branch}..HEAD', '--count'],
+        cwd=vault_path, capture_output=True, text=True,
+    )
+    try:
+        return int(result.stdout.strip()) > 0
+    except ValueError:
+        return False
+
+
+def stage_scope_files(vault_path: str, scope: str) -> tuple[bool, str]:
+    """Stage all files within the scope directory."""
+    try:
+        result = subprocess.run(
+            ['git', 'add', scope + '/'],
+            cwd=vault_path, capture_output=True, text=True,
+        )
+        # Also stage root-level files that may have changed
+        subprocess.run(
+            ['git', 'add', '*.yaml', '*.md'],
+            cwd=vault_path, capture_output=True, text=True,
+        )
+        output = result.stdout + result.stderr
+        return result.returncode == 0, output.strip()
+    except subprocess.CalledProcessError as e:
+        return False, (e.stdout or '') + (e.stderr or '')

--- a/cli/schist/spoke_config.py
+++ b/cli/schist/spoke_config.py
@@ -1,0 +1,51 @@
+"""Spoke configuration persistence (.schist/spoke.yaml)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+SPOKE_CONFIG_FILE = ".schist/spoke.yaml"
+
+
+@dataclass
+class SpokeConfig:
+    hub: str
+    identity: str
+    scope: str
+    scope_convention: str = "subdirectory"
+
+
+def spoke_config_path(vault_path: str) -> Path:
+    return Path(vault_path) / SPOKE_CONFIG_FILE
+
+
+def is_spoke(vault_path: str) -> bool:
+    return spoke_config_path(vault_path).is_file()
+
+
+def load_spoke_config(vault_path: str) -> SpokeConfig:
+    path = spoke_config_path(vault_path)
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    return SpokeConfig(
+        hub=data["hub"],
+        identity=data["identity"],
+        scope=data["scope"],
+        scope_convention=data.get("scope_convention", "subdirectory"),
+    )
+
+
+def save_spoke_config(vault_path: str, config: SpokeConfig) -> None:
+    path = spoke_config_path(vault_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "hub": config.hub,
+        "identity": config.identity,
+        "scope": config.scope,
+        "scope_convention": config.scope_convention,
+    }
+    with open(path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False)

--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -1,0 +1,153 @@
+"""Spoke sync operations: init, pull, push."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+from . import git_ops
+from .spoke_config import SpokeConfig, is_spoke, load_spoke_config, save_spoke_config
+
+
+def init_spoke(args, vault_path: str, db_path: str) -> None:
+    """Initialize a spoke vault from hub via shallow clone + sparse checkout."""
+    hub = args.hub
+    scope = args.scope
+    identity = args.identity
+
+    if not hub:
+        print("Error: --hub is required for spoke init", file=sys.stderr)
+        sys.exit(1)
+    if not scope:
+        print("Error: --scope is required for spoke init", file=sys.stderr)
+        sys.exit(1)
+    if not identity:
+        print("Error: --identity is required (or set SCHIST_IDENTITY)", file=sys.stderr)
+        sys.exit(1)
+
+    if Path(vault_path).exists() and any(Path(vault_path).iterdir()):
+        print(f"Error: directory '{vault_path}' already exists and is not empty", file=sys.stderr)
+        sys.exit(1)
+
+    # Step 1: Shallow clone (no checkout)
+    print(f"Cloning from {hub}...")
+    ok, output = git_ops.clone_shallow(hub, vault_path)
+    if not ok:
+        print(f"Error: clone failed: {output}", file=sys.stderr)
+        # Clean up partial clone
+        if Path(vault_path).exists():
+            shutil.rmtree(vault_path)
+        sys.exit(1)
+
+    # Step 2: Sparse checkout for scope
+    print(f"Setting up sparse checkout for scope '{scope}'...")
+    ok, output = git_ops.setup_sparse_checkout(vault_path, scope)
+    if not ok:
+        print(f"Error: sparse checkout failed: {output}", file=sys.stderr)
+        shutil.rmtree(vault_path)
+        sys.exit(1)
+
+    # Step 3: Write spoke config
+    config = SpokeConfig(hub=hub, identity=identity, scope=scope)
+    save_spoke_config(vault_path, config)
+
+    # Step 4: Exclude spoke config from git
+    exclude_path = Path(vault_path) / ".git" / "info" / "exclude"
+    exclude_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(exclude_path, "a") as f:
+        f.write(f"\n# schist spoke config (never pushed to hub)\n{'.schist/spoke.yaml'}\n")
+
+    # Step 5: Rebuild SQLite index
+    _rebuild_index(vault_path, db_path)
+
+    # Summary
+    scope_path = Path(vault_path) / scope
+    file_count = sum(1 for _ in scope_path.rglob("*.md")) if scope_path.exists() else 0
+    print(f"Spoke initialized: identity={identity} scope={scope} ({file_count} files)")
+
+
+def sync_pull(args, vault_path: str, db_path: str) -> None:
+    """Pull updates from hub and rebuild SQLite index."""
+    if not is_spoke(vault_path):
+        print("Error: not a spoke vault (missing .schist/spoke.yaml)", file=sys.stderr)
+        sys.exit(1)
+
+    config = load_spoke_config(vault_path)
+    print(f"Pulling from hub as {config.identity}...")
+
+    ok, output = git_ops.pull_rebase(vault_path)
+    if not ok:
+        print(f"Error: pull failed — {output}", file=sys.stderr)
+        if "conflict" in output.lower() or "CONFLICT" in output:
+            print("Resolve conflicts manually or re-clone the spoke.", file=sys.stderr)
+        sys.exit(1)
+
+    # Rebuild index
+    _rebuild_index(vault_path, db_path)
+    print(f"Pull complete. Index rebuilt.")
+
+
+def sync_push(args, vault_path: str, db_path: str) -> None:
+    """Push local changes to hub."""
+    if not is_spoke(vault_path):
+        print("Error: not a spoke vault (missing .schist/spoke.yaml)", file=sys.stderr)
+        sys.exit(1)
+
+    config = load_spoke_config(vault_path)
+
+    # Auto-commit if there are uncommitted changes
+    if git_ops.has_uncommitted_changes(vault_path):
+        git_ops.stage_scope_files(vault_path, config.scope)
+
+        # Count staged files
+        import subprocess
+
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            cwd=vault_path, capture_output=True, text=True,
+        )
+        staged = [f for f in result.stdout.strip().split("\n") if f]
+        n = len(staged)
+
+        if n > 0:
+            msg = f"sync({config.identity}): {n} file{'s' if n != 1 else ''}"
+            ok, output = git_ops.commit(vault_path, msg)
+            if not ok:
+                print(f"Error: commit failed: {output}", file=sys.stderr)
+                sys.exit(1)
+            print(f"Committed {n} file{'s' if n != 1 else ''}")
+
+    # Push
+    if not git_ops.has_unpushed_commits(vault_path):
+        print("Nothing to push — local is up to date with hub.")
+        return
+
+    print(f"Pushing as {config.identity}...")
+    ok, output = git_ops.push(vault_path)
+    if not ok:
+        if "REJECTED" in output.upper() or "rejected" in output:
+            print(f"Push rejected by hub:\n{output}", file=sys.stderr)
+        elif "Could not resolve" in output or "fatal:" in output:
+            print(f"Hub unreachable — changes saved locally. Push when network available.", file=sys.stderr)
+            print(f"  Detail: {output}", file=sys.stderr)
+        else:
+            print(f"Push failed: {output}", file=sys.stderr)
+        sys.exit(1)
+
+    print("Pushed to hub.")
+
+
+def _rebuild_index(vault_path: str, db_path: str) -> None:
+    """Delete existing SQLite and re-ingest from markdown files."""
+    db = Path(db_path)
+    if db.exists():
+        db.unlink()
+
+    from .sqlite_query import _run_ingest
+
+    try:
+        _run_ingest(vault_path, db_path)
+    except Exception as e:
+        print(f"Warning: index rebuild failed: {e}", file=sys.stderr)

--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -113,7 +113,7 @@ def sync_push(args, vault_path: str, db_path: str) -> None:
 
         if n > 0:
             msg = f"sync({config.identity}): {n} file{'s' if n != 1 else ''}"
-            ok, output = git_ops.commit(vault_path, msg)
+            ok, output = git_ops.commit(vault_path, msg, files=staged)
             if not ok:
                 print(f"Error: commit failed: {output}", file=sys.stderr)
                 sys.exit(1)
@@ -140,14 +140,25 @@ def sync_push(args, vault_path: str, db_path: str) -> None:
 
 
 def _rebuild_index(vault_path: str, db_path: str) -> None:
-    """Delete existing SQLite and re-ingest from markdown files."""
+    """Delete existing SQLite and re-ingest from markdown files.
+
+    Uses rename-on-success: old DB is only removed after ingest succeeds.
+    """
     db = Path(db_path)
+    backup = None
     if db.exists():
-        db.unlink()
+        backup = db.with_suffix(".db.bak")
+        db.rename(backup)
 
     from .sqlite_query import _run_ingest
 
     try:
         _run_ingest(vault_path, db_path)
+        # Success — remove backup
+        if backup and backup.exists():
+            backup.unlink()
     except Exception as e:
+        # Restore backup so user keeps old (stale) index rather than none
+        if backup and backup.exists():
+            backup.rename(db)
         print(f"Warning: index rebuild failed: {e}", file=sys.stderr)

--- a/cli/tests/test_spoke_config.py
+++ b/cli/tests/test_spoke_config.py
@@ -1,0 +1,36 @@
+"""Tests for spoke configuration read/write."""
+
+from schist.spoke_config import SpokeConfig, is_spoke, load_spoke_config, save_spoke_config
+
+
+class TestSpokeConfig:
+    def test_roundtrip(self, tmp_path):
+        vault = str(tmp_path / "vault")
+        config = SpokeConfig(
+            hub="git@pi.local:vault.git",
+            identity="cluster-mario",
+            scope="research/mario",
+        )
+        save_spoke_config(vault, config)
+        loaded = load_spoke_config(vault)
+        assert loaded.hub == config.hub
+        assert loaded.identity == config.identity
+        assert loaded.scope == config.scope
+        assert loaded.scope_convention == "subdirectory"
+
+    def test_is_spoke_true(self, tmp_path):
+        vault = str(tmp_path / "vault")
+        config = SpokeConfig(hub="url", identity="id", scope="s")
+        save_spoke_config(vault, config)
+        assert is_spoke(vault) is True
+
+    def test_is_spoke_false(self, tmp_path):
+        vault = str(tmp_path / "vault")
+        assert is_spoke(vault) is False
+
+    def test_custom_scope_convention(self, tmp_path):
+        vault = str(tmp_path / "vault")
+        config = SpokeConfig(hub="url", identity="id", scope="s", scope_convention="flat")
+        save_spoke_config(vault, config)
+        loaded = load_spoke_config(vault)
+        assert loaded.scope_convention == "flat"

--- a/cli/tests/test_sync.py
+++ b/cli/tests/test_sync.py
@@ -1,0 +1,235 @@
+"""Tests for spoke sync operations: init, pull, push."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from schist.spoke_config import SpokeConfig, save_spoke_config
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_spoke(tmp_path: Path, scope: str = "research/mario") -> str:
+    """Create a minimal spoke vault directory with config."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / ".git").mkdir()
+    (vault / scope).mkdir(parents=True)
+    save_spoke_config(str(vault), SpokeConfig(
+        hub="git@pi.local:vault.git",
+        identity="cluster-mario",
+        scope=scope,
+    ))
+    return str(vault)
+
+
+# ---------------------------------------------------------------------------
+# init_spoke
+# ---------------------------------------------------------------------------
+
+
+class TestInitSpoke:
+    def test_rejects_missing_hub(self, tmp_path, capsys):
+        from schist.sync import init_spoke
+
+        args = MagicMock(hub=None, scope="research/mario", identity="cluster-mario")
+        with pytest.raises(SystemExit):
+            init_spoke(args, str(tmp_path / "new"), "db.sqlite")
+        assert "--hub is required" in capsys.readouterr().err
+
+    def test_rejects_missing_scope(self, tmp_path, capsys):
+        from schist.sync import init_spoke
+
+        args = MagicMock(hub="git@host:repo.git", scope=None, identity="cluster-mario")
+        with pytest.raises(SystemExit):
+            init_spoke(args, str(tmp_path / "new"), "db.sqlite")
+        assert "--scope is required" in capsys.readouterr().err
+
+    def test_rejects_missing_identity(self, tmp_path, capsys):
+        from schist.sync import init_spoke
+
+        args = MagicMock(hub="git@host:repo.git", scope="research/mario", identity=None)
+        with pytest.raises(SystemExit):
+            init_spoke(args, str(tmp_path / "new"), "db.sqlite")
+        assert "--identity is required" in capsys.readouterr().err
+
+    def test_rejects_nonempty_dir(self, tmp_path, capsys):
+        from schist.sync import init_spoke
+
+        dest = tmp_path / "existing"
+        dest.mkdir()
+        (dest / "file.txt").write_text("content")
+        args = MagicMock(hub="git@host:repo.git", scope="s", identity="id")
+        with pytest.raises(SystemExit):
+            init_spoke(args, str(dest), "db.sqlite")
+        assert "already exists" in capsys.readouterr().err
+
+    @patch("schist.sync.git_ops.clone_shallow", return_value=(True, ""))
+    @patch("schist.sync.git_ops.setup_sparse_checkout", return_value=(True, ""))
+    @patch("schist.sync._rebuild_index")
+    def test_creates_spoke_config(self, mock_ingest, mock_sparse, mock_clone, tmp_path, capsys):
+        from schist.spoke_config import is_spoke, load_spoke_config
+        from schist.sync import init_spoke
+
+        dest = str(tmp_path / "spoke")
+        args = MagicMock(hub="git@pi:vault.git", scope="research/mario", identity="cluster-mario")
+
+        # clone_shallow creates the directory
+        def create_dir(*a, **kw):
+            Path(dest).mkdir(parents=True, exist_ok=True)
+            (Path(dest) / ".git" / "info").mkdir(parents=True)
+            return True, ""
+        mock_clone.side_effect = create_dir
+
+        init_spoke(args, dest, str(tmp_path / "db.sqlite"))
+
+        assert is_spoke(dest)
+        config = load_spoke_config(dest)
+        assert config.hub == "git@pi:vault.git"
+        assert config.identity == "cluster-mario"
+        assert config.scope == "research/mario"
+
+        # Verify exclude file
+        exclude = Path(dest) / ".git" / "info" / "exclude"
+        assert "spoke.yaml" in exclude.read_text()
+
+        output = capsys.readouterr().out
+        assert "Spoke initialized" in output
+
+    @patch("schist.sync.git_ops.clone_shallow", return_value=(False, "Connection refused"))
+    def test_clone_failure_cleans_up(self, mock_clone, tmp_path, capsys):
+        from schist.sync import init_spoke
+
+        dest = tmp_path / "spoke"
+        args = MagicMock(hub="git@bad:repo.git", scope="s", identity="id")
+        with pytest.raises(SystemExit):
+            init_spoke(args, str(dest), "db.sqlite")
+        assert not dest.exists()
+        assert "clone failed" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# sync_pull
+# ---------------------------------------------------------------------------
+
+
+class TestSyncPull:
+    def test_non_spoke_fails(self, tmp_path, capsys):
+        from schist.sync import sync_pull
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        args = MagicMock()
+        with pytest.raises(SystemExit):
+            sync_pull(args, str(vault), "db.sqlite")
+        assert "not a spoke vault" in capsys.readouterr().err
+
+    @patch("schist.sync.git_ops.pull_rebase", return_value=(True, "Already up to date."))
+    @patch("schist.sync._rebuild_index")
+    def test_pull_rebuilds_db(self, mock_ingest, mock_pull, tmp_path, capsys):
+        from schist.sync import sync_pull
+
+        vault = _make_spoke(tmp_path)
+        db = Path(vault) / ".schist" / "schist.db"
+        db.parent.mkdir(parents=True, exist_ok=True)
+        db.write_text("old data")
+
+        args = MagicMock()
+        sync_pull(args, vault, str(db))
+
+        # DB should have been deleted before rebuild
+        mock_ingest.assert_called_once()
+        assert "Pull complete" in capsys.readouterr().out
+
+    @patch("schist.sync.git_ops.pull_rebase", return_value=(False, "CONFLICT in research/mario/note.md"))
+    def test_pull_conflict_aborts(self, mock_pull, tmp_path, capsys):
+        from schist.sync import sync_pull
+
+        vault = _make_spoke(tmp_path)
+        args = MagicMock()
+        with pytest.raises(SystemExit):
+            sync_pull(args, vault, "db.sqlite")
+        err = capsys.readouterr().err
+        assert "pull failed" in err
+        assert "conflict" in err.lower() or "re-clone" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# sync_push
+# ---------------------------------------------------------------------------
+
+
+class TestSyncPush:
+    def test_non_spoke_fails(self, tmp_path, capsys):
+        from schist.sync import sync_push
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        args = MagicMock()
+        with pytest.raises(SystemExit):
+            sync_push(args, str(vault), "db.sqlite")
+        assert "not a spoke vault" in capsys.readouterr().err
+
+    @patch("schist.sync.git_ops.has_unpushed_commits", return_value=False)
+    @patch("schist.sync.git_ops.has_uncommitted_changes", return_value=False)
+    def test_nothing_to_push(self, mock_changes, mock_unpushed, tmp_path, capsys):
+        from schist.sync import sync_push
+
+        vault = _make_spoke(tmp_path)
+        args = MagicMock()
+        sync_push(args, vault, "db.sqlite")
+        assert "Nothing to push" in capsys.readouterr().out
+
+    @patch("schist.sync.git_ops.push", return_value=(True, ""))
+    @patch("schist.sync.git_ops.has_unpushed_commits", return_value=True)
+    @patch("schist.sync.git_ops.commit", return_value=(True, ""))
+    @patch("schist.sync.git_ops.stage_scope_files", return_value=(True, ""))
+    @patch("schist.sync.git_ops.has_uncommitted_changes", return_value=True)
+    @patch("subprocess.run")
+    def test_auto_commits_and_pushes(self, mock_run, mock_changes, mock_stage, mock_commit,
+                                     mock_unpushed, mock_push, tmp_path, capsys):
+        from schist.sync import sync_push
+
+        # Mock git diff --cached --name-only
+        mock_run.return_value = MagicMock(stdout="research/mario/note.md\n", returncode=0)
+
+        vault = _make_spoke(tmp_path)
+        args = MagicMock()
+        sync_push(args, vault, "db.sqlite")
+
+        mock_commit.assert_called_once()
+        commit_msg = mock_commit.call_args[0][1]
+        assert "sync(cluster-mario)" in commit_msg
+        mock_push.assert_called_once()
+        assert "Pushed to hub" in capsys.readouterr().out
+
+    @patch("schist.sync.git_ops.push", return_value=(False, "REJECTED: push contains out-of-scope writes"))
+    @patch("schist.sync.git_ops.has_unpushed_commits", return_value=True)
+    @patch("schist.sync.git_ops.has_uncommitted_changes", return_value=False)
+    def test_push_rejection(self, mock_changes, mock_unpushed, mock_push, tmp_path, capsys):
+        from schist.sync import sync_push
+
+        vault = _make_spoke(tmp_path)
+        args = MagicMock()
+        with pytest.raises(SystemExit):
+            sync_push(args, vault, "db.sqlite")
+        assert "rejected" in capsys.readouterr().err.lower()
+
+    @patch("schist.sync.git_ops.push", return_value=(False, "fatal: Could not resolve hostname"))
+    @patch("schist.sync.git_ops.has_unpushed_commits", return_value=True)
+    @patch("schist.sync.git_ops.has_uncommitted_changes", return_value=False)
+    def test_hub_unreachable(self, mock_changes, mock_unpushed, mock_push, tmp_path, capsys):
+        from schist.sync import sync_push
+
+        vault = _make_spoke(tmp_path)
+        args = MagicMock()
+        with pytest.raises(SystemExit):
+            sync_push(args, vault, "db.sqlite")
+        err = capsys.readouterr().err
+        assert "unreachable" in err.lower() or "saved locally" in err.lower()


### PR DESCRIPTION
## Summary

- **`schist init --spoke`** — shallow clone + git sparse-checkout for scope-filtered spoke vaults
- **`schist sync pull`** — fetch from hub with rebase, rebuild SQLite index
- **`schist sync push`** — auto-commit uncommitted changes, push to hub (pre-receive validates ACL)

Implements phases 3 of the remote MCP plan. Pairs with the pre-receive hook (#9) for hub-side ACL enforcement.

## Design

- Sparse checkout (cone mode) materializes only scope dirs + root files (vault.yaml)
- SQLite is disposable — deleted and rebuilt on every pull
- Spoke config stored in `.schist/spoke.yaml`, excluded from git
- Pull uses `--rebase` to replay local commits on top of hub
- Push auto-commits staged .md files with spoke identity in commit message

## Test plan

- [x] 18 new tests passing (spoke config, init, pull, push flows)
- [x] All 134 tests passing
- [ ] Manual integration: init spoke from schist-vault, pull, create note, push

🤖 Generated with [Claude Code](https://claude.com/claude-code)