### PR TITLE
feat(sync): rich conflict recovery UX for schist sync pull

### DIFF
--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -183,14 +184,93 @@ def sync_pull(args, vault_path: str, db_path: str) -> None:
 
     ok, output = git_ops.pull_rebase(vault_path)
     if not ok:
-        print(f"Error: pull failed — {output}", file=sys.stderr)
-        if "conflict" in output.lower() or "CONFLICT" in output:
-            print("Resolve conflicts manually or re-clone the spoke.", file=sys.stderr)
+        if "CONFLICT" in output or "conflict" in output.lower():
+            _print_conflict_recovery(vault_path, config, output)
+        else:
+            print(f"Error: pull failed — {output}", file=sys.stderr)
         sys.exit(1)
 
     # Rebuild index
     _rebuild_index(vault_path, db_path)
     print(f"Pull complete. Index rebuilt.")
+
+
+_CONFLICT_RE = re.compile(r"CONFLICT \([^)]+\): Merge conflict in (.+)")
+
+
+def _extract_conflicting_files(git_output: str) -> list[str]:
+    """Parse git rebase output for `CONFLICT (content): Merge conflict in <path>`
+    lines. Returns the list of conflicting file paths, in order of appearance,
+    deduplicated. Returns an empty list if no conflicts were matched (e.g. the
+    failure was a delete-modify conflict that git phrases differently)."""
+    seen: set[str] = set()
+    files: list[str] = []
+    for line in git_output.splitlines():
+        match = _CONFLICT_RE.match(line.strip())
+        if match:
+            path = match.group(1).strip()
+            if path not in seen:
+                seen.add(path)
+                files.append(path)
+    return files
+
+
+def _print_conflict_recovery(
+    vault_path: str, config: SpokeConfig, git_output: str
+) -> None:
+    """Render the pull-conflict error block with concrete recovery steps.
+
+    `pull_rebase` in git_ops.py auto-aborts the failed rebase, so by the time
+    we land here the local working tree is already back to pre-pull state.
+    The user's work is NOT lost — they just couldn't automatically absorb the
+    hub's changes. This message tells them that explicitly and gives three
+    concrete recovery paths sized from safest to most-hands-on."""
+    conflicts = _extract_conflicting_files(git_output)
+
+    print(
+        "Error: pull failed with conflicts. Local state is unchanged "
+        "(the rebase was auto-aborted).",
+        file=sys.stderr,
+    )
+    if conflicts:
+        print("", file=sys.stderr)
+        print("Conflicting files:", file=sys.stderr)
+        for f in conflicts:
+            print(f"  {f}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(
+        "The hub has commits that touch the same lines as your local work. "
+        "Recovery options:",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    print("  1. INSPECT what's on the hub first:", file=sys.stderr)
+    print(f"       git -C {vault_path} fetch origin", file=sys.stderr)
+    print(f"       git -C {vault_path} log HEAD..origin/main --oneline", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  2. MANUAL REBASE (advanced — resolve conflicts yourself):", file=sys.stderr)
+    print(
+        f"       git -C {vault_path} fetch origin && "
+        f"git -C {vault_path} rebase origin/main",
+        file=sys.stderr,
+    )
+    print(
+        "       # edit conflicting files, git add <files>, git rebase --continue",
+        file=sys.stderr,
+    )
+    print(f"       schist sync pull   # rebuild index", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(
+        "  3. RE-CLONE (safest — your local changes must already be pushed):",
+        file=sys.stderr,
+    )
+    print(f"       schist sync push              # push first if you have any", file=sys.stderr)
+    print(f"       rm -rf {vault_path}", file=sys.stderr)
+    print(
+        f"       schist init --spoke --hub {config.hub} "
+        f"--scope {config.scope} --identity {config.identity}",
+        file=sys.stderr,
+    )
 
 
 def sync_push(args, vault_path: str, db_path: str) -> None:

--- a/cli/tests/test_sync.py
+++ b/cli/tests/test_sync.py
@@ -215,8 +215,21 @@ class TestSyncPull:
         assert "could not clear rebase state" in err
         assert "Manual fix" in err
 
-    @patch("schist.sync.git_ops.pull_rebase", return_value=(False, "CONFLICT in research/mario/note.md"))
-    def test_pull_conflict_aborts(self, mock_pull, tmp_path, capsys):
+    @patch(
+        "schist.sync.git_ops.pull_rebase",
+        return_value=(
+            False,
+            "Auto-merging research/mario/a.md\n"
+            "CONFLICT (content): Merge conflict in research/mario/a.md\n"
+            "Auto-merging research/mario/b.md\n"
+            "CONFLICT (content): Merge conflict in research/mario/b.md\n"
+            "error: Failed to merge in the changes.",
+        ),
+    )
+    def test_pull_conflict_rich_recovery_message(self, mock_pull, tmp_path, capsys):
+        """On conflict, sync_pull prints conflicting-file list + 3 recovery
+        paths (INSPECT, MANUAL REBASE, RE-CLONE) and explicitly tells the
+        user their local state is unchanged."""
         from schist.sync import sync_pull
 
         vault = _make_spoke(tmp_path)
@@ -224,8 +237,79 @@ class TestSyncPull:
         with pytest.raises(SystemExit):
             sync_pull(args, vault, "db.sqlite")
         err = capsys.readouterr().err
-        assert "pull failed" in err
-        assert "conflict" in err.lower() or "re-clone" in err.lower()
+
+        # Core message: what happened + that local state is safe
+        assert "pull failed with conflicts" in err
+        assert "Local state is unchanged" in err
+        assert "auto-aborted" in err
+
+        # Both conflicting files appear in the list
+        assert "research/mario/a.md" in err
+        assert "research/mario/b.md" in err
+
+        # All three recovery paths are presented
+        assert "INSPECT" in err
+        assert "MANUAL REBASE" in err
+        assert "RE-CLONE" in err
+
+        # Re-clone option shows the exact re-init command with spoke identity
+        assert "schist init --spoke" in err
+        assert "cluster-mario" in err  # identity from _make_spoke()
+        assert "git@pi.local:vault.git" in err  # hub URL from _make_spoke()
+
+    def test_pull_non_conflict_error_keeps_raw_output(self, tmp_path, capsys):
+        """Non-conflict errors (e.g. network failure) skip the rich recovery
+        block and just surface the raw git output."""
+        from schist.sync import sync_pull
+
+        vault = _make_spoke(tmp_path)
+        args = MagicMock()
+        with patch(
+            "schist.sync.git_ops.pull_rebase",
+            return_value=(False, "fatal: Could not resolve hostname pi.local"),
+        ), pytest.raises(SystemExit):
+            sync_pull(args, vault, "db.sqlite")
+        err = capsys.readouterr().err
+        assert "Error: pull failed" in err
+        assert "Could not resolve hostname" in err
+        # None of the rich-recovery headers should appear
+        assert "INSPECT" not in err
+        assert "RE-CLONE" not in err
+
+    def test_extract_conflicting_files_parses_git_output(self):
+        """Unit test on the helper: various CONFLICT line shapes are matched."""
+        from schist.sync import _extract_conflicting_files
+
+        output = (
+            "Auto-merging a.md\n"
+            "CONFLICT (content): Merge conflict in a.md\n"
+            "CONFLICT (modify/delete): b.md deleted in HEAD and modified in commit\n"
+            "CONFLICT (content): Merge conflict in nested/dir/c.md\n"
+            "error: Failed to merge in the changes."
+        )
+        files = _extract_conflicting_files(output)
+        # Only "content"-style conflicts are matched (intentional — that's
+        # what the regex targets). modify/delete is a different shape.
+        assert files == ["a.md", "nested/dir/c.md"]
+
+    def test_extract_conflicting_files_deduplicates(self):
+        """Duplicate conflict lines are deduplicated in the returned list."""
+        from schist.sync import _extract_conflicting_files
+
+        output = (
+            "CONFLICT (content): Merge conflict in foo.md\n"
+            "CONFLICT (content): Merge conflict in foo.md\n"
+            "CONFLICT (content): Merge conflict in bar.md\n"
+        )
+        assert _extract_conflicting_files(output) == ["foo.md", "bar.md"]
+
+    def test_extract_conflicting_files_empty_on_no_match(self):
+        """If git output has no CONFLICT lines (unusual but possible),
+        return an empty list rather than raising."""
+        from schist.sync import _extract_conflicting_files
+
+        assert _extract_conflicting_files("fatal: something else") == []
+        assert _extract_conflicting_files("") == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replaces the old one-line conflict error from `schist sync pull` with a structured recovery block that actually helps the user.

**Before:**
```
Error: pull failed — <raw git output>
Resolve conflicts manually or re-clone the spoke.
```

This was misleading. `git_ops.pull_rebase` auto-aborts the failed rebase before returning, so by the time `sync_pull` prints this message the working tree is **already back to pre-pull state** — there's nothing to "resolve manually" locally.

**After:**
```
Error: pull failed with conflicts. Local state is unchanged (the rebase was auto-aborted).

Conflicting files:
  research/mario/a.md
  research/mario/b.md

The hub has commits that touch the same lines as your local work. Recovery options:

  1. INSPECT what's on the hub first:
       git -C <vault> fetch origin
       git -C <vault> log HEAD..origin/main --oneline

  2. MANUAL REBASE (advanced — resolve conflicts yourself):
       git -C <vault> fetch origin && git -C <vault> rebase origin/main
       # edit conflicting files, git add <files>, git rebase --continue
       schist sync pull   # rebuild index

  3. RE-CLONE (safest — your local changes must already be pushed):
       schist sync push              # push first if you have any
       rm -rf <vault>
       schist init --spoke --hub git@pi.local:vault.git --scope research/mario --identity cluster-mario
```

The re-clone option uses the **actual hub URL, scope, and identity** from the live spoke config (via `load_spoke_config`), so it's copy-paste-ready.

## Changes

- **`cli/schist/sync.py`:**
  - `_extract_conflicting_files(git_output)` — parses `CONFLICT (content): Merge conflict in <path>` lines, deduplicates, returns list in order of appearance
  - `_print_conflict_recovery(vault_path, config, git_output)` — renders the structured block
  - `sync_pull` conflict branch now delegates to `_print_conflict_recovery` instead of the old one-liner
  - Non-conflict errors (network failure, auth, etc.) still surface the raw git output unchanged
  - Added `import re` for the regex

## Test plan

- [x] `python -m pytest cli/tests/test_sync.py -v` — **31/31 passing** (27 prior + 5 net new after replacing the old one-line conflict test)
- [x] `python -m pytest cli/tests/` — **234/234 passing**
- [ ] CI green on this PR

## Design choices

- **Regex targets `CONFLICT (content)` lines only.** Git has several conflict shapes (`content`, `modify/delete`, `rename/delete`, etc.). Keeping the regex tight to `content` (the overwhelming majority) avoids false-positive parsing and documentation debt. The unit test verifies this intentionally: a `modify/delete` line does NOT get picked up. If no conflicts are matched (unusual but possible), the output gracefully prints the recovery options without a file list.
- **`pull_rebase` auto-abort is unchanged.** The session-1 self-heal code at `sync_pull:154-180` depends on leftover rebase state being unusual, so preserving the rebase would require broader refactoring. The new message honestly tells users the abort happened.
- **All three recovery paths are always shown**, even when the diagnostic file list is empty. The options apply regardless of which files conflicted.
- **No change to MCP-side auto-pull.** `maybeSpokePull` in the MCP server has a 5s timeout and silently falls through on failure (per existing behavior). This PR only affects the human-facing CLI path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)