### PR TITLE
feat(init): JSON fallback for --print-mcp-config on older Claude CLIs (closes #42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,27 @@ capture lessons and recall them from elsewhere. Details and the
 
 ## Agent Integration
 
-### Claude Desktop / Claude Code
+### Claude Code
 
-Add to `~/.claude/settings.json`:
+Register schist as a user-scope MCP server with the printed `claude mcp add`
+command:
+
+```bash
+schist --vault /absolute/path/to/vault init --print-mcp-config --format claude --identity local
+# then run the printed `claude mcp add ...` line
+```
+
+Claude Code stores user-scope MCP servers in `~/.claude.json`. On older
+Claude Code CLIs that predate `mcp add` / `--scope`, `--print-mcp-config`
+also emits a commented JSON fallback below the command — uncomment it and
+hand-merge the block under the top-level `mcpServers` key in
+`~/.claude.json`.
+
+### Claude Desktop
+
+Claude Desktop reads `~/Library/Application Support/Claude/claude_desktop_config.json`
+(macOS). Run the same `--print-mcp-config --format claude` and merge the
+commented JSON block under `mcpServers` in that file. The shape is:
 
 ```json
 {

--- a/cli/README.md
+++ b/cli/README.md
@@ -51,21 +51,20 @@ The schist MCP server (`@schist/mcp-server`) is published separately on npm:
 npm install -g @schist/mcp-server
 ```
 
-Add to `~/.claude/settings.json`:
+Register it as a user-scope MCP server:
 
-```json
-{
-  "mcpServers": {
-    "schist": {
-      "command": "node",
-      "args": ["/absolute/path/to/schist/mcp-server/dist/index.js"],
-      "env": {
-        "SCHIST_VAULT_PATH": "/absolute/path/to/vault"
-      }
-    }
-  }
-}
+```bash
+schist --vault /absolute/path/to/vault init --print-mcp-config --format claude --identity local
+# then run the printed `claude mcp add ...` line
 ```
+
+Claude Code stores user-scope MCP servers in `~/.claude.json` (managed
+by the CLI). On older Claude Code CLIs without `mcp add`,
+`--print-mcp-config` also emits a commented JSON fallback — uncomment
+the block and hand-merge it under the top-level `mcpServers` key in
+`~/.claude.json`. Claude Desktop uses
+`~/Library/Application Support/Claude/claude_desktop_config.json`
+instead; the JSON shape is the same.
 
 See the [full README](https://github.com/yibeichan/schist#readme) for architecture docs, hub & spoke setup, and MCP tool reference.
 

--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -788,6 +788,23 @@ def _print_mcp_config(args) -> None:
         env_flags = " ".join("-e " + shlex.quote(f"{k}={v}") for k, v in env.items())
         print("# Run to register schist with Claude Code (user scope):")
         print(f"claude mcp add --scope user schist {env_flags} -- node {shlex.quote(mcp_path)}")
+        # Fallback for older Claude Code CLIs that predate `mcp add` /
+        # `--scope` — emit a commented JSON block the user can hand-merge
+        # under the top-level `mcpServers` key in ~/.claude.json. See #42.
+        fallback = {
+            "mcpServers": {
+                "schist": {
+                    "command": "node",
+                    "args": [mcp_path],
+                    "env": env,
+                }
+            }
+        }
+        print()
+        print("# Fallback (older Claude Code without `mcp add`):")
+        print("# merge under `mcpServers` in ~/.claude.json")
+        for line in _json.dumps(fallback, indent=2).splitlines():
+            print(f"# {line}")
     elif fmt == "cursor":
         config = {
             "mcpServers": {

--- a/cli/tests/test_init_standalone.py
+++ b/cli/tests/test_init_standalone.py
@@ -543,13 +543,19 @@ class TestPrintMcpConfig:
         assert "~/.claude.json" in out
         assert "Fallback" in out or "fallback" in out
 
-        # Strip leading "# " from comment lines and parse — proves the JSON
-        # is well-formed and matches the structure ~/.claude.json expects.
-        comment_lines = [
-            line[2:] for line in out.splitlines()
-            if line.startswith("# {") or line.startswith("#   ") or line.startswith("# }")
-        ]
-        parsed = _json.loads("\n".join(comment_lines))
+        # Locate the JSON fallback block by its opening "# {" line, then
+        # walk consecutive "# "-prefixed lines until the comment block ends.
+        # Robust to json.dumps indent changes (was previously coupled to
+        # indent=2 via prefix-string filters that silently dropped lines on
+        # other indents).
+        lines = out.splitlines()
+        start = lines.index("# {")
+        block = []
+        for line in lines[start:]:
+            if not line.startswith("# "):
+                break
+            block.append(line[2:])
+        parsed = _json.loads("\n".join(block))
         assert parsed == {
             "mcpServers": {
                 "schist": {

--- a/cli/tests/test_init_standalone.py
+++ b/cli/tests/test_init_standalone.py
@@ -508,8 +508,61 @@ class TestPrintMcpConfig:
         # validation, SCHIST_IDENTITY for the auto-push to the hub.
         assert "-e SCHIST_IDENTITY=test-agent" in out
         assert f"node {fake_mcp}" in out
-        # Output should NOT be raw JSON (that was the Claude Desktop format).
-        assert "mcpServers" not in out
+        # The runnable `claude mcp add` line must not be raw JSON (that was
+        # the pre-#39 Claude Desktop format). The commented JSON fallback
+        # added for #42 is fine; check `mcpServers` only appears in comment
+        # lines, never as runnable output.
+        for line in out.splitlines():
+            if "mcpServers" in line:
+                assert line.lstrip().startswith("#"), \
+                    f"raw (uncommented) JSON leaked into output: {line!r}"
+
+    def test_claude_emits_commented_json_fallback(self, tmp_path, capsys):
+        """`--format claude` also prints a commented-out JSON snippet so users
+        on older Claude Code CLIs (predating `mcp add` / `--scope`) can fall
+        back to hand-editing ~/.claude.json. Surfaced by issue #42 — the move
+        from raw JSON to `claude mcp add` in #39 left those users with no
+        path forward when the runnable command errored.
+        """
+        import json as _json
+        from schist.sync import _dispatch_init
+
+        fake_mcp = tmp_path / "fake-index.js"
+        fake_mcp.write_text("// fake")
+        _dispatch_init(_args(
+            print_mcp_config=True,
+            mcp_format="claude",
+            vault=str(tmp_path),
+            identity="test-agent",
+            mcp_server_path=str(fake_mcp),
+        ))
+        out = capsys.readouterr().out
+
+        # Fallback header references ~/.claude.json (the actual user-scope
+        # config file) and signals it's for older CLIs.
+        assert "~/.claude.json" in out
+        assert "Fallback" in out or "fallback" in out
+
+        # Strip leading "# " from comment lines and parse — proves the JSON
+        # is well-formed and matches the structure ~/.claude.json expects.
+        comment_lines = [
+            line[2:] for line in out.splitlines()
+            if line.startswith("# {") or line.startswith("#   ") or line.startswith("# }")
+        ]
+        parsed = _json.loads("\n".join(comment_lines))
+        assert parsed == {
+            "mcpServers": {
+                "schist": {
+                    "command": "node",
+                    "args": [str(fake_mcp)],
+                    "env": {
+                        "SCHIST_VAULT_PATH": str(tmp_path),
+                        "SCHIST_AGENT_ID": "test-agent",
+                        "SCHIST_IDENTITY": "test-agent",
+                    },
+                }
+            }
+        }
 
     def test_claude_without_identity_omits_agent_vars(self, tmp_path, capsys, monkeypatch):
         from schist.sync import _dispatch_init

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -140,19 +140,14 @@ export SCHIST_VAULT_PATH=~/my-vault
 schist --vault ~/my-vault init --print-mcp-config --format claude --identity local
 ```
 
-This prints a JSON block. Paste the `mcpServers` object into the appropriate config file:
+This prints a runnable `claude mcp add` command — paste-and-run to register
+schist as a user-scope MCP server (stored in `~/.claude.json`). It also emits
+a commented-out JSON fallback below the command for older Claude Code CLIs
+that predate `mcp add` / `--scope`; in that case, uncomment the block and
+hand-merge it under the `mcpServers` key in `~/.claude.json`.
 
-**Claude Code** (global):
-```
-~/.claude/settings.json
-```
-
-**Claude Code** (project-scoped):
-```
-<project>/.claude/settings.json
-```
-
-**Claude Desktop** (macOS):
+**Claude Desktop** (macOS) — uses a different config file; merge the
+commented JSON under `mcpServers` in:
 ```
 ~/Library/Application Support/Claude/claude_desktop_config.json
 ```

--- a/docs/hub-spoke-pi-hpc-mac.md
+++ b/docs/hub-spoke-pi-hpc-mac.md
@@ -168,7 +168,11 @@ schist init --spoke \
 schist --vault ~/schist-vault init --print-mcp-config --format claude --identity mac
 ```
 
-Paste the output into `~/.claude/settings.json`. The result looks like:
+Run the printed `claude mcp add` line — Claude Code stores user-scope MCP
+servers in `~/.claude.json` and registers them via the CLI. The command
+also emits a commented JSON fallback for older CLIs without `mcp add`;
+merge that under the `mcpServers` key in `~/.claude.json` if the runnable
+form errors with `unknown command: mcp`. The fallback shape is:
 
 ```json
 {
@@ -178,6 +182,7 @@ Paste the output into `~/.claude/settings.json`. The result looks like:
       "args": ["/path/to/schist/mcp-server/dist/index.js"],
       "env": {
         "SCHIST_VAULT_PATH": "/Users/yibei/schist-vault",
+        "SCHIST_AGENT_ID": "mac",
         "SCHIST_IDENTITY": "mac"
       }
     }

--- a/docs/hub-spoke-setup.md
+++ b/docs/hub-spoke-setup.md
@@ -116,7 +116,20 @@ talks to the hub. Without it, the pre-receive hook rejects every push.
 
 ## Step 3. Point the MCP server at the spoke
 
-In the spoke's `~/.claude/settings.json` (or equivalent for your agent):
+Generate and register the MCP config for this spoke. `--print-mcp-config`
+emits a runnable `claude mcp add` line that registers schist as a
+user-scope server (stored in `~/.claude.json`):
+
+```bash
+schist --vault ~/vault init --print-mcp-config --format claude --identity laptop
+# then run the printed `claude mcp add ...` line
+```
+
+The command bakes in `SCHIST_VAULT_PATH`, `SCHIST_AGENT_ID`, and
+`SCHIST_IDENTITY` from the flags above. On older Claude Code CLIs that
+predate `mcp add`, the same output also includes a commented JSON
+fallback — uncomment that block and hand-merge it under the top-level
+`mcpServers` key in `~/.claude.json`. The fallback shape is:
 
 ```json
 {
@@ -126,6 +139,7 @@ In the spoke's `~/.claude/settings.json` (or equivalent for your agent):
       "args": ["/path/to/schist/mcp-server/dist/index.js"],
       "env": {
         "SCHIST_VAULT_PATH": "/home/you/vault",
+        "SCHIST_AGENT_ID": "laptop",
         "SCHIST_IDENTITY": "laptop"
       }
     }


### PR DESCRIPTION
## Summary

- `schist init --print-mcp-config --format claude` now emits the runnable `claude mcp add` line **plus** a commented-out JSON fallback for older Claude Code CLIs that predate `mcp add` / `--scope`.
- Users hitting `unknown command: mcp` on older builds can uncomment the JSON block and hand-merge it under `mcpServers` in `~/.claude.json`.
- Doc drift cleanup carried over from #39: `docs/getting-started.md` and `docs/hub-spoke-pi-hpc-mac.md` still described the pre-#39 raw-JSON output as the primary mechanism — updated to match current behavior, plus added the missing `SCHIST_AGENT_ID` env var to the hub-spoke example.

## Output preview

```
# Run to register schist with Claude Code (user scope):
claude mcp add --scope user schist -e SCHIST_VAULT_PATH=... -e SCHIST_AGENT_ID=... -e SCHIST_IDENTITY=... -- node /path/to/index.js

# Fallback (older Claude Code without `mcp add`):
# merge under `mcpServers` in ~/.claude.json
# {
#   "mcpServers": {
#     "schist": {
#       "command": "node",
#       "args": ["/path/to/index.js"],
#       "env": { ... }
#     }
#   }
# }
```

## Test plan

- [x] New `test_claude_emits_commented_json_fallback` parses the commented JSON and asserts shape matches `~/.claude.json` expectations.
- [x] Updated `test_claude_emits_mcp_add_command`: old assertion `"mcpServers" not in out` was reversed by #42; new check enforces that `mcpServers` only appears in `#`-prefixed lines (no raw JSON leaks into runnable output).
- [x] Other `TestPrintMcpConfig` tests (cursor, no-identity, spaces, no-files-created, etc.) still pass.
- [x] Full CLI suite: 311 passed, 1 skipped.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)