### PR TITLE
fix(sync): preserve domains + concept_aliases across spoke-pull rebuild

### DIFF
--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -644,6 +644,12 @@ def _rebuild_index(vault_path: str, db_path: str) -> None:
     """Delete existing SQLite and re-ingest from markdown files.
 
     Uses rename-on-success: old DB is only removed after ingest succeeds.
+    Before dropping the backup, side tables (`domains`, `concept_aliases`)
+    are copied forward into the new DB — they live alongside
+    docs/concepts/edges in schist.db but are not rebuilt from markdown, so
+    on the commit-path rebuild they survive naturally (ingest.py runs
+    against the existing DB). Here we rename the whole file, so the copy
+    is the only thing keeping them alive.
     """
     db = Path(db_path)
     backup = None
@@ -655,11 +661,52 @@ def _rebuild_index(vault_path: str, db_path: str) -> None:
 
     try:
         _run_ingest(vault_path, db_path)
-        # Success — remove backup
         if backup and backup.exists():
+            _preserve_side_tables(backup, db)
             backup.unlink()
     except Exception as e:
         # Restore backup so user keeps old (stale) index rather than none
         if backup and backup.exists():
             backup.rename(db)
         print(f"Warning: index rebuild failed: {e}", file=sys.stderr)
+
+
+# Side tables that live in schist.db but are not populated by ingest.py.
+# Columns are hardcoded (rather than using `SELECT *`) so a schema evolution
+# in `ingestion/schema.sql` cannot silently misalign columns during the copy.
+# If you add a column to either table, update this map too — `test_sync.py`
+# has a guard test that asserts every table column is listed here.
+_SIDE_TABLE_COLUMNS: dict[str, tuple[str, ...]] = {
+    "domains": ("slug", "label", "description", "parent_slug"),
+    "concept_aliases": (
+        "duplicate_slug", "canonical_slug", "reason", "created_by", "created_at",
+    ),
+}
+
+
+def _preserve_side_tables(backup: Path, new_db: Path) -> None:
+    """Copy side-table rows from `backup` into `new_db`.
+
+    Uses ATTACH DATABASE + INSERT OR IGNORE SELECT with explicit column lists
+    so schema drift between backup and new DB can't cause column-order
+    corruption. A missing table in the backup (older DB format) is skipped
+    silently; any other sqlite3 error re-raises.
+    """
+    import sqlite3
+
+    conn = sqlite3.connect(str(new_db))
+    try:
+        conn.execute("ATTACH DATABASE ? AS backup", (str(backup),))
+        for table, cols in _SIDE_TABLE_COLUMNS.items():
+            col_list = ", ".join(cols)
+            try:
+                conn.execute(
+                    f"INSERT OR IGNORE INTO main.{table} ({col_list}) "
+                    f"SELECT {col_list} FROM backup.{table}"
+                )
+            except sqlite3.OperationalError as e:
+                if "no such table" not in str(e).lower():
+                    raise
+        conn.commit()
+    finally:
+        conn.close()

--- a/cli/tests/test_sync.py
+++ b/cli/tests/test_sync.py
@@ -301,3 +301,187 @@ class TestSyncPush:
             sync_push(args, vault, "db.sqlite")
         err = capsys.readouterr().err
         assert "unreachable" in err.lower() or "saved locally" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# _rebuild_index side-table preservation
+# ---------------------------------------------------------------------------
+
+
+def _init_vault_with_schema(tmp_path: Path) -> tuple[str, str]:
+    """Set up a minimal vault + run a real ingest so schist.db exists with
+    the current schema.sql applied. Returns (vault_path, db_path).
+    """
+    import shutil
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "notes").mkdir()
+    (vault / "concepts").mkdir()
+    # One real markdown file so ingest has something to insert into docs
+    (vault / "notes" / "2026-01-01-seed.md").write_text(
+        "---\ntitle: seed\ndate: '2026-01-01'\nstatus: draft\n---\n\nSeed body.\n"
+    )
+    db_path = str(vault / ".schist" / "schist.db")
+    (vault / ".schist").mkdir()
+
+    # Run _rebuild_index once to lay down the schema + seed doc row
+    from schist.sync import _rebuild_index
+
+    _rebuild_index(str(vault), db_path)
+    if not Path(db_path).exists():
+        pytest.skip("ingest.py unavailable — can't set up the rebuild preservation tests")
+    return str(vault), db_path
+
+
+class TestRebuildIndexSideTablePreservation:
+    def test_concept_aliases_survive_rebuild(self, tmp_path):
+        """Rows in concept_aliases must survive a second _rebuild_index."""
+        import sqlite3
+        from schist.sync import _rebuild_index
+
+        vault, db_path = _init_vault_with_schema(tmp_path)
+
+        # Insert a concept_alias row into the existing DB
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                "INSERT INTO concept_aliases "
+                "(duplicate_slug, canonical_slug, reason, created_by) "
+                "VALUES (?, ?, ?, ?)",
+                ("backprop", "backpropagation", "short form", "tester"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Rebuild (simulates spoke pull)
+        _rebuild_index(vault, db_path)
+
+        # Row should still be there
+        conn = sqlite3.connect(db_path)
+        try:
+            rows = conn.execute(
+                "SELECT duplicate_slug, canonical_slug, reason, created_by "
+                "FROM concept_aliases"
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert rows == [("backprop", "backpropagation", "short form", "tester")]
+
+    def test_domains_survive_rebuild(self, tmp_path):
+        """Rows in domains must survive a second _rebuild_index."""
+        import sqlite3
+        from schist.sync import _rebuild_index
+
+        vault, db_path = _init_vault_with_schema(tmp_path)
+
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.executemany(
+                "INSERT INTO domains (slug, label, description, parent_slug) "
+                "VALUES (?, ?, ?, ?)",
+                [
+                    ("ai", "AI", "Artificial intelligence", None),
+                    ("ml", "ML", "Machine learning", "ai"),
+                ],
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        _rebuild_index(vault, db_path)
+
+        conn = sqlite3.connect(db_path)
+        try:
+            rows = conn.execute(
+                "SELECT slug, label, description, parent_slug FROM domains "
+                "ORDER BY slug"
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert rows == [
+            ("ai", "AI", "Artificial intelligence", None),
+            ("ml", "ML", "Machine learning", "ai"),
+        ]
+
+    def test_rebuild_ok_with_no_prior_db(self, tmp_path):
+        """First rebuild (no backup) should succeed with no side-table data."""
+        import sqlite3
+        from schist.sync import _rebuild_index
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "notes").mkdir()
+        (vault / ".schist").mkdir()
+        (vault / "notes" / "2026-01-01-seed.md").write_text(
+            "---\ntitle: seed\ndate: '2026-01-01'\nstatus: draft\n---\n\nBody.\n"
+        )
+        db_path = str(vault / ".schist" / "schist.db")
+
+        _rebuild_index(str(vault), db_path)
+
+        if not Path(db_path).exists():
+            pytest.skip("ingest.py unavailable")
+
+        conn = sqlite3.connect(db_path)
+        try:
+            # Both side tables should exist, both empty
+            assert conn.execute("SELECT COUNT(*) FROM domains").fetchone()[0] == 0
+            assert conn.execute("SELECT COUNT(*) FROM concept_aliases").fetchone()[0] == 0
+        finally:
+            conn.close()
+
+    def test_rebuild_handles_missing_side_table_in_backup(self, tmp_path):
+        """Older DB format without `domains` or `concept_aliases` should not
+        crash the rebuild — the missing tables should be skipped silently."""
+        import sqlite3
+        from schist.sync import _rebuild_index
+
+        vault, db_path = _init_vault_with_schema(tmp_path)
+
+        # Simulate an older DB format by dropping concept_aliases
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("DROP TABLE concept_aliases")
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Rebuild should still succeed (missing table in backup is skipped)
+        _rebuild_index(vault, db_path)
+
+        # New DB should have the fresh (empty) concept_aliases table
+        conn = sqlite3.connect(db_path)
+        try:
+            count = conn.execute("SELECT COUNT(*) FROM concept_aliases").fetchone()[0]
+            assert count == 0
+        finally:
+            conn.close()
+
+    def test_side_table_columns_list_is_complete(self, tmp_path):
+        """Guard test: if schema.sql adds a column to domains or
+        concept_aliases, the hardcoded column list in sync.py must be
+        updated too. This test reads the actual schema from a fresh DB and
+        compares against the hardcoded list.
+        """
+        import sqlite3
+        from schist.sync import _SIDE_TABLE_COLUMNS
+
+        vault, db_path = _init_vault_with_schema(tmp_path)
+
+        conn = sqlite3.connect(db_path)
+        try:
+            for table, expected_cols in _SIDE_TABLE_COLUMNS.items():
+                rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+                actual_cols = tuple(r[1] for r in rows)
+                assert actual_cols == expected_cols, (
+                    f"{table}: schema.sql and sync.py disagree.\n"
+                    f"  schema.sql columns: {actual_cols}\n"
+                    f"  sync.py columns:    {expected_cols}\n"
+                    f"  Update _SIDE_TABLE_COLUMNS in cli/schist/sync.py."
+                )
+        finally:
+            conn.close()


### PR DESCRIPTION
## Summary

`_rebuild_index` (called from `schist sync pull` and `init_spoke`) wipes `domains` and `concept_aliases` on every rebuild because it renames the old `schist.db` aside and runs ingest.py to create a fresh one. This is a real data-loss bug for agents using `add_concept_alias`:

1. Agent calls `add_concept_alias("backprop", "backpropagation", ...)` → row written to `schist.db`
2. Agent runs `schist sync pull` → `_rebuild_index` renames `schist.db` → `.db.bak`, creates fresh `schist.db`, ingest populates docs/concepts/edges, backup gets unlinked
3. **All concept_aliases rows gone** — the new `schist.db` only has whatever was ingested from markdown

On the **commit-path rebuild** (post-commit hook), ingest.py runs against the existing `schist.db` — the side tables naturally survive because they use `CREATE TABLE IF NOT EXISTS` and are NOT in the DROP list in schema.sql. The spoke-pull path is the only one that wipes them.

## Fix

After ingest succeeds and before unlinking the backup, `_rebuild_index` now copies side-table rows from the backup into the new DB:

```python
def _preserve_side_tables(backup: Path, new_db: Path) -> None:
    conn = sqlite3.connect(str(new_db))
    try:
        conn.execute("ATTACH DATABASE ? AS backup", (str(backup),))
        for table, cols in _SIDE_TABLE_COLUMNS.items():
            col_list = ", ".join(cols)
            try:
                conn.execute(
                    f"INSERT OR IGNORE INTO main.{table} ({col_list}) "
                    f"SELECT {col_list} FROM backup.{table}"
                )
            except sqlite3.OperationalError as e:
                if "no such table" not in str(e).lower():
                    raise
        conn.commit()
    finally:
        conn.close()
```

**Hardcoded column lists** (not `SELECT *`) so a schema evolution can't silently misalign columns. The guard test `test_side_table_columns_list_is_complete` reads `PRAGMA table_info` on a fresh DB and asserts the hardcoded list matches — if `schema.sql` adds a column, the test fails loudly.

**Missing tables** in an older backup (pre-memory-v2 DB format) are skipped silently. Any other `sqlite3.OperationalError` re-raises to the outer restore path so real errors surface.

## Tests (`test_sync.py::TestRebuildIndexSideTablePreservation`)

| # | Test | What it covers |
|---|---|---|
| 1 | `test_concept_aliases_survive_rebuild` | Happy path — row roundtrips a full rebuild |
| 2 | `test_domains_survive_rebuild` | Same for `domains`, including parent_slug FK-like reference |
| 3 | `test_rebuild_ok_with_no_prior_db` | First rebuild (no backup) — empty side tables, no crash |
| 4 | `test_rebuild_handles_missing_side_table_in_backup` | Older backup without `concept_aliases` — skipped silently, fresh empty table in new DB |
| 5 | `test_side_table_columns_list_is_complete` | **Schema-drift guard** — `PRAGMA table_info` vs `_SIDE_TABLE_COLUMNS` |

## Not changed

- The restore-on-failure path (outer `except Exception` renames backup back) is untouched — if `_preserve_side_tables` itself raises, the restore still runs.
- `agent_memory` / `agent_state` are NOT copied. They live in a separate DB file (`SCHIST_MEMORY_DB` or `~/.openclaw/memory/agent-state.db`), never in `schist.db`, and never touched by ingestion. See PR #23 for the cleanup that removed the dead schema.

## Test plan

- [x] `python -m pytest cli/tests/test_sync.py -v` — **22/22 passing** (17 existing + 5 new)
- [x] `python -m pytest cli/tests/` — **225/225 passing**
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)