### PR TITLE
docs: remove dead memory v2 schema + fix CLAUDE.md drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ cd mcp-server && npm install        # install deps
 npm run build                        # compile TS → dist/
 npm run dev                          # watch mode
 npm test                             # jest (ESM mode)
-npm test -- --testPathPattern=<pattern>  # run a single test file
+npm test -- --testPathPatterns=<pattern>  # run a single test file (Jest 30+)
 ```
 
 ### CLI (Python, in `cli/`)
@@ -28,7 +28,7 @@ python -m pytest cli/tests/test_acl.py::test_name -v  # single test
 ### Ingestion (Python, in `ingestion/`)
 ```bash
 pip install -r ingestion/requirements.txt
-python ingestion/ingest.py <vault-path>  # rebuild SQLite from markdown
+python ingestion/ingest.py --vault <path> --db <path>  # rebuild SQLite from markdown
 ```
 
 ### Viewer
@@ -87,7 +87,9 @@ ACLs. Create one with `schist init --hub --hub-path /path --name X
 - Full spec: `schema/SCHEMA.md`, vault config spec: `schema/vault-yaml.md`
 
 ### SQLite tables
-`docs`, `concepts`, `edges`, `docs_fts` (FTS5), `agent_memory`, `agent_state`, `domains`, `concept_aliases` — defined in `ingestion/schema.sql`. Memory tables (`agent_memory`, `agent_state`) persist across re-ingestion.
+Vault DB (`<vault>/.schist/schist.db`): `docs`, `concepts`, `edges`, `docs_fts` (FTS5), `domains`, `concept_aliases` — defined in `ingestion/schema.sql`. `docs`/`concepts`/`edges`/`docs_fts` are dropped and rebuilt from markdown on every commit; `domains` and `concept_aliases` use `CREATE TABLE IF NOT EXISTS` and survive commit-path rebuilds.
+
+Memory DB (`~/.openclaw/memory/agent-state.db` by default, or `SCHIST_MEMORY_DB`): `agent_memory`, `agent_memory_fts`, `agent_state` — schema inlined in `mcp-server/src/sqlite-reader.ts` as `MEMORY_SCHEMA`. Separate file from the vault DB, never touched by ingestion.
 
 ## Git Hooks
 - **post-commit** — triggers SQLite ingestion

--- a/ingestion/schema.sql
+++ b/ingestion/schema.sql
@@ -66,41 +66,18 @@ CREATE INDEX idx_edges_type ON edges(type);
 CREATE INDEX idx_docs_status ON docs(status);
 CREATE INDEX idx_docs_date ON docs(date);
 
--- ── Memory V2 Extension ────────────────────────────────────────────────────
--- These tables are NOT rebuilt on re-ingest. They are persistent state.
-
-CREATE TABLE IF NOT EXISTS agent_memory (
-  id           INTEGER PRIMARY KEY AUTOINCREMENT,
-  owner        TEXT NOT NULL,
-  date         TEXT NOT NULL,
-  entry_type   TEXT NOT NULL CHECK(entry_type IN ('decision','lesson','blocker','completion','observation')),
-  content      TEXT NOT NULL,
-  tags         TEXT,
-  related_doc  TEXT,
-  source_ref   TEXT,
-  confidence   TEXT NOT NULL DEFAULT 'medium' CHECK(confidence IN ('low','medium','high')),
-  created_at   TEXT NOT NULL DEFAULT (datetime('now'))
-);
-
-CREATE VIRTUAL TABLE IF NOT EXISTS agent_memory_fts USING fts5(owner, entry_type, content, tags, content='agent_memory', content_rowid='id');
-
-CREATE TRIGGER IF NOT EXISTS agent_memory_ai AFTER INSERT ON agent_memory BEGIN
-  INSERT INTO agent_memory_fts(rowid, owner, entry_type, content, tags)
-  VALUES (new.id, new.owner, new.entry_type, new.content, new.tags);
-END;
-
-CREATE TRIGGER IF NOT EXISTS agent_memory_ad AFTER DELETE ON agent_memory BEGIN
-  INSERT INTO agent_memory_fts(agent_memory_fts, rowid, owner, entry_type, content, tags)
-  VALUES ('delete', old.id, old.owner, old.entry_type, old.content, old.tags);
-END;
-
-CREATE TABLE IF NOT EXISTS agent_state (
-  key        TEXT PRIMARY KEY,
-  value      TEXT NOT NULL,
-  owner      TEXT NOT NULL,
-  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-  ttl_hours  INTEGER DEFAULT NULL
-);
+-- ── Side tables (survive commit-path rebuilds) ────────────────────────────
+-- `domains` and `concept_aliases` live alongside docs/concepts/edges in
+-- schist.db. They use CREATE TABLE IF NOT EXISTS and are NOT in the DROP
+-- list above, so on the commit-path rebuild (post-commit hook re-runs
+-- ingest.py on the existing DB) their rows survive. On the spoke-pull path
+-- (`_rebuild_index` in cli/schist/sync.py renames the entire DB file), they
+-- are currently lost — tracked as a known issue.
+--
+-- `agent_memory` and `agent_state` intentionally do NOT live here. They use
+-- a separate database (`~/.openclaw/memory/agent-state.db` by default, or
+-- `SCHIST_MEMORY_DB`) whose schema is defined inline in
+-- `mcp-server/src/sqlite-reader.ts` as the `MEMORY_SCHEMA` constant.
 
 CREATE TABLE IF NOT EXISTS domains (
   slug        TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary

Two related cleanups discovered during an overnight audit:

1. **`ingestion/schema.sql`** had 32 lines of dead schema defining `agent_memory`, `agent_memory_fts`, triggers, and `agent_state` tables in `schist.db` that nothing ever reads or writes.
2. **`CLAUDE.md`** had three drift items (wrong Jest flag, wrong ingest.py command, wrong description of where memory tables live).

## The dead schema

The `agent_memory` / `agent_state` tables intentionally live in a **separate database file** — `~/.openclaw/memory/agent-state.db` by default, or `SCHIST_MEMORY_DB` env var. The schema is defined inline in `mcp-server/src/sqlite-reader.ts` as the `MEMORY_SCHEMA` constant, and the tables are opened via `openMemoryDb()`. The CREATE statements in `schema.sql` created empty tables in `schist.db` that nothing ever touched.

Removal is safe — confirmed via grep across the whole repo:

```bash
grep -rn "agent_memory\|agent_state" cli ingestion
# Only the schema.sql comment references them; no Python code reads/writes
grep -rn "agent_memory\|agent_state" mcp-server/src
# All TypeScript references go through openMemoryDb() (separate file)
```

The removed definitions are replaced with an accurate comment block that documents:
- `domains` and `concept_aliases` live in `schist.db` alongside docs/concepts/edges
- They use `CREATE TABLE IF NOT EXISTS` and are NOT in the DROP list, so they survive the commit-path rebuild (post-commit hook re-runs ingest on the existing DB)
- On the spoke-pull path (`_rebuild_index` in `cli/schist/sync.py` renames the whole DB file), they're currently lost — tracked as a separate known issue
- `agent_memory` / `agent_state` live in a separate DB and never touch ingestion

## CLAUDE.md drift fixes

1. **Jest flag rename:** `--testPathPattern=<pattern>` → `--testPathPatterns=<pattern>`. Jest 30 (which we're on after PR #19) renamed the flag to the plural form and removed the singular. Verified with `node ./node_modules/jest/bin/jest.js --help` in this PR's worktree.

2. **ingest.py command signature:** `python ingestion/ingest.py <vault-path>` → `python ingestion/ingest.py --vault <path> --db <path>`. The positional form never worked — `ingest.py`'s argparse requires both `--vault` and `--db` flags (they're `required=True`).

3. **SQLite tables section:** previously listed `agent_memory` and `agent_state` as schist.db tables and claimed _"Memory tables (`agent_memory`, `agent_state`) persist across re-ingestion."_ Both wrong — they live in a separate DB file. Rewrote the section to split vault DB and memory DB, document which tables are in the DROP list vs `CREATE TABLE IF NOT EXISTS`, and document the `SCHIST_MEMORY_DB` override.

## Test plan

- [x] `python -m pytest cli/tests/` — **220/220 passing** locally
- [x] `cd mcp-server && npm run build && npm test` — **65/65 passing** locally (arm64 Pi)
- [ ] CI green on this PR

## Not in this PR (tracked as follow-ups)

- **`_rebuild_index` wipes `domains` and `concept_aliases` on spoke-pull** — real data loss for users who call `add_concept_alias` then `sync pull`. Documented in the updated schema.sql comment and queued as a separate PR.
- **`domains` table is never populated** — `list_domains` always returns `[]` because nothing ingests domain rows from `vault.yaml` or note frontmatter. Design question requiring user input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)