### PR TITLE
fix(cli): pin setuptools packages to avoid flat-layout collision

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -11,6 +11,17 @@ dependencies = ["python-frontmatter>=1.1.0", "pyyaml>=6.0.3"]
 [project.scripts]
 schist = "schist.__main__:main"
 
+# Explicit package list — without this, setuptools 82+ flat-layout
+# auto-discovery fails when a local `cli/hooks/` directory exists (as
+# created by test_rate_limit.py's `rejected-pushes.log`, which lands
+# under cli/hooks/ by default even though the log file is gitignored).
+# setuptools then errors with "Multiple top-level packages discovered in
+# a flat-layout: ['hooks', 'schist']" because .gitignore is invisible
+# to it. Pinning packages to ["schist"] makes the install deterministic
+# regardless of stray local directories.
+[tool.setuptools]
+packages = ["schist"]
+
 [tool.pytest.ini_options]
 markers = [
     "integration: slow tests that spawn real git subprocesses",


### PR DESCRIPTION
## Summary

Local-dev footgun discovered during an end-to-end install smoke test on the post-session-4 main. Running `test_rate_limit.py` creates `cli/hooks/rejected-pushes.log` as a test side-effect. The log file is gitignored (two entries in `.gitignore`), but `cli/hooks/` the **directory** is not — empty dirs don't show in git status either way, so it persists silently.

When you subsequently run `pip install -e ./cli` with setuptools 82+ (which we pinned in PR #15), setuptools's flat-layout package auto-discovery sees both `cli/schist/` and `cli/hooks/` as candidate top-level packages and refuses to proceed:

```
error: Multiple top-level packages discovered in a flat-layout: ['hooks', 'schist'].

To avoid accidental inclusion of unwanted files or directories,
setuptools will not proceed with this build.
```

setuptools doesn't honour `.gitignore` — it just sees a directory with a file in it. Before setuptools 82, auto-discovery was more forgiving. The fix is to stop relying on auto-discovery for a single-package project: explicitly list `schist`.

## Fix

```toml
[tool.setuptools]
packages = ["schist"]
```

Plus an inline comment explaining the trap so a future maintainer (or autonomous agent) knows why it's there.

## Not a CI blocker

CI runs `pip install -e ./cli` on a fresh checkout before running tests, so `cli/hooks/` doesn't exist yet when pip is invoked. The bug only manifests in the **local dev/agent workflow** (run tests → reinstall on the same checkout), which is exactly what autonomous agents do on every session. I hit it tonight when smoke-testing the `schist` entry point after all the other Queue E merges landed.

## Verification

Reproduced the bug, applied the fix, confirmed end-to-end:

1. **Created a stray `cli/hooks/rejected-pushes.log`** in the worktree
2. **Before fix:** `pip install -e ./cli` → `error: Multiple top-level packages discovered in a flat-layout`
3. **After fix:** `pip install -e ./cli` → clean build, editable wheel installed
4. **End-to-end entry point test:**
   ```
   schist init /tmp/smoke-vault --name smoke --identity tester
   ```
   → vault initialized with vault.yaml, notes/concepts/papers dirs, git repo, all expected scaffolding
5. `vault.yaml` contents validate (vault_version 1, name/scope_convention/participants/access all correct)

## Test plan

- [x] `python -m pytest cli/tests viewer/tests` — **255/255 passing** (no regressions)
- [x] Fresh-venv install with stray hooks dir present — succeeds
- [x] `schist init` entry point end-to-end works post-install
- [ ] CI green on this PR (will match because CI's fresh-checkout flow was never broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)