### PR TITLE
fix(mcp): top-level-segment match in create_note directory validation

### DIFF
--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -273,10 +273,17 @@ export async function create_note(
         message: "Invalid directory: must be relative and not contain ..",
       } satisfies ToolError;
     }
-    if (!config.directories.includes(directory)) {
+    // Top-level segment match so callers can pass nested paths like
+    // `projects/brain-states-friends` without having to enumerate every
+    // subdirectory in schist.yaml. Mirrors the ACL's parent-grants-child
+    // rule (see cli/schist/acl.py:_scope_matches). The `..` and absolute-
+    // path guard above is what enforces safety; this check is content
+    // configuration, not a security boundary.
+    const topLevel = directory.split("/")[0];
+    if (!config.directories.includes(topLevel)) {
       return {
         error: "VALIDATION_ERROR",
-        message: `Directory "${directory}" not configured. Allowed: ${config.directories.join(", ")}`,
+        message: `Directory "${directory}" not configured. Allowed top-level: ${config.directories.join(", ")}`,
       } satisfies ToolError;
     }
 

--- a/mcp-server/tests/tools.test.ts
+++ b/mcp-server/tests/tools.test.ts
@@ -107,6 +107,82 @@ describe("create_note filename collision", () => {
 });
 
 // ---------------------------------------------------------------------------
+// create_note — directory validation (top-level-segment match)
+// ---------------------------------------------------------------------------
+
+describe("create_note directory validation", () => {
+  // makeTempVault appends `extraYaml` after `connection_types:`, which would
+  // mis-parse a stray `- projects` as a connection type. So these tests
+  // overwrite schist.yaml directly with the directories list they need.
+  async function vaultWithDirectories(dirs: string[]): Promise<string> {
+    const vault = await makeTempVault();
+    const yaml = [
+      "name: Test Vault",
+      "write_branch: drafts",
+      "directories:",
+      ...dirs.map((d) => `  - ${d}`),
+      "statuses: [draft, review, final]",
+      "connection_types: [extends, supports]",
+    ].join("\n") + "\n";
+    await fs.writeFile(path.join(vault, "schist.yaml"), yaml);
+    await execFile("git", ["add", "schist.yaml"], { cwd: vault });
+    await execFile("git", ["commit", "-m", "update directories"], { cwd: vault });
+    return vault;
+  }
+
+  test("accepts nested path when top-level segment is configured", async () => {
+    // schist.yaml lists 'projects' as a top-level dir; nested per-project
+    // subdirs (projects/<name>/) should be accepted without enumerating each.
+    const vault = await vaultWithDirectories(["notes", "papers", "projects"]);
+    const config = await loadVaultConfig(vault);
+
+    const result = await create_note(
+      vault,
+      { title: "Nested Path Note", body: "lives under projects/foo", directory: "projects/foo" },
+      config
+    ) as { id: string; path: string; commitSha: string };
+
+    expect(result.path).toBeDefined();
+    expect(result.path.startsWith("projects/foo/")).toBe(true);
+    expect(result.commitSha).toBeDefined();
+    const onDisk = await fs.readFile(path.join(vault, result.path), "utf-8");
+    expect(onDisk).toContain("lives under projects/foo");
+  }, 30000);
+
+  test("rejects nested path when top-level segment is not configured", async () => {
+    // schist.yaml does NOT list 'projects'; create_note must reject
+    // 'projects/foo' rather than silently accepting via prefix match.
+    const vault = await vaultWithDirectories(["notes", "papers"]);
+    const config = await loadVaultConfig(vault);
+
+    const result = await create_note(
+      vault,
+      { title: "Should Fail", body: "x", directory: "projects/foo" },
+      config
+    ) as { error: string; message: string };
+
+    expect(result.error).toBe("VALIDATION_ERROR");
+    expect(result.message).toContain("projects/foo");
+    expect(result.message).toContain("Allowed top-level");
+  }, 30000);
+
+  test("path-traversal guard still rejects ..", async () => {
+    // The top-level-match change must not weaken the existing safety guard.
+    const vault = await vaultWithDirectories(["notes", "papers", "projects"]);
+    const config = await loadVaultConfig(vault);
+
+    const result = await create_note(
+      vault,
+      { title: "Traversal Attempt", body: "x", directory: "projects/../etc" },
+      config
+    ) as { error: string; message: string };
+
+    expect(result.error).toBe("VALIDATION_ERROR");
+    expect(result.message).toContain("..");
+  }, 30000);
+});
+
+// ---------------------------------------------------------------------------
 // Lazy capabilities — index-level behaviour (unit test via tools layer)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`create_note`'s directory-allowlist check used exact-match
(`config.directories.includes(directory)`), forcing callers to enumerate
every nested path in `schist.yaml`. The upcoming vault-structure refactor
introduces per-project subdirs (`projects/<project-name>/`); enumerating
each one would force a config edit on every new project and silently
break `create_note` for agents writing into `projects/<new>/` before the
config catches up.

This PR switches the check to **top-level-segment match**: a configured
directory `projects` covers any `projects/<name>/...` path. Mirrors the
ACL's parent-grants-child rule in `cli/schist/acl.py:_scope_matches`.

The `..` and absolute-path guard above the check (`tools.ts:270`) is the
safety boundary; this change only relaxes the configuration allowlist,
not path-traversal protection.

## Test plan

- [x] new test: accepts nested path when top-level segment is configured
- [x] new test: rejects nested path when top-level segment is NOT configured
- [x] new test: `..` traversal guard still rejects malicious paths
- [x] `npm run build` clean
- [x] All directory-validation tests pass (3 new + 13 pre-existing)
- [ ] CI green on Ubuntu (the HPC node's pre-existing better-sqlite3/glibc failures don't apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)