### PR TITLE
feat: schist init standalone mode

### DIFF
--- a/cli/schist/__main__.py
+++ b/cli/schist/__main__.py
@@ -56,15 +56,17 @@ def main():
     p_schema.add_argument('--validate', action='store_true')
 
     # init
-    p_init = sub.add_parser('init', help='Initialize a vault (hub or spoke)')
+    p_init = sub.add_parser('init', help='Initialize a vault (standalone, hub, or spoke)')
+    p_init.add_argument('path', nargs='?', default=None,
+                        help='(standalone) Path to new vault (default: current dir)')
     p_init.add_argument('--spoke', action='store_true', help='Initialize as spoke vault')
     p_init.add_argument('--hub', help='(spoke) Hub repository URL')
     p_init.add_argument('--scope', help='(spoke) Scope to sync (directory path)')
     p_init.add_argument('--identity', default=os.environ.get('SCHIST_IDENTITY'),
-                        help='(spoke) Spoke identity (or set SCHIST_IDENTITY)')
+                        help='(spoke/standalone) Identity name (or set SCHIST_IDENTITY)')
     p_init.add_argument('--hub-path', dest='hub_path',
                         help='(hub) Path to the bare repo to create')
-    p_init.add_argument('--name', help='(hub) Vault name for the seeded vault.yaml')
+    p_init.add_argument('--name', help='(hub/standalone) Vault name for vault.yaml')
     p_init.add_argument('--participant', action='append',
                         help='(hub) Participant name (repeatable)')
 
@@ -80,19 +82,10 @@ def main():
         parser.print_help()
         sys.exit(1)
 
-    # init --hub-path: hub init, no vault path needed
-    if args.command == 'init' and getattr(args, 'hub_path', None):
-        if getattr(args, 'spoke', False):
-            print('Error: --hub-path and --spoke are mutually exclusive', file=sys.stderr)
-            sys.exit(1)
-        sync.init_hub(args, args.hub_path)
-        sys.exit(0)
-
-    # init --spoke: vault doesn't exist yet, special path
-    if args.command == 'init' and getattr(args, 'spoke', False):
-        vault_path = args.vault or os.path.basename(args.hub or 'vault').removesuffix('.git')
-        db_path = args.db or os.path.join(vault_path, '.schist', 'schist.db')
-        sync.init_spoke(args, vault_path, db_path)
+    # init: all modes (hub, spoke, standalone) routed through one helper so
+    # the conflict matrix lives in one place.
+    if args.command == 'init':
+        sync._dispatch_init(args)
         sys.exit(0)
 
     vault_path = args.vault

--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -12,11 +12,11 @@ from pathlib import Path
 import yaml
 
 from . import git_ops
-from .acl import ACLError, parse_vault_data
+from .acl import ACLError, NAME_RE, parse_vault_data
 from .spoke_config import SpokeConfig, is_spoke, load_spoke_config, save_spoke_config
 
-class _HubInitError(Exception):
-    """Raised by init_hub build steps so the outer function can clean up staging."""
+class _InitError(Exception):
+    """Raised by init_* build steps so the outer function can clean up staging."""
 
 
 PRE_RECEIVE_HOOK = """\
@@ -32,6 +32,53 @@ import sys
 from schist.pre_receive import main
 
 sys.exit(main())
+"""
+
+
+POST_COMMIT_HOOK = r"""#!/bin/sh
+# schist post-commit hook — re-ingest vault into SQLite after every commit
+
+VAULT_ROOT=$(git rev-parse --show-toplevel)
+DB_PATH="$VAULT_ROOT/.schist/schist.db"
+mkdir -p "$VAULT_ROOT/.schist"
+
+# Find ingest.py: env var, then common locations
+if [ -n "$SCHIST_INGEST_SCRIPT" ] && [ -f "$SCHIST_INGEST_SCRIPT" ]; then
+    INGEST="$SCHIST_INGEST_SCRIPT"
+elif [ -f "$VAULT_ROOT/.schist/ingest.py" ]; then
+    INGEST="$VAULT_ROOT/.schist/ingest.py"
+elif command -v schist-ingest >/dev/null 2>&1; then
+    schist-ingest --vault "$VAULT_ROOT" --db "$DB_PATH"
+    exit $?
+else
+    echo "schist: ingest.py not found. Set SCHIST_INGEST_SCRIPT or install schist."
+    exit 0
+fi
+
+python3 "$INGEST" --vault "$VAULT_ROOT" --db "$DB_PATH"
+"""
+
+
+PRE_COMMIT_HOOK = r"""#!/bin/sh
+# schist pre-commit hook — reject staged files containing secrets
+
+PATTERNS='sk-|ghp_|ghs_|AKIA|-----BEGIN|password\s*=|api_key\s*='
+
+STAGED_FILES=$(git diff --cached --name-only)
+if [ -z "$STAGED_FILES" ]; then
+    exit 0
+fi
+
+MATCH=$(echo "$STAGED_FILES" | xargs grep -lE "$PATTERNS" 2>/dev/null)
+if [ -n "$MATCH" ]; then
+    echo "ERROR: Potential secret detected in staged files:"
+    echo "$MATCH" | sed 's/^/  /'
+    echo ""
+    echo "If this is intentional, use git commit --no-verify"
+    exit 1
+fi
+
+exit 0
 """
 
 
@@ -239,7 +286,10 @@ def init_hub(args, hub_path: str) -> None:
 
     try:
         _build_hub_in_staging(staging, hub, vault_data, participants, name)
-    except _HubInitError as e:
+    except (_InitError, OSError) as e:
+        # OSError catches filesystem failures (permission denied, disk full,
+        # etc.) raised by staging.mkdir() or any subsequent write so the user
+        # gets a clean "Error: ..." line instead of a raw traceback.
         print(f"Error: {e}", file=sys.stderr)
         # Best-effort staging cleanup. If it fails, surface the path so the
         # user can remove it manually — but the final hub_path is untouched.
@@ -280,7 +330,7 @@ def _build_hub_in_staging(
 ) -> None:
     """Build the bare repo + hook + seed commit entirely inside `staging`.
 
-    Raises _HubInitError with a descriptive message on any failure. The caller
+    Raises _InitError with a descriptive message on any failure. The caller
     is responsible for cleaning up `staging`.
     """
     # 1. Create bare repo at the staging path
@@ -290,7 +340,7 @@ def _build_hub_in_staging(
         capture_output=True, text=True,
     )
     if result.returncode != 0:
-        raise _HubInitError(f"git init --bare failed: {result.stderr.strip()}")
+        raise _InitError(f"git init --bare failed: {result.stderr.strip()}")
 
     # 2. Install pre-receive hook
     hook_path = staging / "hooks" / "pre-receive"
@@ -339,7 +389,7 @@ def _build_hub_in_staging(
         ):
             r = run(cmd, seed)
             if r.returncode != 0:
-                raise _HubInitError(f"{' '.join(cmd)} failed: {r.stderr.strip()}")
+                raise _InitError(f"{' '.join(cmd)} failed: {r.stderr.strip()}")
 
         (seed / "vault.yaml").write_text(
             yaml.dump(vault_data, default_flow_style=False, sort_keys=False)
@@ -352,7 +402,7 @@ def _build_hub_in_staging(
         ):
             r = run(cmd, seed)
             if r.returncode != 0:
-                raise _HubInitError(f"{' '.join(cmd)} failed: {r.stderr.strip()}")
+                raise _InitError(f"{' '.join(cmd)} failed: {r.stderr.strip()}")
 
 
 def _build_seed_vault(name: str, participants: list[str]) -> dict:
@@ -379,6 +429,215 @@ def _build_seed_vault(name: str, participants: list[str]) -> dict:
         "participants": participant_entries,
         "access": access,
     }
+
+
+def init_standalone(args) -> None:
+    """Initialize a local standalone vault with no hub or participants.
+
+    Scaffolds: a git working repo at the target path with vault.yaml, empty
+    notes/concepts/papers directories (each with .gitkeep), a .gitignore that
+    excludes .schist/ (runtime SQLite state), and the post-commit + pre-commit
+    hooks installed in .git/hooks/ (after the seed commit, so the hooks don't
+    run on it).
+
+    Mirrors init_hub's staging-dir + atomic rename pattern so a half-initialized
+    target never exists on disk. On failure, only the staging directory is
+    touched and it is cleaned up before exit.
+    """
+    path_arg = getattr(args, "path", None) or "."
+    target = Path(path_arg).resolve()
+
+    name = getattr(args, "name", None) or target.name
+    identity = getattr(args, "identity", None) or "local"
+
+    if not NAME_RE.match(identity):
+        print(
+            f"Error: --identity '{identity}' must match ^[a-z][a-z0-9-]*$",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if target.exists() and any(target.iterdir()):
+        print(
+            f"Error: '{path_arg}' already exists and is not empty",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Build vault.yaml data and validate before touching the filesystem.
+    vault_data = _build_standalone_vault(name, identity)
+    try:
+        parse_vault_data(vault_data)
+    except ACLError as e:
+        print(
+            f"Error: generated vault.yaml failed validation: {e}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Stage in a sibling directory so the final os.rename is atomic (same FS).
+    target.parent.mkdir(parents=True, exist_ok=True)
+    staging = target.parent / f".{target.name}.init-{os.getpid()}"
+    if staging.exists():
+        shutil.rmtree(staging)
+
+    try:
+        _build_standalone_in_staging(staging, vault_data, name)
+    except (_InitError, OSError) as e:
+        # OSError catches filesystem failures (permission denied, disk full,
+        # etc.) raised by staging.mkdir() or any subsequent write so the user
+        # gets a clean "Error: ..." line instead of a raw traceback.
+        print(f"Error: {e}", file=sys.stderr)
+        try:
+            if staging.exists():
+                shutil.rmtree(staging)
+        except OSError as cleanup_err:
+            print(
+                f"Warning: could not clean up staging dir {staging}: {cleanup_err}\n"
+                f"  Manual fix: rm -rf {staging}",
+                file=sys.stderr,
+            )
+        sys.exit(1)
+
+    # Atomic rename: either target points at a complete vault, or it doesn't
+    # exist at all.
+    if target.exists():
+        target.rmdir()
+    os.rename(staging, target)
+
+    print(f"Vault initialized at {target}")
+    print()
+    print("Next steps:")
+    print(f"  1. export SCHIST_VAULT_PATH={target}")
+    print(f"  2. schist add --title 'My first note'")
+    print(f"  3. Set SCHIST_INGEST_SCRIPT for post-commit ingest, or install schist-ingest on PATH.")
+
+
+def _build_standalone_in_staging(
+    staging: Path,
+    vault_data: dict,
+    name: str,
+) -> None:
+    """Build the standalone working-tree repo entirely inside `staging`.
+
+    Raises _InitError with a descriptive message on any failure. The caller is
+    responsible for cleaning up `staging`.
+    """
+    staging.mkdir(parents=True)
+
+    result = subprocess.run(
+        ["git", "init", "--initial-branch=main", str(staging)],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise _InitError(f"git init failed: {result.stderr.strip()}")
+
+    # Scaffold empty content dirs with .gitkeep sentinels so they survive the
+    # initial commit even though git doesn't track empty directories.
+    for d in ("notes", "concepts", "papers"):
+        sub = staging / d
+        sub.mkdir()
+        (sub / ".gitkeep").write_text("")
+
+    # Runtime SQLite state lives under .schist/ and must never be committed.
+    (staging / ".gitignore").write_text(".schist/\n")
+
+    (staging / "vault.yaml").write_text(
+        yaml.dump(vault_data, default_flow_style=False, sort_keys=False)
+    )
+
+    env = os.environ.copy()
+    env.setdefault("GIT_AUTHOR_NAME", "schist")
+    env.setdefault("GIT_AUTHOR_EMAIL", "schist@local")
+    env.setdefault("GIT_COMMITTER_NAME", "schist")
+    env.setdefault("GIT_COMMITTER_EMAIL", "schist@local")
+
+    def run(cmd: list[str]) -> subprocess.CompletedProcess:
+        return subprocess.run(cmd, cwd=staging, env=env, capture_output=True, text=True)
+
+    # Seed commit runs BEFORE installing hooks so the commit is unaffected by
+    # the pre-commit secret scanner (benign here, but keeps intent explicit).
+    for cmd in (
+        ["git", "add", "."],
+        ["git", "commit", "-m", f"init: scaffold standalone vault {name}"],
+    ):
+        r = run(cmd)
+        if r.returncode != 0:
+            raise _InitError(f"{' '.join(cmd)} failed: {r.stderr.strip()}")
+
+    hooks_dir = staging / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    post = hooks_dir / "post-commit"
+    post.write_text(POST_COMMIT_HOOK)
+    post.chmod(0o755)
+    pre = hooks_dir / "pre-commit"
+    pre.write_text(PRE_COMMIT_HOOK)
+    pre.chmod(0o755)
+
+
+def _build_standalone_vault(name: str, identity: str) -> dict:
+    """Construct a minimal valid vault.yaml data dict for a standalone vault.
+
+    Single-participant, single-agent, full-vault read+write. Kept separate from
+    `_build_seed_vault` because the two diverge on participant type, default
+    scope, and ACL shape — parametrizing would hide the difference behind
+    callbacks.
+    """
+    return {
+        "vault_version": 1,
+        "name": name,
+        "scope_convention": "subdirectory",
+        "participants": [{
+            "name": identity,
+            "type": "agent",
+            "default_scope": "global",
+        }],
+        "access": {identity: {"read": ["*"], "write": ["*"]}},
+    }
+
+
+def _dispatch_init(args) -> None:
+    """Route `schist init` to the right mode based on arg combination.
+
+    Three modes (mutually exclusive):
+      - hub:        `--hub-path PATH` (optionally --name/--participant)
+      - spoke:      `--spoke --hub URL --scope S --identity I`
+      - standalone: no mode flags; optional positional <path>
+
+    Centralizing the conflict matrix here also closes a pre-existing trap:
+    `--hub URL` without `--spoke` used to fall through to a KeyError crash,
+    and with standalone init added would silently run as standalone and drop
+    the hub URL. Both are rejected up front.
+    """
+    hub_path = getattr(args, "hub_path", None)
+    spoke = getattr(args, "spoke", False)
+    hub_url = getattr(args, "hub", None)
+    standalone_path = getattr(args, "path", None)
+
+    if hub_path and spoke:
+        print("Error: --hub-path and --spoke are mutually exclusive", file=sys.stderr)
+        sys.exit(1)
+    if hub_path and hub_url:
+        print("Error: --hub-path and --hub are mutually exclusive (--hub is for spoke mode)", file=sys.stderr)
+        sys.exit(1)
+    if hub_url and not spoke:
+        print("Error: --hub requires --spoke", file=sys.stderr)
+        sys.exit(1)
+    if standalone_path and (hub_path or spoke):
+        print("Error: positional <path> is only valid for standalone init", file=sys.stderr)
+        sys.exit(1)
+
+    if hub_path:
+        init_hub(args, hub_path)
+        return
+
+    if spoke:
+        vault_path = args.vault or os.path.basename(hub_url or "vault").removesuffix(".git")
+        db_path = args.db or os.path.join(vault_path, ".schist", "schist.db")
+        init_spoke(args, vault_path, db_path)
+        return
+
+    init_standalone(args)
 
 
 def _rebuild_index(vault_path: str, db_path: str) -> None:

--- a/cli/tests/test_init_standalone.py
+++ b/cli/tests/test_init_standalone.py
@@ -1,0 +1,420 @@
+"""Tests for `schist init` standalone mode and the unified init dispatch."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _has_git() -> bool:
+    return shutil.which("git") is not None
+
+
+pytestmark = pytest.mark.skipif(not _has_git(), reason="git not available")
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _args(**kwargs) -> SimpleNamespace:
+    """Build an argparse-like args namespace with standalone-init defaults."""
+    defaults = {
+        "path": None,
+        "name": None,
+        "identity": None,
+        "spoke": False,
+        "hub": None,
+        "hub_path": None,
+        "scope": None,
+        "participant": None,
+        "vault": None,
+        "db": None,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+class TestInitStandalone:
+    def test_creates_vault_at_explicit_path(self, tmp_path):
+        from schist.sync import init_standalone
+
+        target = tmp_path / "my-vault"
+        init_standalone(_args(path=str(target), name="my-vault", identity="local"))
+
+        assert (target / "vault.yaml").is_file()
+        assert (target / ".git").is_dir()
+        assert (target / "notes" / ".gitkeep").is_file()
+        assert (target / "concepts" / ".gitkeep").is_file()
+        assert (target / "papers" / ".gitkeep").is_file()
+        assert (target / ".gitignore").read_text() == ".schist/\n"
+
+    def test_defaults_path_to_cwd(self, tmp_path, monkeypatch):
+        from schist.sync import init_standalone
+
+        cwd = tmp_path / "workdir"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        init_standalone(_args())
+
+        assert (cwd / "vault.yaml").is_file()
+        assert (cwd / ".git").is_dir()
+
+    def test_defaults_name_from_dir(self, tmp_path):
+        import yaml
+        from schist.sync import init_standalone
+
+        target = tmp_path / "alpha-vault"
+        init_standalone(_args(path=str(target)))
+
+        data = yaml.safe_load((target / "vault.yaml").read_text())
+        assert data["name"] == "alpha-vault"
+
+    def test_defaults_identity_to_local(self, tmp_path):
+        import yaml
+        from schist.sync import init_standalone
+
+        target = tmp_path / "v"
+        init_standalone(_args(path=str(target)))
+
+        data = yaml.safe_load((target / "vault.yaml").read_text())
+        assert data["participants"][0]["name"] == "local"
+        assert "local" in data["access"]
+
+    def test_rejects_invalid_identity_format(self, tmp_path, capsys):
+        from schist.sync import init_standalone
+
+        target = tmp_path / "v"
+        with pytest.raises(SystemExit):
+            init_standalone(_args(path=str(target), identity="Not_Valid"))
+        err = capsys.readouterr().err
+        assert "--identity" in err
+        assert "^[a-z][a-z0-9-]*$" in err
+        assert not target.exists()
+
+    def test_rejects_nonempty_target(self, tmp_path, capsys):
+        from schist.sync import init_standalone
+
+        target = tmp_path / "existing"
+        target.mkdir()
+        (target / "file").write_text("already here")
+        with pytest.raises(SystemExit):
+            init_standalone(_args(path=str(target)))
+        assert "already exists and is not empty" in capsys.readouterr().err
+
+    def test_allows_empty_target_dir(self, tmp_path):
+        from schist.sync import init_standalone
+
+        target = tmp_path / "empty-target"
+        target.mkdir()
+        init_standalone(_args(path=str(target)))
+        assert (target / "vault.yaml").is_file()
+
+    def test_creates_intermediate_dirs(self, tmp_path):
+        from schist.sync import init_standalone
+
+        target = tmp_path / "a" / "b" / "c" / "vault"
+        init_standalone(_args(path=str(target)))
+        assert (target / "vault.yaml").is_file()
+
+    def test_seed_vault_yaml_parses_and_validates(self, tmp_path):
+        from schist.acl import parse_vault_yaml
+        from schist.sync import init_standalone
+
+        target = tmp_path / "v"
+        init_standalone(_args(path=str(target), name="v", identity="yibei"))
+
+        acl = parse_vault_yaml(target / "vault.yaml")
+        assert acl.name == "v"
+        assert acl.vault_version == 1
+        assert {p.name for p in acl.participants} == {"yibei"}
+        assert acl.can_write("yibei", "notes")
+        assert acl.can_write("yibei", "concepts/x")
+        assert acl.can_read("yibei", "papers")
+
+    def test_directory_scaffold_committed_with_gitkeeps(self, tmp_path):
+        from schist.sync import init_standalone
+
+        target = tmp_path / "v"
+        init_standalone(_args(path=str(target)))
+
+        result = subprocess.run(
+            ["git", "ls-tree", "-r", "--name-only", "main"],
+            cwd=target, capture_output=True, text=True, check=True,
+        )
+        tracked = set(result.stdout.splitlines())
+        assert ".gitignore" in tracked
+        assert "vault.yaml" in tracked
+        assert "notes/.gitkeep" in tracked
+        assert "concepts/.gitkeep" in tracked
+        assert "papers/.gitkeep" in tracked
+
+    def test_hooks_installed_and_executable(self, tmp_path):
+        from schist.sync import init_standalone
+
+        target = tmp_path / "v"
+        init_standalone(_args(path=str(target)))
+
+        post = target / ".git" / "hooks" / "post-commit"
+        pre = target / ".git" / "hooks" / "pre-commit"
+        assert post.is_file() and os.access(post, os.X_OK)
+        assert pre.is_file() and os.access(pre, os.X_OK)
+        assert post.read_text().startswith("#!/bin/sh")
+        assert "schist post-commit hook" in post.read_text()
+        assert "schist pre-commit hook" in pre.read_text()
+
+    def test_hooks_not_committed(self, tmp_path):
+        """Hooks live in .git/hooks/ (untracked by git by design)."""
+        from schist.sync import init_standalone
+
+        target = tmp_path / "v"
+        init_standalone(_args(path=str(target)))
+
+        result = subprocess.run(
+            ["git", "ls-tree", "-r", "--name-only", "main"],
+            cwd=target, capture_output=True, text=True, check=True,
+        )
+        tracked = result.stdout.splitlines()
+        assert not any("hooks/" in f for f in tracked)
+
+    def test_vault_yaml_roundtrip(self, tmp_path):
+        import yaml
+        from schist.sync import init_standalone
+
+        target = tmp_path / "v"
+        init_standalone(_args(path=str(target), name="roundtrip", identity="local"))
+
+        data = yaml.safe_load((target / "vault.yaml").read_text())
+        assert data["vault_version"] == 1
+        assert data["name"] == "roundtrip"
+        assert data["scope_convention"] == "subdirectory"
+        assert data["access"]["local"] == {"read": ["*"], "write": ["*"]}
+
+    def test_initial_commit_on_main_branch(self, tmp_path):
+        from schist.sync import init_standalone
+
+        target = tmp_path / "v"
+        init_standalone(_args(path=str(target), name="v"))
+
+        branch = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=target, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        assert branch == "main"
+
+        msg = subprocess.run(
+            ["git", "log", "-1", "--format=%s"],
+            cwd=target, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        assert msg == "init: scaffold standalone vault v"
+
+    def test_custom_identity_produces_correct_acl(self, tmp_path):
+        from schist.acl import parse_vault_yaml
+        from schist.sync import init_standalone
+
+        target = tmp_path / "v"
+        init_standalone(_args(path=str(target), identity="yibei"))
+        acl = parse_vault_yaml(target / "vault.yaml")
+        assert acl.can_write("yibei", "any/scope/here")
+        assert not acl.can_write("someone-else", "any")
+
+    def test_rollback_on_git_init_failure(self, tmp_path, monkeypatch, capsys):
+        """If git init fails, staging dir cleaned up and target untouched."""
+        from schist import sync as sync_mod
+
+        target = tmp_path / "v"
+        real_run = sync_mod.subprocess.run
+
+        def fake_run(cmd, *a, **kw):
+            if "init" in cmd and "--initial-branch=main" in cmd:
+                return type("R", (), {
+                    "returncode": 1, "stdout": "", "stderr": "simulated init failure",
+                })()
+            return real_run(cmd, *a, **kw)
+
+        monkeypatch.setattr(sync_mod.subprocess, "run", fake_run)
+
+        with pytest.raises(SystemExit):
+            sync_mod.init_standalone(_args(path=str(target)))
+
+        assert not target.exists()
+        leftover = list(tmp_path.glob(".v.init-*"))
+        assert not leftover, f"staging dir not cleaned: {leftover}"
+        assert "simulated init failure" in capsys.readouterr().err
+
+    def test_rollback_on_commit_failure(self, tmp_path, monkeypatch):
+        """If the seed commit fails, staging cleaned up and target untouched."""
+        from schist import sync as sync_mod
+
+        target = tmp_path / "v"
+        real_run = sync_mod.subprocess.run
+
+        def fake_run(cmd, *a, **kw):
+            if "commit" in cmd:
+                return type("R", (), {
+                    "returncode": 1, "stdout": "", "stderr": "simulated commit failure",
+                })()
+            return real_run(cmd, *a, **kw)
+
+        monkeypatch.setattr(sync_mod.subprocess, "run", fake_run)
+
+        with pytest.raises(SystemExit):
+            sync_mod.init_standalone(_args(path=str(target)))
+
+        assert not target.exists()
+        assert not list(tmp_path.glob(".v.init-*"))
+
+    def test_rejects_unwritable_parent_cleanly(self, tmp_path, monkeypatch, capsys):
+        """PermissionError from staging.mkdir() surfaces as a clean error line,
+        not a traceback. Regression test for the OSError-escapes-handler bug
+        where `except _InitError` let filesystem errors propagate untouched.
+        """
+        from schist import sync as sync_mod
+
+        target = tmp_path / "unwritable-parent" / "v"
+        real_mkdir = Path.mkdir
+
+        def fake_mkdir(self, *args, **kwargs):
+            # Fire only for the staging dir; let target.parent.mkdir succeed.
+            if ".v.init-" in self.name:
+                raise PermissionError(13, "Permission denied", str(self))
+            return real_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", fake_mkdir)
+
+        with pytest.raises(SystemExit):
+            sync_mod.init_standalone(_args(path=str(target)))
+
+        err = capsys.readouterr().err
+        assert err.startswith("Error: "), f"expected clean error line, got: {err!r}"
+        assert "Permission denied" in err
+        assert not target.exists()
+
+    def test_renames_over_empty_target(self, tmp_path):
+        """If the target exists but is empty, init still succeeds (atomic rename)."""
+        from schist.sync import init_standalone
+
+        target = tmp_path / "empty"
+        target.mkdir()
+        init_standalone(_args(path=str(target)))
+        assert (target / "vault.yaml").is_file()
+
+    def test_post_commit_constant_matches_disk(self):
+        """Drift guard — in-memory POST_COMMIT_HOOK must equal the on-disk copy."""
+        from schist.sync import POST_COMMIT_HOOK
+
+        disk = (REPO_ROOT / "hooks" / "post-commit").read_text()
+        assert POST_COMMIT_HOOK == disk, (
+            "POST_COMMIT_HOOK in sync.py has drifted from hooks/post-commit. "
+            "Update the constant so standalone-init-installed hooks match the "
+            "repo reference."
+        )
+
+    def test_pre_commit_constant_matches_disk(self):
+        """Drift guard — in-memory PRE_COMMIT_HOOK must equal the on-disk copy."""
+        from schist.sync import PRE_COMMIT_HOOK
+
+        disk = (REPO_ROOT / "hooks" / "pre-commit").read_text()
+        assert PRE_COMMIT_HOOK == disk, (
+            "PRE_COMMIT_HOOK in sync.py has drifted from hooks/pre-commit. "
+            "Update the constant so standalone-init-installed hooks match the "
+            "repo reference."
+        )
+
+
+class TestDispatchInit:
+    """Conflict matrix for `schist init` across all three modes."""
+
+    def test_hub_path_and_spoke_rejected(self, tmp_path, capsys):
+        from schist.sync import _dispatch_init
+
+        args = _args(hub_path=str(tmp_path / "hub.git"), spoke=True)
+        with pytest.raises(SystemExit):
+            _dispatch_init(args)
+        assert "mutually exclusive" in capsys.readouterr().err
+
+    def test_hub_path_and_hub_url_rejected(self, tmp_path, capsys):
+        from schist.sync import _dispatch_init
+
+        args = _args(hub_path=str(tmp_path / "hub.git"), hub="git@host:r.git")
+        with pytest.raises(SystemExit):
+            _dispatch_init(args)
+        err = capsys.readouterr().err
+        assert "--hub-path and --hub" in err
+
+    def test_hub_url_without_spoke_rejected(self, capsys):
+        """Pre-existing bug fix: `--hub URL` without `--spoke` would silently
+        fall through and drop the URL. Now rejected up front."""
+        from schist.sync import _dispatch_init
+
+        args = _args(hub="git@host:r.git")
+        with pytest.raises(SystemExit):
+            _dispatch_init(args)
+        assert "--hub requires --spoke" in capsys.readouterr().err
+
+    def test_positional_path_with_hub_path_rejected(self, tmp_path, capsys):
+        from schist.sync import _dispatch_init
+
+        args = _args(path=str(tmp_path / "v"), hub_path=str(tmp_path / "hub.git"))
+        with pytest.raises(SystemExit):
+            _dispatch_init(args)
+        assert "positional <path>" in capsys.readouterr().err
+
+    def test_positional_path_with_spoke_rejected(self, tmp_path, capsys):
+        from schist.sync import _dispatch_init
+
+        args = _args(path=str(tmp_path / "v"), spoke=True, hub="git@host:r.git")
+        with pytest.raises(SystemExit):
+            _dispatch_init(args)
+        assert "positional <path>" in capsys.readouterr().err
+
+    def test_standalone_routes_to_init_standalone(self, tmp_path):
+        from schist.sync import _dispatch_init
+
+        target = tmp_path / "v"
+        _dispatch_init(_args(path=str(target)))
+        assert (target / "vault.yaml").is_file()
+
+    def test_hub_mode_routes_to_init_hub(self, monkeypatch, tmp_path):
+        """--hub-path routes to init_hub with the path forwarded."""
+        from schist import sync as sync_mod
+
+        called: dict = {}
+
+        def fake_init_hub(args, hub_path):
+            called["args"] = args
+            called["hub_path"] = hub_path
+
+        monkeypatch.setattr(sync_mod, "init_hub", fake_init_hub)
+        sync_mod._dispatch_init(
+            _args(hub_path=str(tmp_path / "hub.git"), name="v", participant=["a"])
+        )
+        assert called["hub_path"] == str(tmp_path / "hub.git")
+
+    def test_spoke_mode_routes_to_init_spoke(self, monkeypatch):
+        """--spoke routes to init_spoke with vault_path derived from --hub URL.
+
+        Uses an HTTP-style URL so `os.path.basename(...).removesuffix('.git')`
+        produces a clean 'foo'. SSH-style `git@host:foo.git` derivation is a
+        pre-existing quirk of the inherited logic (colons aren't path
+        separators) — out of scope for this PR.
+        """
+        from schist import sync as sync_mod
+
+        called: dict = {}
+
+        def fake_init_spoke(args, vault_path, db_path):
+            called["args"] = args
+            called["vault_path"] = vault_path
+            called["db_path"] = db_path
+
+        monkeypatch.setattr(sync_mod, "init_spoke", fake_init_spoke)
+        sync_mod._dispatch_init(
+            _args(spoke=True, hub="https://example.com/foo.git", scope="notes", identity="a")
+        )
+        assert called["vault_path"] == "foo"
+        assert called["db_path"] == os.path.join("foo", ".schist", "schist.db")


### PR DESCRIPTION
## Summary

Adds the third `schist init` mode: **standalone**, alongside the existing `--hub-path` (bare hub repo) and `--spoke` (hub-linked clone) modes. Fills the gap on the path to v0.1.0 per `memory/project_schist_plan.md`.

```
schist init [<path>] [--name N] [--identity I]
```

- Scaffolds a local git repo at `<path>` (default cwd) with `vault.yaml`, empty `notes/` / `concepts/` / `papers/` directories with `.gitkeep` sentinels, `.gitignore` excluding runtime `.schist/` state, and installs `post-commit` + `pre-commit` hooks.
- Staging-dir + atomic-rename pattern (mirrors `init_hub`) — a half-initialized target can never exist on disk; retries after failure work cleanly.
- Default identity `local` with full-vault `read: ['*'], write: ['*']` ACL. `--identity` validated against `^[a-z][a-z0-9-]*$` (matches `NAME_RE` in `acl.py`).
- Hook content lives as string constants in `sync.py` with drift-guard unit tests against `hooks/post-commit` and `hooks/pre-commit` — installed hooks can never silently desync from the repo reference.

## Design decisions

Locked via `/plan-eng-review` in the prior session; resolved in this PR as **1B, 2B, 3A, 4A**:

- **1B — Hook source of truth:** inline string constants + drift-guard unit tests (matches existing `PRE_RECEIVE_HOOK` pattern).
- **2B — `_dispatch_init` helper:** centralizes the conflict matrix across all three init modes; `__main__.py` collapses two inline init branches into one `sync._dispatch_init(args)` call.
- **3A — Pre-existing `--hub` without `--spoke` trap, fixed in this PR:** previously silently fell through to a `KeyError` crash, and with standalone init added would have silently dropped the hub URL and scaffolded a personal vault. Now rejected up front with `Error: --hub requires --spoke`.
- **4A — Keep `_build_standalone_vault` separate from `_build_seed_vault`:** they diverge on participant type, default scope, and ACL shape; parametrizing would hide the differences behind callbacks.

## Review cycle (per `feedback_pr_workflow.md`)

- **`/review`** → 2 INFO findings (`_dispatch_init` hub-mode and spoke-mode routing not tested) → **AUTO-FIXED**: added 2 monkeypatched routing tests
- **`/cso --diff`** → **0 findings** at ≥8/10 confidence. No SQL, no LLM, no crypto, no network. All subprocess calls use argv (no shell). Inputs from CLI/env are trusted per filter precedent. Self-verified.
- **Sonnet cross-model adversarial** → **1 LOW/9 finding**:
  - `staging.mkdir(parents=True)` in `_build_*_in_staging` can raise `OSError` (permission denied, disk full) which escapes the `except _InitError` handler as an unhandled traceback. Pre-existing in `init_hub`; replicated in `init_standalone`. **FIXED in both functions**: broadened outer catch to `(_InitError, OSError)` so filesystem failures surface as clean `Error: ...` lines. Regression test `test_rejects_unwritable_parent_cleanly` added.

Sonnet is now **6-for-6** on catching real issues the structured review missed.

## Test plan

- [x] `python -m pytest cli/tests/` — **220/220 passing** (191 prior + 29 new in `test_init_standalone.py`)
- [x] Smoke-tested through argparse:
  - `schist init /tmp/smoke-test --name smoke-test --identity tester` creates the scaffold correctly (branch `main`, seed commit, vault.yaml, tracked files, hooks installed + executable)
  - `schist init --hub URL` → `Error: --hub requires --spoke` (Issue 3A fix)
  - `schist init foo --hub-path /tmp/hub.git` → `Error: positional <path> is only valid for standalone init`
  - `schist init foo --spoke` → `Error: positional <path> is only valid for standalone init`
- [x] Drift-guard tests confirm the embedded `POST_COMMIT_HOOK` / `PRE_COMMIT_HOOK` constants match `hooks/post-commit` / `hooks/pre-commit` byte-for-byte (passed first-run, no manual alignment needed)
- [ ] CI green on this PR

## Test coverage

New tests in `cli/tests/test_init_standalone.py` (29 tests across `TestInitStandalone` and `TestDispatchInit`):

- Happy path: explicit path, cwd default, name/identity defaults, custom name/identity
- Validation: invalid identity format, non-empty target rejection, empty-target allowance
- Rollback: git init failure, git commit failure, staging cleanup on all failure paths, unwritable parent (OSError handler regression test)
- Filesystem: intermediate-dir creation, rename over empty target, hooks installed + executable, hooks not committed, `.gitignore` correctness
- YAML: vault.yaml parses + validates via `parse_vault_yaml`, roundtrip integrity, scope_convention correct, ACL grants match identity
- Git state: initial commit on `main` branch, commit message format, all scaffolded files tracked
- Dispatch: all five conflict-matrix rejection paths (`--hub-path + --spoke`, `--hub-path + --hub`, `--hub` w/o `--spoke`, positional + `--hub-path`, positional + `--spoke`), and all three routing paths (hub → `init_hub`, spoke → `init_spoke`, standalone → `init_standalone`)
- Drift guards: `POST_COMMIT_HOOK` and `PRE_COMMIT_HOOK` constants byte-equal to on-disk reference

## Not in this PR

- SSH-style URL derivation for spoke vault path (`git@host:foo.git` → `git@host:foo` instead of `foo`) — pre-existing quirk in `os.path.basename(...).removesuffix('.git')` logic that this PR inherited unchanged. Not introduced here. Documented in `test_spoke_mode_routes_to_init_spoke` docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)