### PR TITLE
fix: spoke init hooks + MCP doctor/print-config for Claude Code

### DIFF
--- a/cli/schist/doctor.py
+++ b/cli/schist/doctor.py
@@ -206,6 +206,10 @@ def check_spoke(vault_path: Optional[str]) -> CheckResult:
 def check_mcp_config(vault_path: Optional[str]) -> CheckResult:
     """Check if schist is configured in Claude Code or Cursor settings."""
     candidates = [
+        # Claude Code (active product) stores user-scope MCP servers here.
+        # Same `mcpServers` shape as Claude Desktop, different path.
+        Path.home() / ".claude.json",
+        # Claude Desktop / settings.json paths (legacy and project-scoped).
         Path.home() / ".claude" / "settings.json",
         Path.home() / ".claude" / "settings.local.json",
     ]
@@ -240,7 +244,8 @@ def check_mcp_config(vault_path: Optional[str]) -> CheckResult:
             pass
 
     return CheckResult("WARN", "MCP", "no schist entry found",
-                       "Run `schist init --print-mcp-config` for a ready-to-paste config.")
+                       "Run `schist init --print-mcp-config --identity <name>` and "
+                       "execute the printed `claude mcp add` command.")
 
 
 def run_doctor(vault_path: Optional[str], db_path: Optional[str],

--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -83,6 +83,23 @@ exit 0
 """
 
 
+def _install_local_hooks(vault_path) -> None:
+    """Write the post-commit and pre-commit hooks into a working-tree repo.
+
+    Shared by standalone and spoke init so either flavor of vault gets the
+    SQLite auto-rebuild and the staged-secret guard. Caller must have already
+    created `<vault>/.git/`.
+    """
+    hooks_dir = Path(vault_path) / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    post = hooks_dir / "post-commit"
+    post.write_text(POST_COMMIT_HOOK)
+    post.chmod(0o755)
+    pre = hooks_dir / "pre-commit"
+    pre.write_text(PRE_COMMIT_HOOK)
+    pre.chmod(0o755)
+
+
 def init_spoke(args, vault_path: str, db_path: str) -> None:
     """Initialize a spoke vault from hub via shallow clone + sparse checkout."""
     hub = args.hub
@@ -131,7 +148,11 @@ def init_spoke(args, vault_path: str, db_path: str) -> None:
     with open(exclude_path, "a") as f:
         f.write(f"\n# schist spoke config (never pushed to hub)\n{'.schist/spoke.yaml'}\n")
 
-    # Step 5: Rebuild SQLite index
+    # Step 5: Install commit hooks (post-commit re-ingests SQLite, pre-commit
+    # rejects staged secrets — same hooks standalone init writes).
+    _install_local_hooks(vault_path)
+
+    # Step 6: Rebuild SQLite index
     _rebuild_index(vault_path, db_path)
 
     # Summary
@@ -653,14 +674,7 @@ def _build_standalone_in_staging(
         if r.returncode != 0:
             raise _InitError(f"{' '.join(cmd)} failed: {r.stderr.strip()}")
 
-    hooks_dir = staging / ".git" / "hooks"
-    hooks_dir.mkdir(parents=True, exist_ok=True)
-    post = hooks_dir / "post-commit"
-    post.write_text(POST_COMMIT_HOOK)
-    post.chmod(0o755)
-    pre = hooks_dir / "pre-commit"
-    pre.write_text(PRE_COMMIT_HOOK)
-    pre.chmod(0o755)
+    _install_local_hooks(staging)
 
 
 def _build_standalone_vault(name: str, identity: str) -> dict:
@@ -711,25 +725,39 @@ def _print_mcp_config(args) -> None:
         sys.exit(1)
     mcp_path = os.path.abspath(mcp_path)
 
-    config = {
-        "mcpServers": {
-            "schist": {
-                "command": "node",
-                "args": [mcp_path],
-                "env": {
-                    "SCHIST_VAULT_PATH": vault_path,
-                    **({"SCHIST_AGENT_ID": identity} if identity else {}),
-                },
-            }
-        }
-    }
+    # Both env vars are needed: SCHIST_AGENT_ID gates MCP write tools (memory
+    # ownership), SCHIST_IDENTITY is what the hub's pre-receive hook reads
+    # when the MCP server's auto-push fires. Set both when an identity is
+    # provided so the user doesn't have to discover the second one later.
+    env = {"SCHIST_VAULT_PATH": vault_path}
+    if identity:
+        env["SCHIST_AGENT_ID"] = identity
+        env["SCHIST_IDENTITY"] = identity
 
     fmt = getattr(args, "mcp_format", "claude")
     if fmt == "claude":
-        print("# Paste into ~/.claude/settings.json or project .claude/settings.json:")
+        # Claude Code stores user-scope MCP servers in ~/.claude.json (not the
+        # ~/.claude/settings.json file that Claude Desktop uses). The CLI is
+        # the supported way to register one — emit a copy-paste-runnable
+        # `claude mcp add` command instead of raw JSON.
+        env_flags = " ".join(f"-e {k}={v}" for k, v in env.items())
+        print("# Run to register schist with Claude Code (user scope):")
+        print(f"claude mcp add --scope user schist {env_flags} -- node {mcp_path}")
     elif fmt == "cursor":
+        config = {
+            "mcpServers": {
+                "schist": {
+                    "command": "node",
+                    "args": [mcp_path],
+                    "env": env,
+                }
+            }
+        }
         print("# Paste into .cursor/mcp.json in your project:")
-    print(_json.dumps(config, indent=2))
+        print(_json.dumps(config, indent=2))
+    else:
+        print(f"Error: unknown --format value '{fmt}'", file=sys.stderr)
+        sys.exit(1)
 
 
 def _dispatch_init(args) -> None:

--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -740,9 +741,12 @@ def _print_mcp_config(args) -> None:
         # ~/.claude/settings.json file that Claude Desktop uses). The CLI is
         # the supported way to register one — emit a copy-paste-runnable
         # `claude mcp add` command instead of raw JSON.
-        env_flags = " ".join(f"-e {k}={v}" for k, v in env.items())
+        # Shell-quote each value so paths/identities containing spaces or
+        # metacharacters survive copy-paste-run (e.g. macOS
+        # '~/Library/Application Support/...').
+        env_flags = " ".join("-e " + shlex.quote(f"{k}={v}") for k, v in env.items())
         print("# Run to register schist with Claude Code (user scope):")
-        print(f"claude mcp add --scope user schist {env_flags} -- node {mcp_path}")
+        print(f"claude mcp add --scope user schist {env_flags} -- node {shlex.quote(mcp_path)}")
     elif fmt == "cursor":
         config = {
             "mcpServers": {

--- a/cli/tests/test_doctor.py
+++ b/cli/tests/test_doctor.py
@@ -242,15 +242,26 @@ class TestCheckSpoke:
 
 
 class TestCheckMcpConfig:
-    def test_found_in_claude_settings(self, tmp_path, monkeypatch):
-        settings = tmp_path / "settings.json"
-        settings.write_text(json.dumps({
+    def test_found_in_claude_code_user_config(self, tmp_path, monkeypatch):
+        """Claude Code (the active product) stores user-scope MCP servers in
+        ~/.claude.json — distinct from Claude Desktop's ~/.claude/settings.json.
+        """
+        (tmp_path / ".claude.json").write_text(json.dumps({
             "mcpServers": {"schist": {"command": "node", "args": ["/path/to/index.js"]}}
         }))
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
         r = check_mcp_config(None)
-        assert r.status == "WARN"  # won't find because home patching is tricky
+        assert r.status == "PASS"
+        assert ".claude.json" in r.message
+
+    def test_found_in_claude_desktop_settings(self, tmp_path, monkeypatch):
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".claude" / "settings.json").write_text(json.dumps({
+            "mcpServers": {"schist": {"command": "node", "args": ["/path/to/index.js"]}}
+        }))
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        r = check_mcp_config(None)
+        assert r.status == "PASS"
 
     def test_not_found(self, tmp_path, monkeypatch):
         monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)

--- a/cli/tests/test_init_standalone.py
+++ b/cli/tests/test_init_standalone.py
@@ -425,7 +425,11 @@ class TestDispatchInit:
 
 
 class TestPrintMcpConfig:
-    def test_prints_valid_json(self, tmp_path, capsys):
+    def test_claude_emits_mcp_add_command(self, tmp_path, capsys):
+        """`--format claude` prints a runnable `claude mcp add` command — Claude
+        Code's user-scope config lives in ~/.claude.json, registered via the
+        CLI rather than by hand-editing JSON.
+        """
         from schist.sync import _dispatch_init
 
         fake_mcp = tmp_path / "fake-index.js"
@@ -437,14 +441,39 @@ class TestPrintMcpConfig:
             identity="test-agent",
             mcp_server_path=str(fake_mcp),
         ))
-        captured = capsys.readouterr()
-        assert "# Paste into" in captured.out
-        # Find the JSON part (after the comment line)
-        json_start = captured.out.index("{")
-        data = json.loads(captured.out[json_start:])
-        assert "mcpServers" in data
-        assert "schist" in data["mcpServers"]
-        assert data["mcpServers"]["schist"]["env"]["SCHIST_AGENT_ID"] == "test-agent"
+        out = capsys.readouterr().out
+        assert "claude mcp add --scope user schist" in out
+        assert "-e SCHIST_VAULT_PATH=" in out
+        assert "-e SCHIST_AGENT_ID=test-agent" in out
+        # Both identity vars are needed: SCHIST_AGENT_ID for MCP write
+        # validation, SCHIST_IDENTITY for the auto-push to the hub.
+        assert "-e SCHIST_IDENTITY=test-agent" in out
+        assert f"node {fake_mcp}" in out
+        # Output should NOT be raw JSON (that was the Claude Desktop format).
+        assert "mcpServers" not in out
+
+    def test_claude_without_identity_omits_agent_vars(self, tmp_path, capsys, monkeypatch):
+        from schist.sync import _dispatch_init
+
+        # _print_mcp_config falls back to SCHIST_IDENTITY in the env when
+        # --identity isn't passed. Strip it so this test exercises the
+        # genuinely-no-identity branch regardless of the dev's shell.
+        monkeypatch.delenv("SCHIST_IDENTITY", raising=False)
+        monkeypatch.delenv("SCHIST_AGENT_ID", raising=False)
+
+        fake_mcp = tmp_path / "fake-index.js"
+        fake_mcp.write_text("// fake")
+        _dispatch_init(_args(
+            print_mcp_config=True,
+            mcp_format="claude",
+            vault=str(tmp_path),
+            identity=None,
+            mcp_server_path=str(fake_mcp),
+        ))
+        out = capsys.readouterr().out
+        assert "-e SCHIST_VAULT_PATH=" in out
+        assert "SCHIST_AGENT_ID" not in out
+        assert "SCHIST_IDENTITY" not in out
 
     def test_cursor_format(self, tmp_path, capsys):
         from schist.sync import _dispatch_init

--- a/cli/tests/test_init_standalone.py
+++ b/cli/tests/test_init_standalone.py
@@ -490,6 +490,48 @@ class TestPrintMcpConfig:
         captured = capsys.readouterr()
         assert ".cursor/mcp.json" in captured.out
 
+    def test_unknown_format_errors(self, tmp_path, capsys):
+        """Unknown --format value exits 1 with a stderr message — guards the
+        dispatch's else branch against silent no-ops on typos."""
+        from schist.sync import _dispatch_init
+
+        fake_mcp = tmp_path / "fake-index.js"
+        fake_mcp.write_text("// fake")
+        with pytest.raises(SystemExit) as exc:
+            _dispatch_init(_args(
+                print_mcp_config=True,
+                mcp_format="bogus",
+                vault=str(tmp_path),
+                identity="test-agent",
+                mcp_server_path=str(fake_mcp),
+            ))
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "unknown --format value" in err
+        assert "bogus" in err
+
+    def test_claude_quotes_paths_with_spaces(self, tmp_path, capsys):
+        """Vault paths or mcp paths containing spaces must be shell-quoted so
+        the printed `claude mcp add` line is safe to paste-run (real-world
+        case: macOS '~/Library/Application Support/...')."""
+        from schist.sync import _dispatch_init
+
+        spaced_dir = tmp_path / "with space"
+        spaced_dir.mkdir()
+        fake_mcp = spaced_dir / "fake-index.js"
+        fake_mcp.write_text("// fake")
+        _dispatch_init(_args(
+            print_mcp_config=True,
+            mcp_format="claude",
+            vault=str(spaced_dir),
+            identity="alice",
+            mcp_server_path=str(fake_mcp),
+        ))
+        out = capsys.readouterr().out
+        # shlex.quote wraps space-containing values in single quotes.
+        assert f"'SCHIST_VAULT_PATH={spaced_dir}'" in out
+        assert f"node '{fake_mcp}'" in out
+
     def test_no_files_created(self, tmp_path, capsys):
         from schist.sync import _dispatch_init
 

--- a/cli/tests/test_sync.py
+++ b/cli/tests/test_sync.py
@@ -113,6 +113,35 @@ class TestInitSpoke:
         assert not dest.exists()
         assert "clone failed" in capsys.readouterr().err
 
+    @patch("schist.sync.git_ops.clone_shallow", return_value=(True, ""))
+    @patch("schist.sync.git_ops.setup_sparse_checkout", return_value=(True, ""))
+    @patch("schist.sync._rebuild_index")
+    def test_installs_local_hooks(self, mock_ingest, mock_sparse, mock_clone, tmp_path):
+        """Spoke init must install the post-commit + pre-commit hooks so the
+        spoke behaves like a standalone vault for local commits — without
+        them, post-commit ingest never fires and staged secrets aren't blocked.
+        """
+        from schist.sync import init_spoke
+
+        dest = str(tmp_path / "spoke")
+
+        def create_dir(*a, **kw):
+            Path(dest).mkdir(parents=True, exist_ok=True)
+            (Path(dest) / ".git" / "info").mkdir(parents=True)
+            return True, ""
+        mock_clone.side_effect = create_dir
+
+        args = MagicMock(hub="git@pi:vault.git", scope="research/x", identity="x")
+        init_spoke(args, dest, str(tmp_path / "db.sqlite"))
+
+        post = Path(dest) / ".git" / "hooks" / "post-commit"
+        pre = Path(dest) / ".git" / "hooks" / "pre-commit"
+        assert post.is_file() and "schist post-commit" in post.read_text()
+        assert pre.is_file() and "schist pre-commit" in pre.read_text()
+        # Hooks must be executable for git to invoke them.
+        assert post.stat().st_mode & 0o111
+        assert pre.stat().st_mode & 0o111
+
 
 # ---------------------------------------------------------------------------
 # sync_pull


### PR DESCRIPTION
## Summary

Three fixes from standing up an HPC spoke against a Pi hub — each one is a place where Claude Code wasn't being treated as a first-class consumer.

- **`init_spoke` now installs commit hooks.** Previously, fresh spokes silently lacked the post-commit SQLite ingest and pre-commit secret guard; `schist doctor` reported a FAIL on every spoke. Hook installation is now factored into `_install_local_hooks` and called from both standalone and spoke paths.
- **`schist doctor` now checks `~/.claude.json`.** Claude Code stores user-scope MCP servers there; previously the doctor only looked at `~/.claude/settings.json` (Claude Desktop) and reported a false-positive `WARN`.
- **`--print-mcp-config --format claude` emits a runnable `claude mcp add` command.** The old output was Claude Desktop JSON with a comment pointing to the wrong file. New output is copy-pasteable into a shell. Includes both `SCHIST_AGENT_ID` and `SCHIST_IDENTITY` so the MCP server's auto-push works without a separate config step. Cursor format unchanged.

## Test plan

- [x] Full CLI suite: 293 passed, 1 skipped
- [x] New `TestInitSpoke.test_installs_local_hooks` covers fix 1
- [x] New `TestCheckMcpConfig.test_found_in_claude_code_user_config` covers fix 2 (replaces a previously-broken test that asserted WARN with a "home patching is tricky" comment)
- [x] Updated `TestPrintMcpConfig` covers fix 3, including the env-leak case where the dev's shell has `SCHIST_IDENTITY` set
- [ ] Manually verify: `schist init --spoke ... && schist doctor` reports PASS for the post-commit hook check on a fresh spoke
- [ ] Manually verify: `schist init --print-mcp-config --format claude --identity foo` prints a `claude mcp add` line that actually registers the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)