### PR TITLE
chore: release prep for v0.1.0 (PyPI + npm publish infra)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]*'  # Only match version tags like v0.1.0, not arbitrary v-prefixed tags
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      id-token: write   # Required for Trusted Publishing (OIDC)
+      contents: read
+    environment: pypi
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install build tooling
+        run: pip install build
+
+      - name: Build CLI wheel
+        run: python -m build cli/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: cli/dist
+
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    environment: npm
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+          cache-dependency-path: mcp-server/package-lock.json
+
+      - name: Install and build MCP server
+        working-directory: mcp-server
+        run: |
+          npm ci
+          npm run build
+
+      - name: Copy LICENSE to mcp-server (included in published tarball)
+        run: cp LICENSE mcp-server/
+
+      - name: Publish to npm
+        working-directory: mcp-server
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # TODO(post-v0.1.0): Migrate to OIDC Trusted Publishing for npm.
+      # First publish requires NPM_TOKEN because @schist/mcp-server package doesn't
+      # exist yet to configure OIDC against. After v0.1.0 is on npm:
+      # 1. Go to https://www.npmjs.com/package/@schist/mcp-server/access
+      # 2. Enable "Trusted Publishing with GitHub (OIDC)"
+      # 3. Configure: yibeichan/schist, release.yml, npm environment
+      # 4. Add 'id-token: write' permission, remove NODE_AUTH_TOKEN, add --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]*'  # Only match version tags like v0.1.0, not arbitrary v-prefixed tags
+      - 'v[0-9]+\.[0-9]+\.[0-9]+.*'  # Only match semver like v0.1.0, v1.2.3-rc.1
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ Thumbs.db
 # Pre-receive hook audit log (runtime-generated)
 hooks/rejected-pushes.log
 cli/hooks/rejected-pushes.log
+
+# Personal agent tooling (speckit framework + handoff skill — not part of schist)
+.specify/
+.claude/skills/speckit-*/
+.claude/skills/handoff/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to schist are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - Unreleased
+
+### Added
+- Agent-first knowledge graph with markdown + YAML frontmatter storage
+- MCP server (`@schist/mcp-server`) for Claude Desktop, Claude Code, and Cursor integration
+- Python CLI (`schist`) with full CRUD operations for notes, connections, and concepts
+- SQLite ingestion layer triggered by git post-commit hook (FTS5 search, graph queries)
+- Static D3.js viewer with force-directed graph and lunr.js search
+- Hub & spoke multi-machine topology with ACL-based scoped writes
+- Pre-commit hook that rejects commits containing secrets or API keys
+- Cross-project agent memory subsystem (`~/.openclaw/memory/agent-state.db`)
+- `/learn` and `/recall` CLI skills for cross-project lesson capture and retrieval
+
+### Changed
+- Moved ingestion module from standalone `ingestion/` into `schist` package (PR #31)
+- `schist-ingest` now shipped as console script via `pip install schist`
+- MCP server now lists all tools at `ListTools` time; write access gated at call-time (PR #30)
+
+### Fixed
+- setuptools 82+ flat-layout collision with local `cli/hooks/` directory (PR #28)
+- Viewer `normalize_endpoint` stripping `.md` from note paths (PR #27)
+- MCP `triggerIngestion` path after ingestion move (PR #31, second commit)
+- In-process ingest leaving partial DB on failure; now deletes on exception (PR #31)
+
+### Security
+- All write tools (`create_note`, `add_connection`, `add_memory`, `set_agent_state`) require explicit capability unlock via `request_capabilities`
+- `query_graph` tool rejects non-SELECT SQL
+- Git writes serialized via async-mutex (10s timeout) to prevent concurrent commit conflicts
+
+[Unreleased]: https://github.com/yibeichan/schist/compare/v0.0.0...v0.1.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 schist contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -15,15 +15,14 @@ Agent-first knowledge graph. Git is truth, SQLite is query, humans just watch.
 ## Quick Start
 
 ```bash
-# Clone schist
-git clone https://github.com/youruser/schist.git
-cd schist
+# Install CLI and MCP server (published packages)
+pip install schist
+npm install -g @schist/mcp-server
 
-# Install CLI
-pip install -e ./cli
-
-# Install MCP server dependencies
-cd mcp-server && npm install && npm run build && cd ..
+# Or install from source (for contributors):
+# git clone https://github.com/yibeichan/schist.git
+# cd schist && pip install -e ./cli
+# cd mcp-server && npm install && npm run build
 
 # Create a vault
 mkdir -p ~/vaults/research/{notes,papers,concepts,logs,.schist}
@@ -167,11 +166,12 @@ See [schema/SCHEMA.md](./schema/SCHEMA.md) for the markdown schema specification
 
 ## Security Model
 
-- Agents write to `drafts/` branch, not `main`
+- Hub pre-receive hook enforces vault.yaml ACLs per-scope and per-agent
 - No delete, no force-push, no history rewrite via MCP
 - Pre-commit hook rejects commits containing secrets/API keys
 - Web viewer is static only — no server-side execution
-- Vault repo uses scoped deploy keys
+- Write tools gated behind explicit `request_capabilities` unlock
+- `query_graph` rejects non-SELECT SQL
 
 ## Requirements
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,74 @@
+# schist
+
+Agent-first knowledge graph. Git is truth, SQLite is query, humans just watch.
+
+**schist** is a generic, domain-agnostic knowledge graph where AI agents are the primary writers. Content is markdown + YAML frontmatter, version-controlled in git. SQLite provides the query layer. A static web viewer (D3.js + lunr.js) gives humans a read-only visualization.
+
+## Installation
+
+```bash
+pip install schist
+```
+
+This installs the `schist` CLI and the `schist-ingest` console script (used by the git post-commit hook).
+
+## Quick Start
+
+```bash
+# Create a vault
+mkdir -p ~/vaults/research/{notes,papers,concepts,.schist}
+
+# Add your first note
+schist add --vault ~/vaults/research \
+  --title "First Note" \
+  --tags getting-started \
+  --body "Hello, knowledge graph."
+
+# Search it
+schist search --vault ~/vaults/research "knowledge"
+
+# Get graph context (useful for agent session start)
+schist context --vault ~/vaults/research
+```
+
+## CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `schist add` | Create a new note |
+| `schist link` | Add a connection between nodes |
+| `schist search` | Full-text search |
+| `schist query` | Raw SQL query |
+| `schist build` | Generate static viewer data |
+| `schist context` | Dump session context |
+| `schist schema` | Print or validate schema |
+
+## MCP Server
+
+The schist MCP server (`@schist/mcp-server`) is published separately on npm:
+
+```bash
+npm install -g @schist/mcp-server
+```
+
+Add to `~/.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "schist": {
+      "command": "node",
+      "args": ["/absolute/path/to/schist/mcp-server/dist/index.js"],
+      "env": {
+        "SCHIST_VAULT_PATH": "/absolute/path/to/vault"
+      }
+    }
+  }
+}
+```
+
+See the [full README](https://github.com/yibeichan/schist#readme) for architecture docs, hub & spoke setup, and MCP tool reference.
+
+## License
+
+MIT

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -5,8 +5,31 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "schist"
 version = "0.1.0"
+description = "Agent-first knowledge graph: git is truth, SQLite is query, humans just watch"
+readme = "README.md"
 requires-python = ">=3.11"
+license = "MIT"
+authors = [
+    { name = "schist contributors" }
+]
+keywords = ["knowledge-graph", "agents", "mcp", "markdown", "sqlite"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
 dependencies = ["python-frontmatter>=1.1.0", "pyyaml>=6.0.3"]
+
+[project.urls]
+Homepage = "https://github.com/yibeichan/schist"
+Repository = "https://github.com/yibeichan/schist"
+Issues = "https://github.com/yibeichan/schist/issues"
+Changelog = "https://github.com/yibeichan/schist/blob/main/CHANGELOG.md"
 
 [project.scripts]
 schist = "schist.__main__:main"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -16,7 +16,6 @@ keywords = ["knowledge-graph", "agents", "mcp", "markdown", "sqlite"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -7,7 +7,7 @@ name = "schist"
 version = "0.1.0"
 description = "Agent-first knowledge graph: git is truth, SQLite is query, humans just watch"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = "MIT"
 authors = [
     { name = "schist contributors" }
@@ -18,7 +18,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,104 @@
+# Release Checklist
+
+This document is for maintainers preparing a schist release.
+
+## Pre-Tag Checklist
+
+Before creating a release tag, verify the following:
+
+### 1. Version Bumps
+
+Update these files with the new version (e.g., `0.1.0` → `0.2.0`):
+
+- `cli/pyproject.toml`: `version = "X.Y.Z"`
+- `mcp-server/package.json`: `"version": "X.Y.Z"`
+- `CHANGELOG.md`: Move `[Unreleased]` entry to `[X.Y.Z]` with release date
+- Add new `[Unreleased]` section at top for next cycle
+
+### 2. CHANGELOG Entry
+
+Summarize changes since the last release in Keep a Changelog format:
+- `Added` — new features
+- `Changed` — changes to existing functionality
+- `Fixed` — bug fixes
+- `Security` — security-relevant changes
+
+### 3. CI Status
+
+Ensure all CI checks pass on `main`:
+- [ ] CLI tests (`python -m pytest cli/tests viewer/tests`)
+- [ ] MCP server tests (`npm test` in `mcp-server/`)
+- [ ] Type-check passes (`npm run build` completes cleanly)
+
+### 4. GitHub Environments
+
+Verify these environments exist in the repository (Settings → Environments):
+- `pypi` — for PyPI Trusted Publishing (OIDC)
+- `npm` — for npm publish with `NPM_TOKEN` secret
+
+Optionally enable "Require reviewers" for manual approval before publish.
+
+## Tagging and Publishing
+
+### Dry-Run (First Release or Big Changes)
+
+For a dry-run that publishes to TestPyPI but not npm:
+
+```bash
+# Tag release candidate
+git tag v0.1.0-rc.1
+git push origin v0.1.0-rc.1
+```
+
+Modify `release.yml` `publish-pypi` job to use `repository-url: https://test.pypi.org/legacy/`
+and a separate `TESTPYPI_TOKEN` secret for the dry-run. Revert after verification.
+
+### Production Release
+
+Once dry-run succeeds:
+
+```bash
+# Ensure CHANGELOG is updated (version + date)
+# Verify version numbers in pyproject.toml and package.json
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+The `release.yml` workflow will:
+1. Build CLI wheel and publish to PyPI via Trusted Publishing (OIDC)
+2. Build MCP server tarball and publish to npm via `NPM_TOKEN`
+
+Both jobs run in parallel. If one fails, the other may still have succeeded — check
+PyPI (`https://pypi.org/project/schist/`) and npm (`https://www.npmjs.com/package/@schist/mcp-server`).
+
+## Post-Release
+
+### 1. Verify Packages
+
+- [ ] `pip install schist` in a fresh venv works
+- [ ] `schist --help` runs
+- [ ] `npm install -g @schist/mcp-server` works
+- [ ] `schist-ingest` console script exists on PATH after pip install
+
+### 2. GitHub Release (Optional)
+
+Create a GitHub Release at <https://github.com/yibeichan/schist/releases/new>:
+- Tag: the just-pushed tag
+- Title: `vX.Y.Z`
+- Body: copy relevant section from CHANGELOG.md
+
+### 3. Post-Release Cleanup Tasks
+
+Items tracked for future releases:
+- [ ] Migrate npm publish from `NPM_TOKEN` to OIDC Trusted Publishing (post-v0.1.0)
+- [ ] Add `list_concepts` alias inclusion (separate small PR)
+- [ ] Cross-project memory migration pass (separate session)
+
+## Rollback
+
+If a release needs to be yanked:
+
+- **PyPI**: Login to <https://pypi.org/manage/project/schist/releases/> and yank the version
+- **npm**: `npm deprecate @schist/mcp-server@X.Y.Z "Reason for deprecation"`
+
+For security issues, contact maintainers directly before filing public issues.

--- a/mcp-server/LICENSE
+++ b/mcp-server/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 schist contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,8 +1,39 @@
 {
   "name": "@schist/mcp-server",
   "version": "0.1.0",
+  "description": "MCP server for schist: agent-first knowledge graph with git + SQLite",
+  "author": "schist contributors",
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yibeichan/schist.git",
+    "directory": "mcp-server"
+  },
+  "bugs": {
+    "url": "https://github.com/yibeichan/schist/issues"
+  },
+  "homepage": "https://github.com/yibeichan/schist#readme",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "knowledge-graph",
+    "agents",
+    "sqlite",
+    "markdown"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "files": [
+    "dist/",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",


### PR DESCRIPTION
## Summary
Completes the release infrastructure for v0.1.0: LICENSE, CHANGELOG, package metadata, and tag-triggered publish workflow for both PyPI (`schist`) and npm (`@schist/mcp-server`).

## What's in this PR
- **New files**:
  - `LICENSE` (MIT, schist contributors)
  - `CHANGELOG.md` (Keep a Changelog format)
  - `docs/RELEASE.md` (maintainer checklist)
  - `cli/README.md` (PyPI project page)
  - `.github/workflows/release.yml` (tag-triggered PyPI/npm publish)
- **Modified**:
  - `README.md`: fix repo URL, add published package installs, update Security Model
  - `cli/pyproject.toml`: add PyPI metadata (description, authors, license, URLs)
  - `mcp-server/package.json`: add npm metadata + `engines.node >= 22`
  - `.gitignore`: ignore personal tooling

## Pre-requisites (already done)
- ✅ PyPI: schist registered, Trusted Publishing configured for yibeichan/schist
- ✅ npm: @schist org created, NPM_TOKEN secret added to GitHub
- ✅ GitHub: `npm` environment created
- ⏭ `pypi` environment needs to be created (documented in docs/RELEASE.md)

## Post-merge action
Tag `v0.1.0-rc.1` and verify both publish workflows fire. Full checklist in `docs/RELEASE.md`.

## Test plan
- [ ] CI passes (pytest + jest)
- [ ] `python -m build cli/` produces a valid wheel
- [ ] `cd mcp-server && npm ci && npm run build` succeeds
- [ ] Review `release.yml` logic for OIDC PyPI + NPM_TOKEN npm paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)