### PR TITLE
Fix/issue 34 scope prefix

### DIFF
--- a/cli/schist/__main__.py
+++ b/cli/schist/__main__.py
@@ -79,6 +79,8 @@ def main():
     p_init.add_argument('--name', help='(hub/standalone) Vault name for vault.yaml')
     p_init.add_argument('--participant', action='append',
                         help='(hub) Participant name (repeatable)')
+    p_init.add_argument('--scope-prefix', default='research',
+                        help='(hub) Scope directory prefix for participants (default: research)')
     p_init.add_argument('--print-mcp-config', action='store_true', dest='print_mcp_config',
                         help='Print MCP server config and exit (no vault creation)')
     p_init.add_argument('--format', choices=['claude', 'cursor'], default='claude',

--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -344,13 +344,21 @@ def init_hub(args, hub_path: str) -> None:
         print("Error: at least one --participant is required", file=sys.stderr)
         sys.exit(1)
 
+    scope_prefix = getattr(args, "scope_prefix", None) or "research"
+    if scope_prefix and not NAME_RE.match(scope_prefix):
+        print(
+            f"Error: --scope-prefix '{scope_prefix}' must match ^[a-z][a-z0-9-]*$",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     hub = Path(hub_path).resolve()
     if hub.exists() and any(hub.iterdir()):
         print(f"Error: hub path '{hub_path}' already exists and is not empty", file=sys.stderr)
         sys.exit(1)
 
     # Build vault.yaml data and validate before touching the filesystem.
-    vault_data = _build_seed_vault(name, participants)
+    vault_data = _build_seed_vault(name, participants, scope_prefix=scope_prefix)
     try:
         parse_vault_data(vault_data)
     except ACLError as e:
@@ -485,16 +493,16 @@ def _build_hub_in_staging(
                 raise _InitError(f"{' '.join(cmd)} failed: {r.stderr.strip()}")
 
 
-def _build_seed_vault(name: str, participants: list[str]) -> dict:
+def _build_seed_vault(name: str, participants: list[str], scope_prefix: str = "research") -> dict:
     """Construct a minimal valid vault.yaml data dict for the seed commit.
 
-    Each participant gets a default scope of `research/<name>` and a matching
+    Each participant gets a default scope of `{scope_prefix}/{name}` and a matching
     write grant, plus read:* so any participant can see the full graph.
     """
     participant_entries = []
     access = {}
     for p in participants:
-        scope = f"research/{p}"
+        scope = f"{scope_prefix}/{p}"
         participant_entries.append({
             "name": p,
             "type": "spoke",

--- a/cli/tests/test_hub.py
+++ b/cli/tests/test_hub.py
@@ -172,3 +172,70 @@ class TestInitHub:
         )
         assert result.returncode != 0
         assert "REJECTED" in result.stderr or "rejected" in result.stderr
+
+    # --- --scope-prefix tests (Issue #34) ---
+
+    def test_scope_prefix_default(self, tmp_path):
+        """Without --scope-prefix, vault.yaml uses research/<name> (backwards compat)."""
+        from schist.sync import init_hub
+
+        hub = tmp_path / "hub.git"
+        args = SimpleNamespace(name="v", participant=["alpha"], scope_prefix="research")
+        init_hub(args, str(hub))
+
+        result = subprocess.run(
+            ["git", "show", "main:vault.yaml"],
+            cwd=hub, capture_output=True, text=True, check=True,
+        )
+        content = result.stdout
+        assert "research/alpha" in content
+        assert "vault_version: 1" in content
+
+    def test_scope_prefix_override(self, tmp_path):
+        """With --scope-prefix vault, vault.yaml uses vault/<name> instead of research/<name>."""
+        from schist.sync import init_hub
+
+        hub = tmp_path / "hub.git"
+        args = SimpleNamespace(name="v", participant=["alpha", "beta"], scope_prefix="vault")
+        init_hub(args, str(hub))
+
+        result = subprocess.run(
+            ["git", "show", "main:vault.yaml"],
+            cwd=hub, capture_output=True, text=True, check=True,
+        )
+        content = result.stdout
+        assert "vault/alpha" in content
+        assert "vault/beta" in content
+        assert "research/" not in content
+
+    def test_scope_prefix_invalid(self, tmp_path, capsys):
+        """Invalid --scope-prefix (spaces, dots, uppercase) is rejected."""
+        from schist.sync import init_hub
+
+        for bad in ["BAD NAME", "../evil", "has.dots", "UPPER"]:
+            hub = tmp_path / f"hub-{bad.replace('/', '_')}"
+            args = SimpleNamespace(name="v", participant=["alpha"], scope_prefix=bad)
+            with pytest.raises(SystemExit):
+                init_hub(args, str(hub))
+            assert not hub.exists(), f"hub created despite invalid prefix '{bad}'"
+            capsys.readouterr()  # clear output
+
+    def test_scope_prefix_seeded_yaml_passes_acl(self, tmp_path):
+        """Vault.yaml with custom scope_prefix passes ACL validation."""
+        from schist.acl import parse_vault_yaml
+        from schist.sync import init_hub
+
+        hub = tmp_path / "hub.git"
+        args = SimpleNamespace(name="v", participant=["a", "b"], scope_prefix="my-vault")
+        init_hub(args, str(hub))
+
+        work = tmp_path / "work"
+        subprocess.run(
+            ["git", "clone", str(hub), str(work)],
+            capture_output=True, text=True, check=True,
+        )
+        acl = parse_vault_yaml(work / "vault.yaml")
+        assert acl.name == "v"
+        assert acl.can_write("a", "my-vault/a")
+        assert not acl.can_write("a", "my-vault/b")
+        assert acl.can_read("a", "my-vault/b")

--- a/cli/tests/test_ingest.py
+++ b/cli/tests/test_ingest.py
@@ -23,6 +23,7 @@ bug this test is here to catch.
 from __future__ import annotations
 
 import os
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -143,16 +144,27 @@ def _cli_source_dir() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
+def _has_uv() -> bool:
+    """Check whether uv is available on PATH."""
+    return shutil.which("uv") is not None
+
+
 def _build_wheel(dest: Path) -> Path:
     """Build the schist wheel into dest/. Returns the wheel file path."""
-    # Use `pip wheel` instead of `python -m build` so we don't require the
-    # `build` package to be pre-installed in the test env.
-    _run_subprocess([
-        sys.executable, "-m", "pip", "wheel",
-        "--no-deps",
-        "--wheel-dir", str(dest),
-        str(_cli_source_dir()),
-    ])
+    if _has_uv():
+        _run_subprocess([
+            "uv", "build",
+            "--wheel",
+            "--out-dir", str(dest),
+            str(_cli_source_dir()),
+        ])
+    else:
+        _run_subprocess([
+            sys.executable, "-m", "pip", "wheel",
+            "--no-deps",
+            "--wheel-dir", str(dest),
+            str(_cli_source_dir()),
+        ])
     wheels = list(dest.glob("schist-*.whl"))
     assert len(wheels) == 1, f"expected exactly one wheel, got {wheels}"
     return wheels[0]
@@ -160,7 +172,12 @@ def _build_wheel(dest: Path) -> Path:
 
 def _make_venv(path: Path) -> Path:
     """Create a venv at path and return its python executable."""
-    _run_subprocess([sys.executable, "-m", "venv", str(path)])
+    if _has_uv():
+        _run_subprocess(["uv", "venv", "--python", sys.executable, str(path)])
+        # uv venvs lack pip — install it so the wheel-install step works.
+        _run_subprocess(["uv", "pip", "install", "--python", str(path / "bin" / "python"), "pip"])
+    else:
+        _run_subprocess([sys.executable, "-m", "venv", str(path)])
     return path / "bin" / "python"
 
 


### PR DESCRIPTION
This pull request introduces support for customizing the scope directory prefix for participants in the `schist` hub initialization process, improving flexibility and addressing Issue #34. It also enhances test coverage for this feature and adds compatibility with the `uv` Python packaging tool in the test suite.

**Scope prefix customization and validation:**

* Added a new `--scope-prefix` argument to the CLI `init` command, allowing users to specify a custom directory prefix for participant scopes (defaults to `research`). (`cli/schist/__main__.py`, [cli/schist/__main__.pyR82-R83](diffhunk://#diff-ce796679b716322b56c635dfbec74c2b620c7a4bf20fbd28e6af252a58be9b98R82-R83))
* Updated the `init_hub` logic to use the provided `scope_prefix` when generating `vault.yaml`, and added validation to ensure the prefix matches the required pattern (`^[a-z][a-z0-9-]*). (`cli/schist/sync.py`, [[1]](diffhunk://#diff-4b569eba562c47d9ce9a61979c73e8008da07ad24f2abba8e3ca51b24cfbdf8bR347-R361) [[2]](diffhunk://#diff-4b569eba562c47d9ce9a61979c73e8008da07ad24f2abba8e3ca51b24cfbdf8bL488-R505)

**Testing improvements:**

* Added comprehensive tests for the new `--scope-prefix` feature, including default behavior, overrides, invalid values, and ACL validation for custom prefixes. (`cli/tests/test_hub.py`, [cli/tests/test_hub.pyR175-R241](diffhunk://#diff-0dea374c1be27f9fead7d772c551ede5112baa9f418666700af4ca905f9f8f6fR175-R241))

**Test suite enhancements:**

* Updated test utilities to detect and use the `uv` tool for building wheels and creating virtual environments if available, improving test performance and compatibility. (`cli/tests/test_ingest.py`, [[1]](diffhunk://#diff-b40cd236a05d498ce3ea689301ae084dee5d42ce3d50be3b154e042c4efe3719R26) [[2]](diffhunk://#diff-b40cd236a05d498ce3ea689301ae084dee5d42ce3d50be3b154e042c4efe3719R147-R161) [[3]](diffhunk://#diff-b40cd236a05d498ce3ea689301ae084dee5d42ce3d50be3b154e042c4efe3719R175-R179)