### PR TITLE
fix(mcp): always list all tools; gate writes at invocation, not listing

### DIFF
--- a/docs/cross-project-memory.md
+++ b/docs/cross-project-memory.md
@@ -64,12 +64,13 @@ new memory entries; see the Identity section below.
 
 ## Tool surface
 
-The memory subsystem exposes six MCP tools. Read tools are available
-immediately; write tools are gated behind
-`request_capabilities({capability: "write"})`, the same gate that protects
-vault write tools.
+The memory subsystem exposes six MCP tools. All tools are listed by
+`ListTools`; write tools require `request_capabilities({capability:
+"write"})` before calls succeed. The gate is at invocation time, not
+listing time — see `docs/mcp-setup.md` "Tool exposure model" for the
+full rationale.
 
-**Read (always available):**
+**Read (callable immediately):**
 
 - `search_memory` — full-text search with optional `owner`, `entry_type`,
   `date_from`, `date_to`, `limit` filters. FTS5 indexes the `content` and
@@ -78,7 +79,7 @@ vault write tools.
 - `list_domains` — list the research domain taxonomy (separate from memory,
   included here because it shares the read surface).
 
-**Write (after `request_capabilities`):**
+**Write (callable after `request_capabilities`):**
 
 - `add_memory` — store a new entry. Required: `owner`, `entry_type` (one of
   `decision | lesson | blocker | completion | observation`), `content`.
@@ -92,6 +93,10 @@ vault write tools.
 The `owner` field on write is enforced to equal `SCHIST_AGENT_ID`. Writes
 without `SCHIST_AGENT_ID` set fail with `CONFIG_ERROR`; writes with a
 mismatched owner fail with `VALIDATION_ERROR`. Reads are unrestricted.
+
+The `request_capabilities` success response now lists every write tool
+that becomes callable — both vault and memory — in its `message` and
+`tools` fields.
 
 ## Identity: `SCHIST_AGENT_ID`
 

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -26,23 +26,38 @@ SCHIST_VAULT_PATH=/path/to/vault node dist/index.js
 
 ## Tool exposure model
 
-<!-- Implementation: mcp-server/src/index.ts — see PR#1 + PR#2 -->
+<!-- Implementation: mcp-server/src/tool-registry.ts + src/index.ts -->
 
-The server starts in read-only mode. Only three tools are available by default:
+The server lists **all** tools at `ListTools` time — read, write, memory,
+and the capability meta-tool. Write-capable tools are gated at **call
+time**, not at listing time: an agent that calls a write tool without
+first calling `request_capabilities` gets a `VALIDATION_ERROR`.
 
-- `get_context` — vault summary (note/concept/edge counts + recent notes). Defaults to `depth: "minimal"`.
-- `search_notes` — full-text search.
-- `request_capabilities` — meta-tool to unlock write tools (see below).
+Always-listed tools (callable immediately):
 
-To unlock write tools (`create_note`, `add_connection`, `get_note`,
-`list_concepts`, `query_graph`), the agent calls:
+- `get_context`, `search_notes` — vault read
+- `search_memory`, `get_agent_state`, `list_domains` — memory read
+- `request_capabilities` — meta-tool to unlock write invocations
+
+Always-listed tools (callable only after `request_capabilities({capability: "write"})`):
+
+- `get_note`, `create_note`, `add_connection`, `list_concepts`, `query_graph` — vault write
+- `add_memory`, `set_agent_state`, `delete_agent_state`, `add_concept_alias` — memory write
+
+To enable write invocations:
 
 ```json
 {"name": "request_capabilities", "arguments": {"capability": "write"}}
 ```
 
-This design minimises token cost for read-only sessions (CLI search, context
-loading) while keeping full write capability available when needed.
+**Why list everything up-front.** MCP clients like Claude Code cache
+tool discovery at session start and never re-fetch. If write tools were
+only listed after the capability unlock (the pre-v0.1.0 design), those
+clients would never see them — `add_memory` and friends would be
+unreachable from Claude Code even after a successful `request_capabilities`
+call. Listing all tools unconditionally costs a few kB in the one-time
+ListTools response in exchange for making write tools actually usable.
+The call-time gate preserves the explicit-opt-in model.
 
 ## Post-commit ingestion
 

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -191,7 +191,7 @@ async function main() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("[schist] MCP server ready (stdio) — default tools: get_context, search_notes");
+  console.error("[schist] MCP server ready (stdio) — all tools listed; write tools require request_capabilities({capability: 'write'}) to invoke");
 }
 
 main().catch((e) => {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -25,6 +25,11 @@ import {
   list_domains,
 } from "./tools.js";
 import type { VaultConfig } from "./types.js";
+import {
+  listAllTools,
+  makeWriteTools,
+  makeMemoryWriteTools,
+} from "./tool-registry.js";
 
 function resolveVaultPath(): string {
   const envVault = process.env.SCHIST_VAULT_PATH;
@@ -37,240 +42,6 @@ function resolveVaultPath(): string {
 
   console.error("Error: SCHIST_VAULT_PATH env var or --vault argument required");
   process.exit(1);
-}
-
-// ---------------------------------------------------------------------------
-// Tool definitions
-// ---------------------------------------------------------------------------
-
-function makeReadTools(config: VaultConfig) {
-  return [
-    {
-      name: "get_context",
-      description:
-        "Get knowledge graph context summary. Defaults to 'minimal' (counts + last 3 notes). " +
-        "Pass depth='standard' or depth='full' for richer detail. Call this first in any session.",
-      inputSchema: {
-        type: "object" as const,
-        properties: {
-          depth: { type: "string", enum: ["minimal", "standard", "full"] },
-        },
-      },
-    },
-    {
-      name: "search_notes",
-      description: "Full-text search across all notes in the knowledge graph",
-      inputSchema: {
-        type: "object" as const,
-        properties: {
-          query: { type: "string" },
-          limit: { type: "number" },
-          status: { type: "string", enum: config.statuses },
-          tags: { type: "array", items: { type: "string" } },
-          scope: { type: "string", description: 'Filter by scope. Use "inherit" to search agent default scope + global.' },
-        },
-        required: ["query"],
-      },
-    },
-  ];
-}
-
-function makeMemoryReadTools(_config: VaultConfig) {
-  return [
-    {
-      name: "search_memory",
-      description: "Search agent memory entries by text, owner, type, or date range.",
-      inputSchema: {
-        type: "object" as const,
-        properties: {
-          query: { type: "string" },
-          owner: { type: "string" },
-          entry_type: { type: "string", enum: ["decision", "lesson", "blocker", "completion", "observation"] },
-          date_from: { type: "string" },
-          date_to: { type: "string" },
-          limit: { type: "number" },
-        },
-      },
-    },
-    {
-      name: "get_agent_state",
-      description: "Get a keyed agent state value (e.g. 'sansan.current_pr').",
-      inputSchema: {
-        type: "object" as const,
-        properties: { key: { type: "string" } },
-        required: ["key"],
-      },
-    },
-    {
-      name: "list_domains",
-      description: "List research domain taxonomy.",
-      inputSchema: { type: "object" as const, properties: {} },
-    },
-  ];
-}
-
-function makeMemoryWriteTools(_config: VaultConfig) {
-  return [
-    {
-      name: "add_memory",
-      description: "Add a memory entry (decision, lesson, blocker, completion, or observation). owner must match SCHIST_AGENT_ID.",
-      inputSchema: {
-        type: "object" as const,
-        properties: {
-          owner: { type: "string" },
-          entry_type: { type: "string", enum: ["decision", "lesson", "blocker", "completion", "observation"] },
-          content: { type: "string" },
-          date: { type: "string" },
-          tags: { type: "array", items: { type: "string" } },
-          related_doc: { type: "string" },
-          source_ref: { type: "string" },
-          confidence: { type: "string", enum: ["low", "medium", "high"] },
-        },
-        required: ["owner", "entry_type", "content"],
-      },
-    },
-    {
-      name: "set_agent_state",
-      description: "Set a keyed agent state value. Key prefix must match owner (e.g. sansan.*). team.* requires owner=eleven.",
-      inputSchema: {
-        type: "object" as const,
-        properties: {
-          key: { type: "string" },
-          value: {},
-          owner: { type: "string" },
-          ttl_hours: { type: "number" },
-        },
-        required: ["key", "value", "owner"],
-      },
-    },
-    {
-      name: "delete_agent_state",
-      description: "Delete a keyed agent state value (owner-enforced).",
-      inputSchema: {
-        type: "object" as const,
-        properties: {
-          key: { type: "string" },
-          owner: { type: "string" },
-        },
-        required: ["key", "owner"],
-      },
-    },
-    {
-      name: "add_concept_alias",
-      description: "Mark a concept slug as a duplicate of a canonical slug.",
-      inputSchema: {
-        type: "object" as const,
-        properties: {
-          duplicate_slug: { type: "string" },
-          canonical_slug: { type: "string" },
-          reason: { type: "string" },
-          created_by: { type: "string" },
-        },
-        required: ["duplicate_slug", "canonical_slug", "created_by"],
-      },
-    },
-  ];
-}
-
-function makeWriteTools(config: VaultConfig) {
-  return [
-    {
-      name: "get_note",
-      description: "Get a note by ID with full content and connections",
-      inputSchema: {
-        type: "object" as const,
-        properties: { id: { type: "string" } },
-        required: ["id"],
-      },
-    },
-    {
-      name: "create_note",
-      description: "Create a new note in the knowledge graph. Auto-commits to git.",
-      inputSchema: {
-        type: "object" as const,
-        properties: {
-          title: { type: "string" },
-          body: { type: "string" },
-          tags: { type: "array", items: { type: "string" } },
-          concepts: { type: "array", items: { type: "string" } },
-          status: { type: "string", enum: config.statuses },
-          connections: {
-            type: "array",
-            items: {
-              type: "object",
-              properties: {
-                target: { type: "string" },
-                type: { type: "string" },
-                context: { type: "string" },
-              },
-              required: ["target", "type"],
-            },
-          },
-          directory: {
-            type: "string",
-            enum: config.directories,
-          },
-        },
-        required: ["title", "body"],
-      },
-    },
-    {
-      name: "add_connection",
-      description: "Add a typed connection between two notes or concepts",
-      inputSchema: {
-        type: "object" as const,
-        properties: {
-          source: { type: "string" },
-          target: { type: "string" },
-          type: { type: "string", enum: config.connectionTypes },
-          context: { type: "string" },
-        },
-        required: ["source", "target", "type"],
-      },
-    },
-    {
-      name: "list_concepts",
-      description: "List all concepts in the knowledge graph",
-      inputSchema: {
-        type: "object" as const,
-        properties: {
-          tags: { type: "array", items: { type: "string" } },
-          search: { type: "string" },
-          limit: { type: "number" },
-        },
-      },
-    },
-    {
-      name: "query_graph",
-      description: "Execute a read-only SQL query against the knowledge graph database",
-      inputSchema: {
-        type: "object" as const,
-        properties: {
-          sql: { type: "string" },
-          params: { type: "array", items: {} },
-        },
-        required: ["sql"],
-      },
-    },
-  ];
-}
-
-function makeCapabilityTool() {
-  return {
-    name: "request_capabilities",
-    description:
-      "Unlock additional schist tools beyond the default read-only set. " +
-      "Pass capability='write' to enable: get_note, create_note, add_connection, " +
-      "list_concepts, query_graph. " +
-      "Read-only sessions (search + context only) do not need to call this.",
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        capability: { type: "string", enum: ["write"] },
-      },
-      required: ["capability"],
-    },
-  };
 }
 
 // ---------------------------------------------------------------------------
@@ -307,14 +78,7 @@ async function main() {
   let writeEnabled = false;
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    const tools = [
-      ...makeReadTools(config),
-      ...makeMemoryReadTools(config),
-      makeCapabilityTool(),
-      ...(writeEnabled ? makeWriteTools(config) : []),
-      ...(writeEnabled ? makeMemoryWriteTools(config) : []),
-    ];
-    return { tools };
+    return { tools: listAllTools(config) };
   });
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
@@ -327,10 +91,14 @@ async function main() {
     if (name === "request_capabilities") {
       if (toolArgs.capability === "write") {
         writeEnabled = true;
+        const unlocked = [
+          ...makeWriteTools(config).map((t) => t.name),
+          ...makeMemoryWriteTools(config).map((t) => t.name),
+        ];
         result = {
           ok: true,
-          message: "Write tools unlocked: get_note, create_note, add_connection, list_concepts, query_graph",
-          tools: makeWriteTools(config).map((t) => t.name),
+          message: `Write capability enabled. Invocation now permitted for: ${unlocked.join(", ")}.`,
+          tools: unlocked,
         };
       } else {
         result = { error: "VALIDATION_ERROR", message: `Unknown capability: ${String(toolArgs.capability)}` };

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -1,0 +1,254 @@
+import type { VaultConfig } from "./types.js";
+
+export function makeReadTools(config: VaultConfig) {
+  return [
+    {
+      name: "get_context",
+      description:
+        "Get knowledge graph context summary. Defaults to 'minimal' (counts + last 3 notes). " +
+        "Pass depth='standard' or depth='full' for richer detail. Call this first in any session.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          depth: { type: "string", enum: ["minimal", "standard", "full"] },
+        },
+      },
+    },
+    {
+      name: "search_notes",
+      description: "Full-text search across all notes in the knowledge graph",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          query: { type: "string" },
+          limit: { type: "number" },
+          status: { type: "string", enum: config.statuses },
+          tags: { type: "array", items: { type: "string" } },
+          scope: { type: "string", description: 'Filter by scope. Use "inherit" to search agent default scope + global.' },
+        },
+        required: ["query"],
+      },
+    },
+  ];
+}
+
+export function makeMemoryReadTools(_config: VaultConfig) {
+  return [
+    {
+      name: "search_memory",
+      description: "Search agent memory entries by text, owner, type, or date range.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          query: { type: "string" },
+          owner: { type: "string" },
+          entry_type: { type: "string", enum: ["decision", "lesson", "blocker", "completion", "observation"] },
+          date_from: { type: "string" },
+          date_to: { type: "string" },
+          limit: { type: "number" },
+        },
+      },
+    },
+    {
+      name: "get_agent_state",
+      description: "Get a keyed agent state value (e.g. 'sansan.current_pr').",
+      inputSchema: {
+        type: "object" as const,
+        properties: { key: { type: "string" } },
+        required: ["key"],
+      },
+    },
+    {
+      name: "list_domains",
+      description: "List research domain taxonomy.",
+      inputSchema: { type: "object" as const, properties: {} },
+    },
+  ];
+}
+
+export function makeMemoryWriteTools(_config: VaultConfig) {
+  return [
+    {
+      name: "add_memory",
+      description: "Add a memory entry (decision, lesson, blocker, completion, or observation). owner must match SCHIST_AGENT_ID.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          owner: { type: "string" },
+          entry_type: { type: "string", enum: ["decision", "lesson", "blocker", "completion", "observation"] },
+          content: { type: "string" },
+          date: { type: "string" },
+          tags: { type: "array", items: { type: "string" } },
+          related_doc: { type: "string" },
+          source_ref: { type: "string" },
+          confidence: { type: "string", enum: ["low", "medium", "high"] },
+        },
+        required: ["owner", "entry_type", "content"],
+      },
+    },
+    {
+      name: "set_agent_state",
+      description: "Set a keyed agent state value. Key prefix must match owner (e.g. sansan.*). team.* requires owner=eleven.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          key: { type: "string" },
+          value: {},
+          owner: { type: "string" },
+          ttl_hours: { type: "number" },
+        },
+        required: ["key", "value", "owner"],
+      },
+    },
+    {
+      name: "delete_agent_state",
+      description: "Delete a keyed agent state value (owner-enforced).",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          key: { type: "string" },
+          owner: { type: "string" },
+        },
+        required: ["key", "owner"],
+      },
+    },
+    {
+      name: "add_concept_alias",
+      description: "Mark a concept slug as a duplicate of a canonical slug.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          duplicate_slug: { type: "string" },
+          canonical_slug: { type: "string" },
+          reason: { type: "string" },
+          created_by: { type: "string" },
+        },
+        required: ["duplicate_slug", "canonical_slug", "created_by"],
+      },
+    },
+  ];
+}
+
+export function makeWriteTools(config: VaultConfig) {
+  return [
+    {
+      name: "get_note",
+      description: "Get a note by ID with full content and connections",
+      inputSchema: {
+        type: "object" as const,
+        properties: { id: { type: "string" } },
+        required: ["id"],
+      },
+    },
+    {
+      name: "create_note",
+      description: "Create a new note in the knowledge graph. Auto-commits to git.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          title: { type: "string" },
+          body: { type: "string" },
+          tags: { type: "array", items: { type: "string" } },
+          concepts: { type: "array", items: { type: "string" } },
+          status: { type: "string", enum: config.statuses },
+          connections: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                target: { type: "string" },
+                type: { type: "string" },
+                context: { type: "string" },
+              },
+              required: ["target", "type"],
+            },
+          },
+          directory: {
+            type: "string",
+            enum: config.directories,
+          },
+        },
+        required: ["title", "body"],
+      },
+    },
+    {
+      name: "add_connection",
+      description: "Add a typed connection between two notes or concepts",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          source: { type: "string" },
+          target: { type: "string" },
+          type: { type: "string", enum: config.connectionTypes },
+          context: { type: "string" },
+        },
+        required: ["source", "target", "type"],
+      },
+    },
+    {
+      name: "list_concepts",
+      description: "List all concepts in the knowledge graph",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          tags: { type: "array", items: { type: "string" } },
+          search: { type: "string" },
+          limit: { type: "number" },
+        },
+      },
+    },
+    {
+      name: "query_graph",
+      description: "Execute a read-only SQL query against the knowledge graph database",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          sql: { type: "string" },
+          params: { type: "array", items: {} },
+        },
+        required: ["sql"],
+      },
+    },
+  ];
+}
+
+export function makeCapabilityTool() {
+  return {
+    name: "request_capabilities",
+    description:
+      "Enable write-capable tools for this session. Pass capability='write' to " +
+      "allow invocation of: get_note, create_note, add_connection, list_concepts, " +
+      "query_graph, add_memory, set_agent_state, delete_agent_state, " +
+      "add_concept_alias. These tools are always listed by ListTools so MCP " +
+      "clients that cache discovery can see them; the gate here controls " +
+      "whether calls to them succeed. Read-only sessions (search + context) " +
+      "do not need to call this.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        capability: { type: "string", enum: ["write"] },
+      },
+      required: ["capability"],
+    },
+  };
+}
+
+/**
+ * Return the full set of tool definitions exposed by the schist MCP server.
+ *
+ * All tools are listed unconditionally. Write-capable tools still require
+ * `request_capabilities({capability: "write"})` to succeed at invocation
+ * time — the capability gate is per-call, not per-list. This matters because
+ * MCP clients like Claude Code cache tool discovery at session start and
+ * never re-fetch; conditional listing made write tools unreachable for
+ * those clients.
+ */
+export function listAllTools(config: VaultConfig) {
+  return [
+    ...makeReadTools(config),
+    ...makeMemoryReadTools(config),
+    makeCapabilityTool(),
+    ...makeWriteTools(config),
+    ...makeMemoryWriteTools(config),
+  ];
+}

--- a/mcp-server/tests/tool-listing.test.ts
+++ b/mcp-server/tests/tool-listing.test.ts
@@ -1,0 +1,65 @@
+import { listAllTools } from "../src/tool-registry.js";
+import type { VaultConfig } from "../src/types.js";
+
+function testConfig(): VaultConfig {
+  return {
+    name: "test",
+    path: "/tmp/irrelevant",
+    directories: ["notes", "papers"],
+    connectionTypes: ["extends", "supports"],
+    statuses: ["draft", "final"],
+    writeBranch: "drafts",
+  };
+}
+
+describe("listAllTools — unconditional tool exposure", () => {
+  test("lists every read, write, memory, and capability tool", () => {
+    const names = listAllTools(testConfig()).map((t) => t.name).sort();
+
+    const expected = [
+      "add_concept_alias",
+      "add_connection",
+      "add_memory",
+      "create_note",
+      "delete_agent_state",
+      "get_agent_state",
+      "get_context",
+      "get_note",
+      "list_concepts",
+      "list_domains",
+      "query_graph",
+      "request_capabilities",
+      "search_memory",
+      "search_notes",
+      "set_agent_state",
+    ].sort();
+
+    expect(names).toEqual(expected);
+  });
+
+  test("write tools appear in the listing even without prior capability unlock", () => {
+    // listAllTools has no knowledge of writeEnabled state — it is invoked by
+    // the ListTools handler unconditionally. If this assertion ever regresses,
+    // MCP clients that cache tool discovery (Claude Code) will silently lose
+    // the ability to call any write tool.
+    const names = listAllTools(testConfig()).map((t) => t.name);
+
+    for (const tool of [
+      "create_note",
+      "add_connection",
+      "add_memory",
+      "set_agent_state",
+      "delete_agent_state",
+      "add_concept_alias",
+    ]) {
+      expect(names).toContain(tool);
+    }
+  });
+
+  test("request_capabilities description mentions invocation gate, not listing gate", () => {
+    const reqCap = listAllTools(testConfig()).find((t) => t.name === "request_capabilities");
+    expect(reqCap).toBeDefined();
+    // The description must convey that the gate is at call time, not list time.
+    expect(reqCap!.description?.toLowerCase()).toMatch(/invocation|calls? to|succeed/);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes a silent bug where Claude Code (and any MCP client that caches tool discovery) could never call schist's write tools — `create_note`, `add_memory`, `set_agent_state`, etc.
- MCP server now lists all tools unconditionally in `ListTools`; writes are gated at invocation time (the existing `writeEnabled` check), not at listing time.
- Zero behavior change for read-only sessions. Zero change to the call-time security boundary.

## Why

Claude Code does MCP tool discovery once at session start and caches the result. schist's pre-fix design conditionally appended write tools to the `ListTools` response only after `request_capabilities({capability: "write"})` — so those tools were permanently invisible to any already-running Claude Code session, even after a successful capability unlock.

Caught during dogfood of the new `/learn` + `/recall` skills (follow-up to PR #29): I called `request_capabilities` successfully, then searched the Claude Code tool inventory for `mcp__schist__add_memory` — no results. The `/learn` skill's primary MCP path was therefore broken for every Claude Code user.

Original design rationale (in `docs/mcp-setup.md`): minimize the ListTools response size for read-only sessions. That optimization was correct for stateless MCP clients but counterproductive for caching ones, and we pay the listing-cost tax every session anyway (since the agent has to call `request_capabilities` before any write).

## What

- **New module `mcp-server/src/tool-registry.ts`** (extracted from `index.ts`): pure functions that construct tool definitions. Exporting them to a side-effect-free module lets tests and other consumers import without triggering `main()` (which would try to resolve `SCHIST_VAULT_PATH` and exit).
- **`mcp-server/src/index.ts`**: 
  - `ListTools` handler returns `listAllTools(config)` — all tools, unconditionally.
  - `request_capabilities` success response now includes both vault and memory write tools in its `message` and `tools` fields (pre-fix it listed vault tools only — an existing bug I flagged yesterday in PR #29's adversarial review).
  - `makeCapabilityTool` description rewritten to describe the new model: capability controls invocation, not visibility.
- **`mcp-server/tests/tool-listing.test.ts`** (new, 3 tests): asserts the complete tool-name set is always listed; asserts the description reflects the invocation-gate model.
- **`docs/mcp-setup.md`**: "Tool exposure model" section rewritten. Includes rationale for the token-cost tradeoff.
- **`docs/cross-project-memory.md`**: updated to match (removes the outdated "gated behind request_capabilities" phrasing that implied listing-level gating).

## Not changed

- The call-time gate logic (`writeEnabled` check + `VALIDATION_ERROR` return) at `index.ts:345+` is the actual security boundary and is unchanged.
- Public behavior of every tool is unchanged.
- `request_capabilities` is still required before writes succeed.

## Test plan

- [x] `npm run build && npm test` — 68/68 pass locally on arm64 Pi (65 pre-existing + 3 new)
- [ ] CI green
- [ ] /review pass
- [ ] /cso pass
- [ ] Sonnet adversarial cross-model review
- [ ] **Post-merge manual validation:** restart a Claude Code session with schist MCP configured. Without calling `request_capabilities`, verify `mcp__schist__add_memory` appears in the deferred tool list (via `ToolSearch select:mcp__schist__add_memory`). This confirms Claude Code's cached discovery now surfaces write tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)