### PR TITLE
refactor: remove assign_domain NOT_IMPLEMENTED stub

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -23,7 +23,6 @@ import {
   delete_agent_state,
   add_concept_alias,
   list_domains,
-  assign_domain,
 } from "./tools.js";
 import type { VaultConfig } from "./types.js";
 
@@ -168,18 +167,6 @@ function makeMemoryWriteTools(_config: VaultConfig) {
           created_by: { type: "string" },
         },
         required: ["duplicate_slug", "canonical_slug", "created_by"],
-      },
-    },
-    {
-      name: "assign_domain",
-      description: "Assign a research domain to a doc.",
-      inputSchema: {
-        type: "object" as const,
-        properties: {
-          doc_id: { type: "string" },
-          domain_slug: { type: "string" },
-        },
-        required: ["doc_id", "domain_slug"],
       },
     },
   ];
@@ -412,11 +399,6 @@ async function main() {
             result = writeEnabled
               ? await add_concept_alias(vaultRoot, toolArgs as Parameters<typeof add_concept_alias>[1])
               : { error: "VALIDATION_ERROR", message: "add_concept_alias requires write capability." };
-            break;
-          case "assign_domain":
-            result = writeEnabled
-              ? await assign_domain(vaultRoot, toolArgs as Parameters<typeof assign_domain>[1])
-              : { error: "VALIDATION_ERROR", message: "assign_domain requires write capability." };
             break;
           default:
             result = { error: "VALIDATION_ERROR", message: `Unknown tool: ${name}` };

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -536,15 +536,3 @@ export async function add_concept_alias(
     return normalizeError(e, "VALIDATION_ERROR");
   }
 }
-
-export async function assign_domain(
-  _vaultRoot: string,
-  args: { doc_id: string; domain_slug: string }
-): Promise<unknown> {
-  // TODO: implement actual persistence — add domain_slug to the doc's
-  // frontmatter via the git-writer path, then trigger re-ingestion.
-  return {
-    error: "NOT_IMPLEMENTED",
-    message: `assign_domain is not yet implemented (doc_id=${args.doc_id}, domain_slug=${args.domain_slug})`,
-  } satisfies ToolError;
-}


### PR DESCRIPTION
## Summary

Removes `assign_domain`, a never-implemented MCP tool stub, per the v0.1.0 completion plan (`memory/project_schist_plan.md` line 22: _"Either wire it up or remove from the tool list before shipping"_).

Remove is the faster path because the TODO's described implementation (in-place frontmatter edit + re-ingest) conflicts with the project's **append-only invariant** (CLAUDE.md: _"no in-place edits via MCP/CLI; to revise, create a new note with `contradicts:`/`extends:` connection"_). Resolving that conflict requires a design decision the plan doesn't specify — whether metadata tagging is exempt, or whether domain assignment should live in a companion file outside the note.

Removing unblocks v0.1.0 and leaves room for a proper re-implementation when the design is locked. An audit trail of the re-implementation path is captured in `memory/session_autonomous_apr14.md`.

## Changes

Four sites, 30 lines deleted, 0 added:

| File | Sites |
|---|---|
| `mcp-server/src/index.ts` | Import, tool definition, switch-case dispatch |
| `mcp-server/src/tools.ts` | Stub function |

No test coverage deleted — the stub had no tests because it never did anything.

## Left in place (deliberately)

- **`list_domains`** — read-side counterpart, still present for future use. The `domains` SQLite table is currently empty on every ingest rebuild (ingest.py doesn't populate it), but that's a separate latent bug tracked for follow-up.

## Review cycle

- **`/review`** — focused manual pass: dead code clean (no orphan imports, `ToolError` still used elsewhere), no test gaps (stub had no tests), no doc references
- **`/cso --diff`** — N/A, removing a NOT_IMPLEMENTED stub has zero security surface
- **Sonnet adversarial (self-check)** — verified no subtle runtime path calls `assign_domain`, no capability-gate fallout, MCP `ListTools` advertisement naturally excludes removed tool

## Test plan

- [x] `npm run build` — clean `tsc`
- [x] `npm test` — **65/65 jest tests pass** (arm64 Raspberry Pi, locally)
- [ ] CI green on this PR

## Backwards compatibility

Any MCP client that previously invoked `assign_domain` would have received `NOT_IMPLEMENTED` before this PR. After this PR, they receive `Unknown tool: assign_domain` (via the dispatch default case). Both are error-path responses; no functional degradation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)