### PR TITLE
docs+audit: MCP context efficiency baseline + spec (#50)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,22 @@ jobs:
           cache: npm
           cache-dependency-path: mcp-server/package-lock.json
 
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: cli/pyproject.toml
+
+      - name: Install CLI (provides schist + schist-ingest for audit-script integration test)
+        working-directory: ${{ github.workspace }}
+        run: pip install -e ./cli
+
+      - name: Configure git identity for fixture vault commits
+        run: |
+          git config --global user.email "ci@schist.test"
+          git config --global user.name "schist-ci"
+          git config --global init.defaultBranch main
+
       - name: Install deps
         run: npm ci
 

--- a/docs/superpowers/plans/2026-05-04-mcp-context-efficiency.md
+++ b/docs/superpowers/plans/2026-05-04-mcp-context-efficiency.md
@@ -138,8 +138,8 @@ import { measureResponse } from "../../scripts/audit_mcp_response_sizes.js";
 describe("measureResponse", () => {
   it("returns byte length of JSON-serialized response", () => {
     const result = measureResponse({ id: "x", title: "y", snippet: "z" });
-    // {"id":"x","title":"y","snippet":"z"} = 35 bytes
-    expect(result.bytes).toBe(35);
+    // {"id":"x","title":"y","snippet":"z"} = 36 bytes
+    expect(result.bytes).toBe(36);
   });
 
   it("returns approximate token count using 4-bytes-per-token heuristic", () => {
@@ -150,8 +150,8 @@ describe("measureResponse", () => {
 
   it("handles array responses (e.g. searchNotes return)", () => {
     const result = measureResponse([{ id: "a" }, { id: "b" }]);
-    // [{"id":"a"},{"id":"b"}] = 21 bytes
-    expect(result.bytes).toBe(21);
+    // [{"id":"a"},{"id":"b"}] = 23 bytes
+    expect(result.bytes).toBe(23);
     expect(result.entryCount).toBe(2);
   });
 

--- a/docs/superpowers/plans/2026-05-04-mcp-context-efficiency.md
+++ b/docs/superpowers/plans/2026-05-04-mcp-context-efficiency.md
@@ -1,0 +1,765 @@
+# MCP Context Efficiency — Multi-PR Rollout Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce agent-context bloat from schist MCP tool responses by tightening default return shapes, adding cursor-based pagination, and replacing sticky verbose flags with reason-string opt-ins.
+
+**Architecture:** Audit-then-spec-then-multi-PR rollout. PR 1 lands measurements + design; PRs 2–8 implement tool family by tool family, all referencing the spec. New shared utilities (cursor module, reason-string verbose) live in `mcp-server/src/protocol/` so individual tools depend on one well-tested module.
+
+**Tech Stack:** TypeScript (Node ≥20), `better-sqlite3`, Jest 30 (ESM mode), Python 3.12+ (audit script), markdown for spec.
+
+**Tracks:** [yibeichan/schist#50](https://github.com/yibeichan/schist/issues/50). Refinements adopted from m13v's comment.
+
+---
+
+## Guiding Principles
+
+The lesson from m13v (saved as schist memory entry #67):
+
+> **Enforcement belongs in the protocol, not the prompt.** Agents take the path of least resistance — passive hints get ignored, boolean opt-ins drift toward always-on.
+
+Two operational consequences for this rollout:
+
+1. **Cursor tokens, not truncation flags.** When results are capped, return a structured cursor that must be consumed to advance. The server tracks recent (query, owner) pairs and refuses to re-serve identical queries without cursor consumption — blind retries become structurally impossible, not just discouraged.
+2. **Reason strings, not boolean opt-ins.** Where verbose / full-body access is needed, gate it behind `verbose: "<reason string>"` instead of `verbose: true`. Adds friction against lazy default-creep and produces auditable logs of when expensive paths are actually used.
+
+---
+
+## Audit Findings (pre-audit code-shape inventory; PR 1 confirms with measurements)
+
+> The table below is derived from reading the current `mcp-server/src/` code, **not** from running the audit. PR 1 Task 1.4 confirms with actual byte/token measurements against a live vault. If the run reveals a tool's behavior diverges from the inventory below (e.g. an undocumented limit), update this table before PR 2 starts.
+
+| Tool | Current default cap | Returns full body? | Biggest risk |
+|------|---------------------|--------------------|--------------|
+| `search_notes` | `limit: 20` | No (FTS5 snippet) | Cursor needed for >20-result queries |
+| `get_note` | n/a (single doc) | Yes | Intentional — explicit body fetch |
+| `list_concepts` | `limit: 50` | No (slug + title + description) | Cursor needed past 50 |
+| `list_domains` | **no limit** | No (slug + label) | Domains are tiny; low priority |
+| `query_graph` | **no default LIMIT** | Depends on caller's SQL | `SELECT * FROM docs` returns entire corpus |
+| `get_context` | tiered (minimal/standard/full) | No | Already tiered; needs reason-string for `full` |
+| `search_memory` | `limit: 50` | **Yes — full `content`** | 50 entries × ~1KB each = ~50KB per call |
+
+Ordering by ROI: `search_memory` and `query_graph` are highest-impact targets. `search_notes` is the dressed-up base case (already snippet-returning). `list_*` and `get_context` are polish.
+
+---
+
+## PR Sequence Overview
+
+| PR | Scope | Depends on | Detailed plan |
+|----|-------|------------|---------------|
+| 1 | Audit script + spec doc | — | **This document, below** |
+| 2 | Cursor module + reason-string verbose helper (shared infra) | PR 1 | Written after spec lands |
+| 3 | `search_memory` adoption (highest ROI) | PR 2 | Written after PR 2 |
+| 4 | `query_graph` adoption (cursor + LIMIT injection / refusal) | PR 2 | Written after PR 2 |
+| 5 | `search_notes` cursor adoption | PR 2 | Written after PR 2 |
+| 6 | `list_concepts` + `list_domains` cursor adoption | PR 2 | Batched; written after PR 2 |
+| 7 | `get_context` reason-string opt-in for `depth: "full"` | PR 2 | Written after PR 2 |
+| 8 | Migration notes + tool-description updates + final cleanup | PRs 3–7 | Written when most adopters have landed |
+
+**Why this ordering:** PR 2 lands the shared infra so each tool-family PR is small and reviewable. `search_memory` is PR 3 because it's the first real adopter — finding rough edges in the cursor API costs less to fix on one tool than after five tools have copied a flawed pattern. `query_graph` (PR 4) is second-highest-impact but trickier semantically (arbitrary user SQL), so it follows the validated pattern from `search_memory`.
+
+**Why PRs 2–8 don't have full TDD steps in this document:** their step-by-step shape depends on decisions locked in PR 1's spec. Writing fake steps now would create placeholders the skill explicitly forbids. Each PR gets its own detailed plan at `docs/superpowers/plans/2026-05-04-mcp-context-efficiency-pr-N.md` written when its prerequisites have landed.
+
+---
+
+## File Structure (across all PRs)
+
+**PR 1 creates:**
+- `scripts/audit_mcp_response_sizes.ts` — reproducible audit harness (TS, runs against a vault path)
+- `docs/superpowers/specs/2026-05-04-mcp-context-efficiency.md` — design spec
+- `docs/superpowers/specs/audit-2026-05-04-mcp-response-sizes.md` — audit results table (linked from spec)
+
+**PR 2 creates:**
+- `mcp-server/src/protocol/cursor.ts` — cursor token module (encode, decode, identical-query refusal store)
+- `mcp-server/src/protocol/verbose.ts` — reason-string verbose validation helper
+- `mcp-server/tests/protocol/cursor.test.ts`
+- `mcp-server/tests/protocol/verbose.test.ts`
+
+**PRs 3–7 modify:**
+- `mcp-server/src/tools.ts` (one tool per PR)
+- `mcp-server/src/sqlite-reader.ts` (paired changes for cursor SQL)
+- `mcp-server/src/tool-registry.ts` (input schema additions)
+- `mcp-server/tests/tools.test.ts`, `mcp-server/tests/sqlite-reader.test.ts`
+
+**PR 8 modifies:**
+- `docs/mcp-setup.md` — caller-facing migration notes
+- `mcp-server/src/tool-registry.ts` — final description audit pass
+
+---
+
+# PR 1 — Audit Script + Spec Doc
+
+**Branch:** `feat/issue-50-mcp-efficiency-audit-spec`
+**No code-behavior change.** PR 1 is doc-and-tooling-only; nothing in `mcp-server/src/` changes.
+
+**Scope-out (explicit):** PR 1 does NOT touch tool implementations, does NOT add cursor or verbose modules, does NOT change tool-registry schemas. Those are PRs 2+.
+
+## Task 1.1: Branch + plan commit
+
+**Files:**
+- Create (commit): `docs/superpowers/plans/2026-05-04-mcp-context-efficiency.md` (this file)
+
+- [ ] **Step 1: Create the branch off latest main**
+
+```bash
+git fetch origin
+git switch -c feat/issue-50-mcp-efficiency-audit-spec origin/main
+```
+
+Expected: branch created, working tree clean except the same untracked items already present (`.gstack/`, `.claude/scheduled_tasks.lock`, `docs/refactor-flatten-spoke-dirs.md`).
+
+- [ ] **Step 2: Commit this plan**
+
+```bash
+git add docs/superpowers/plans/2026-05-04-mcp-context-efficiency.md
+git commit -m "docs: add multi-PR rollout plan for #50 MCP context efficiency"
+```
+
+Expected: one new commit on the branch, no other files staged.
+
+---
+
+## Task 1.2: Audit script — failing test first
+
+**Files:**
+- Create: `scripts/audit_mcp_response_sizes.ts`
+- Create: `mcp-server/tests/audit-script.test.ts`
+
+The audit script lives at the repo root under `scripts/` (not under `mcp-server/`) because it depends on `mcp-server/dist/*.js` as a *consumer*, not a part of the server. Tests for it run inside the `mcp-server` jest harness because that's where the TS-jest config already lives.
+
+- [ ] **Step 1: Write the failing test for byte-counting helper**
+
+Create `mcp-server/tests/audit-script.test.ts`:
+
+```typescript
+import { describe, it, expect } from "@jest/globals";
+import { measureResponse } from "../../scripts/audit_mcp_response_sizes.js";
+
+describe("measureResponse", () => {
+  it("returns byte length of JSON-serialized response", () => {
+    const result = measureResponse({ id: "x", title: "y", snippet: "z" });
+    // {"id":"x","title":"y","snippet":"z"} = 35 bytes
+    expect(result.bytes).toBe(35);
+  });
+
+  it("returns approximate token count using 4-bytes-per-token heuristic", () => {
+    const result = measureResponse({ a: "x".repeat(40) });
+    // {"a":"xxxx...xxxx"} = 48 bytes ≈ 12 tokens
+    expect(result.approxTokens).toBe(12);
+  });
+
+  it("handles array responses (e.g. searchNotes return)", () => {
+    const result = measureResponse([{ id: "a" }, { id: "b" }]);
+    // [{"id":"a"},{"id":"b"}] = 21 bytes
+    expect(result.bytes).toBe(21);
+    expect(result.entryCount).toBe(2);
+  });
+
+  it("reports entryCount: 1 for non-array responses", () => {
+    const result = measureResponse({ noteCount: 0 });
+    expect(result.entryCount).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd mcp-server && npx jest tests/audit-script.test.ts
+```
+
+Expected: FAIL with "Cannot find module '../../scripts/audit_mcp_response_sizes.js'" (TS-jest with ESM imports — the import is the .js compiled name).
+
+- [ ] **Step 3: Implement the audit harness**
+
+Create `scripts/audit_mcp_response_sizes.ts`:
+
+```typescript
+/**
+ * Reproducible audit of MCP tool response sizes.
+ *
+ * Usage (from repo root, via mcp-server's npm script):
+ *   cd mcp-server && npm run audit -- --vault <path>
+ *
+ * Output: JSON report on stdout. Convert to a markdown table in
+ * docs/superpowers/specs/audit-2026-05-04-mcp-response-sizes.md.
+ *
+ * The token approximation is intentionally crude (bytes/4). The point is
+ * to compare relative sizes across tools, not to predict exact LLM cost.
+ */
+
+export interface ResponseMeasurement {
+  bytes: number;
+  approxTokens: number;
+  entryCount: number;
+}
+
+export function measureResponse(response: unknown): ResponseMeasurement {
+  const json = JSON.stringify(response);
+  const bytes = Buffer.byteLength(json, "utf-8");
+  const approxTokens = Math.round(bytes / 4);
+  const entryCount = Array.isArray(response) ? response.length : 1;
+  return { bytes, approxTokens, entryCount };
+}
+
+// CLI driver section follows in Task 1.3
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd mcp-server && npx jest tests/audit-script.test.ts
+```
+
+Expected: PASS, 4 specs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/audit_mcp_response_sizes.ts mcp-server/tests/audit-script.test.ts
+git commit -m "feat(audit): add measureResponse helper with byte/token counting"
+```
+
+---
+
+## Task 1.3: Audit script — driver that calls each tool
+
+**Files:**
+- Modify: `scripts/audit_mcp_response_sizes.ts` (append CLI driver)
+- Modify: `mcp-server/tests/audit-script.test.ts` (add driver test against in-memory vault)
+
+The driver imports each tool function from `mcp-server/dist/tools.js`, calls it with realistic input, measures the response, and emits a markdown table. We test the driver end-to-end against a temp vault built from a fixture, NOT a mock — per CLAUDE.md / project memory feedback, integration tests must hit a real DB.
+
+- [ ] **Step 1: Write a failing end-to-end driver test**
+
+Append to `mcp-server/tests/audit-script.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll } from "@jest/globals";
+import { runAudit } from "../../scripts/audit_mcp_response_sizes.js";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+import { execSync } from "child_process";
+
+describe("runAudit (end-to-end)", () => {
+  let tmpVault: string;
+
+  beforeAll(async () => {
+    tmpVault = await fs.mkdtemp(path.join(os.tmpdir(), "schist-audit-"));
+    // Build a minimal vault: schist init + a few notes
+    execSync(`schist init ${tmpVault} --name audit-test`, { stdio: "pipe" });
+    for (let i = 0; i < 5; i++) {
+      const noteFile = path.join(tmpVault, "notes", `2026-05-04-fixture-${i}.md`);
+      await fs.mkdir(path.dirname(noteFile), { recursive: true });
+      await fs.writeFile(
+        noteFile,
+        `---\ntitle: Fixture ${i}\ndate: 2026-05-04\nstatus: draft\ntags: [audit]\n---\n\nBody for fixture note ${i}, ${"x".repeat(200)}.\n`
+      );
+    }
+    execSync(`cd ${tmpVault} && git add -A && git commit -m "fixtures"`, { stdio: "pipe" });
+    execSync(`schist-ingest --vault ${tmpVault} --db ${tmpVault}/.schist/schist.db`, { stdio: "pipe" });
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpVault, { recursive: true, force: true });
+  });
+
+  it("produces a report covering every tool in the audit set", async () => {
+    const report = await runAudit({ vault: tmpVault });
+    expect(report.tools).toEqual(
+      expect.arrayContaining([
+        "search_notes",
+        "list_concepts",
+        "list_domains",
+        "query_graph",
+        "get_context",
+        "search_memory",
+      ])
+    );
+  });
+
+  it("reports search_notes byte count > 0 against fixture vault", async () => {
+    const report = await runAudit({ vault: tmpVault });
+    const sn = report.measurements.search_notes;
+    expect(sn.bytes).toBeGreaterThan(0);
+    expect(sn.entryCount).toBeGreaterThanOrEqual(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd mcp-server && npx jest tests/audit-script.test.ts -t runAudit
+```
+
+Expected: FAIL — `runAudit` not exported.
+
+- [ ] **Step 3: Implement runAudit**
+
+Append to `scripts/audit_mcp_response_sizes.ts`:
+
+```typescript
+import * as tools from "../mcp-server/dist/tools.js";
+
+export interface AuditReport {
+  vault: string;
+  generatedAt: string;
+  tools: string[];
+  measurements: Record<string, ResponseMeasurement>;
+}
+
+export async function runAudit(opts: { vault: string }): Promise<AuditReport> {
+  const measurements: Record<string, ResponseMeasurement> = {};
+
+  // search_notes — typical "find what I worked on" query
+  measurements.search_notes = measureResponse(
+    await tools.search_notes(opts.vault, { query: "fixture" })
+  );
+
+  // list_concepts — unbounded by default, capture worst case
+  measurements.list_concepts = measureResponse(
+    await tools.list_concepts(opts.vault, {})
+  );
+
+  // list_domains — no limit at all
+  measurements.list_domains = measureResponse(
+    await tools.list_domains(opts.vault, {})
+  );
+
+  // query_graph — the unbounded SELECT case from issue #50
+  measurements.query_graph = measureResponse(
+    await tools.query_graph(opts.vault, { sql: "SELECT * FROM docs" })
+  );
+
+  // get_context — measure all three depths
+  for (const depth of ["minimal", "standard", "full"] as const) {
+    measurements[`get_context_${depth}`] = measureResponse(
+      await tools.get_context(opts.vault, { depth })
+    );
+  }
+
+  // search_memory — long-form content, default 50 limit
+  measurements.search_memory = measureResponse(
+    await tools.search_memory(opts.vault, { limit: 50 })
+  );
+
+  return {
+    vault: opts.vault,
+    generatedAt: new Date().toISOString(),
+    tools: Object.keys(measurements),
+    measurements,
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const vaultIdx = process.argv.indexOf("--vault");
+  if (vaultIdx === -1) {
+    console.error("Usage: tsx scripts/audit_mcp_response_sizes.ts --vault <path>");
+    process.exit(2);
+  }
+  const vault = process.argv[vaultIdx + 1];
+  runAudit({ vault }).then((r) => console.log(JSON.stringify(r, null, 2)));
+}
+```
+
+- [ ] **Step 4: Build mcp-server (driver imports compiled .js)**
+
+```bash
+cd mcp-server && npm run build
+```
+
+Expected: `dist/` populated, no TS errors.
+
+- [ ] **Step 5: Run the driver test**
+
+```bash
+cd mcp-server && npx jest tests/audit-script.test.ts -t runAudit
+```
+
+Expected: PASS, 2 specs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/audit_mcp_response_sizes.ts mcp-server/tests/audit-script.test.ts
+git commit -m "feat(audit): add runAudit driver covering all 6 read-side tools"
+```
+
+---
+
+## Task 1.4: Run the audit against a real vault, capture results
+
+**Files:**
+- Create: `docs/superpowers/specs/audit-2026-05-04-mcp-response-sizes.md`
+
+This task uses the local HPC schist-vault (`~/schist-vault`) as the realistic-vault fixture. That vault has accumulated notes/concepts/edges across multiple spokes since the 2026-05-02 flatten refactor and gives us a non-trivial baseline. (If running on a different machine, substitute the local vault path.)
+
+- [ ] **Step 0: Ensure tsx is available**
+
+`tsx` is not yet a project dep. Add it to `mcp-server/devDependencies` and add an `audit` npm script so the invocation has a stable home:
+
+```bash
+cd mcp-server && npm install --save-dev tsx
+# package.json: add to "scripts":  "audit": "tsx ../scripts/audit_mcp_response_sizes.ts"
+```
+
+Commit the package.json + lockfile change separately (`build: add tsx for audit script`) so it's reviewable on its own.
+
+- [ ] **Step 1: Run the audit and save raw output**
+
+```bash
+cd mcp-server && npm run audit -- --vault ~/schist-vault > /tmp/audit-raw.json
+```
+
+Expected: JSON output, byte counts > 0 for every tool. If `search_memory` returns 0 entries the local memory DB is empty — pass `--vault` to a vault that has memory data, OR populate the memory DB with a fixture before running. Document whichever path was used in the result file.
+
+- [ ] **Step 2: Convert raw output to markdown table**
+
+Create `docs/superpowers/specs/audit-2026-05-04-mcp-response-sizes.md`:
+
+```markdown
+# MCP Tool Response Size Audit — 2026-05-04
+
+**Vault audited:** `~/schist-vault` (HPC spoke, post-flatten)
+**Audit script:** `scripts/audit_mcp_response_sizes.ts`
+**Reproduce:** `cd mcp-server && npm run audit -- --vault <path>`
+
+## Summary
+
+| Tool | Bytes | ≈ Tokens | Entries | Notes |
+|------|-------|----------|---------|-------|
+| `search_notes` (query="fixture") | <fill> | <fill> | <fill> | FTS5 snippet, default limit 20 |
+| `list_concepts` (no opts) | <fill> | <fill> | <fill> | Default limit 50 |
+| `list_domains` (no opts) | <fill> | <fill> | <fill> | **No limit** |
+| `query_graph` (`SELECT * FROM docs`) | <fill> | <fill> | <fill> | **No default LIMIT** — worst case |
+| `get_context` (minimal) | <fill> | <fill> | 1 | Counts only |
+| `get_context` (standard) | <fill> | <fill> | 1 | + recent + hotConcepts |
+| `get_context` (full) | <fill> | <fill> | 1 | + tagCloud (top 30 tags) |
+| `search_memory` (limit=50) | <fill> | <fill> | <fill> | **Returns full content field** |
+
+## Per-tool observations
+
+[Fill in per-tool obs after running. Specifically capture:]
+- Which tools clear ~10KB / ~2.5K tokens — those are the ones the spec must address
+- Which tools are already in good shape — note explicitly so the spec doesn't over-engineer
+- Anomalies (e.g. one tool returns 100x more than expected — investigate)
+
+## Reproduction notes
+
+- Date the vault contained at audit time: <fill>
+- `git rev-parse HEAD` of mcp-server: <fill>
+- Node version: <fill>
+
+The audit script is committed; re-running it after each implementation PR
+gives a regression metric. Keep the markdown table in this file as the
+canonical historical record — append new dated tables, do not overwrite.
+```
+
+Fill in each `<fill>` from `/tmp/audit-raw.json`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/audit-2026-05-04-mcp-response-sizes.md
+git commit -m "docs(audit): capture 2026-05-04 baseline MCP response sizes"
+```
+
+---
+
+## Task 1.5: Write the design spec
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-05-04-mcp-context-efficiency.md`
+
+The spec is the contract every implementation PR (2–8) references during review. It locks in protocol decisions before any tool changes.
+
+- [ ] **Step 1: Draft the spec**
+
+Create `docs/superpowers/specs/2026-05-04-mcp-context-efficiency.md` with these sections:
+
+```markdown
+# MCP Context Efficiency — Design Spec
+
+**Tracks:** [yibeichan/schist#50](https://github.com/yibeichan/schist/issues/50)
+**Implementation plan:** `docs/superpowers/plans/2026-05-04-mcp-context-efficiency.md`
+**Audit baseline:** `docs/superpowers/specs/audit-2026-05-04-mcp-response-sizes.md`
+
+## Goal
+
+Reduce agent context burn from MCP tool responses, especially as the
+vault grows. Adopt cursor-based pagination and reason-string opt-ins so
+agents can't fall back to default-bloat behavior.
+
+## Core principles
+
+[Restate "enforcement in protocol, not prompt" + the two patterns,
+copying language from this plan's Guiding Principles section so the
+spec stands alone.]
+
+## Cursor protocol
+
+### Token shape
+
+A cursor is an opaque (to the agent), HMAC-signed JSON payload:
+
+```json
+{
+  "tool": "search_notes",
+  "queryHash": "<sha256 of (sorted-args + owner)>",
+  "offset": 20,
+  "issuedAt": 1717459200,
+  "ttlSeconds": 300
+}
+```
+
+Encoded as base64url, signed with a per-server-instance HMAC secret
+(generated at process start, not persisted). Agents pass it as
+`{ cursor: "<token>" }` on follow-up calls.
+
+### Server-side identical-query refusal
+
+When a tool returns a cursor, the server stores `(queryHash, owner, issuedAt)`
+in an in-memory LRU (size 256). On a subsequent call:
+
+| Condition | Behavior |
+|-----------|----------|
+| Same `queryHash` + `owner` within `ttlSeconds`, NO cursor passed | Return `error: "CURSOR_REQUIRED", message: "Identical query within ${ttl}s — pass cursor or refine"`, with the original cursor token re-attached. |
+| Same `queryHash` + `owner`, cursor passed and validated | Serve next page; advance LRU entry. |
+| Different `queryHash` (refined query) | Treated as a new query; previous cursor expires. |
+| TTL expired | Treat as new query; emit a soft note in response so debugging is easy. |
+
+### Tool-specific cursor adoption
+
+[For each of search_notes, query_graph, search_memory, list_concepts, list_domains:
+specify what `queryHash` includes, what `offset` semantics are, what the
+"next page" SQL shape looks like.]
+
+## Reason-string verbose
+
+Tools that have a "give me more" mode replace `verbose: boolean` with `verbose: string`.
+
+- The string must be ≥ 12 characters (filters out lazy `verbose: "x"` workarounds).
+- The string is logged to the MCP server's stderr at INFO level for audit.
+- Empty string or omitted field → not verbose. No silent fallback.
+
+Tools adopting reason-string verbose:
+- `get_context` for `depth: "full"` — currently `full` triggers tagCloud computation; gating it is cheap value.
+- `search_memory` for full-content return (default returns content snippet).
+- (Future-proof: any tool that grows a "give me everything" mode.)
+
+`search_notes` does NOT need reason-string verbose — full bodies are obtained via `get_note`, which is already an explicit two-step.
+
+## Default limits
+
+[For each tool, document: current default, proposed default, reasoning.
+Most are already sensible; `list_domains` and `query_graph` are the changes.]
+
+## Compatibility / migration
+
+- All current MCP clients call these tools without `cursor` and without
+  `verbose`. Both fields are added as **optional inputs** in tool-registry
+  schemas, so existing callers continue working — they just may receive
+  a `cursor` field they ignore (and, if they retry identically, a new
+  `CURSOR_REQUIRED` error).
+- The `CURSOR_REQUIRED` error is the user-visible breaking change. Mitigate
+  by:
+  - Updating every tool's description string in `tool-registry.ts` to
+    mention pagination (so agents read the rule from the input schema).
+  - Updating `docs/mcp-setup.md` with the new convention.
+  - Calling out the change in the next release notes.
+
+## Out-of-scope for this rollout
+
+- Authentication / authorization changes (the existing capability gate
+  already covers writes).
+- Streaming responses (would require MCP protocol-level changes).
+- Caching tool responses across sessions (out of scope; orthogonal).
+```
+
+- [ ] **Step 2: Self-review the spec**
+
+Read the spec end-to-end. Check:
+- Every implementation PR (2–8) has a paragraph it can point at for "what should I build?"
+- The cursor format is specified concretely enough that PR 2 can implement it from the spec alone (no tribal knowledge required).
+- The reason-string rules are unambiguous (≥12 chars, logged, no silent fallback).
+- The "compatibility" section names the breaking change explicitly.
+
+If any of those are missing, edit until they are.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-05-04-mcp-context-efficiency.md
+git commit -m "docs(spec): MCP context efficiency design (#50)"
+```
+
+---
+
+## Task 1.6: Open PR for review
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/issue-50-mcp-efficiency-audit-spec
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "docs+audit: MCP context efficiency baseline + spec (#50)" --body "$(cat <<'EOF'
+## Summary
+- Reproducible audit script (`scripts/audit_mcp_response_sizes.ts`) with byte/token measurements per MCP tool
+- Captured 2026-05-04 baseline measurements against the HPC vault
+- Design spec for cursor-based pagination + reason-string verbose, building on m13v's comment on #50
+- Multi-PR rollout plan covering PRs 2–8 (cursor infra, then per-tool adoption)
+
+No behavior change in this PR — purely audit + spec + plan. Implementation lands in PR 2 onwards.
+
+## Test plan
+- [ ] `npm test` passes in `mcp-server/`
+- [ ] Audit script runs cleanly against a fresh vault (`schist init` + a few notes)
+- [ ] Audit script runs cleanly against the live HPC vault
+- [ ] Spec self-review: every PR 2–8 has a section it can reference
+
+## Refs
+Closes part of #50 (audit + spec milestone). Implementation tracked in follow-up PRs.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Verify CI green**
+
+```bash
+gh pr checks
+```
+
+Expected: all checks pass. If they don't, fix in-place — do NOT merge through red.
+
+- [ ] **Step 4: Wait for human review**
+
+Tag yibei (the human owner) for spec review specifically. Implementation PRs depend on the spec being accepted.
+
+---
+
+# PRs 2–8 — Outline Only
+
+Each gets its own detailed plan written when its prerequisites land. The structure below is the scope contract for each PR; detailed steps come later.
+
+## PR 2 — Cursor module + reason-string helper
+
+**Purpose:** Land shared infrastructure so PRs 3–7 are small.
+
+**Scope:**
+- `mcp-server/src/protocol/cursor.ts` exports: `issueCursor(args)`, `validateCursor(token)`, `recordIssued(queryHash, owner)`, `checkIdentical(queryHash, owner)`, `clearExpired()`.
+- `mcp-server/src/protocol/verbose.ts` exports: `parseVerbose(input)` returning `{ enabled: boolean, reason?: string }`.
+- LRU storage is in-process Map, capped at 256 entries; cleared on process restart (acceptable since cursors are TTL-bound at 300s).
+- Full Jest coverage: cursor encode/decode/expiry, identical-query refusal logic, reason-string validation (length, whitespace handling).
+
+**Out of scope:** No tool actually uses these modules in PR 2. Wiring lands in PRs 3–7.
+
+**Detailed plan:** Written after PR 1 spec is accepted, saved as `docs/superpowers/plans/2026-05-04-mcp-context-efficiency-pr-2.md`.
+
+## PR 3 — `search_memory` cursor + reason-string verbose adoption
+
+**Why first adopter:** Highest-impact (returns full `content`) and clearest verbose case (snippet by default, full content via reason string).
+
+**Scope:**
+- `tools.ts`: `search_memory` accepts `cursor` and `verbose: string`. Returns `{ entries: [...], cursor?: token, truncated: boolean }`.
+- `sqlite-reader.ts`: `searchMemory` returns content snippets (first ~200 chars) by default; full content only when verbose reason is non-empty.
+- `tool-registry.ts`: input schema updated to document the new fields.
+- Tests: cursor pagination (page-1, page-2, end-of-results), identical-query refusal, snippet vs full-content modes, ≥12-char reason validation.
+
+**Detailed plan:** Written after PR 2 lands, as `docs/superpowers/plans/2026-05-04-mcp-context-efficiency-pr-3.md`.
+
+## PR 4 — `query_graph` cursor + LIMIT injection
+
+**Why second:** Highest-impact after `search_memory`; unbounded SELECT is a real footgun.
+
+**Scope:**
+- Server-side: if caller's SQL has no `LIMIT`, inject `LIMIT 100`. If the caller did include `LIMIT`, respect it but cap at 1000.
+- Cursor encodes `OFFSET` for re-issue with the same SQL (queryHash includes the SQL string + params).
+- Refuse identical-SQL re-issue without cursor (catches the "agent retries same SELECT * FROM docs" pattern m13v warned about).
+- Tests: bare SELECT gets default LIMIT, large SELECT gets capped, cursor advances OFFSET, identical-query refusal works for SQL too.
+
+**Detailed plan:** as PR 3, post-PR-2.
+
+## PR 5 — `search_notes` cursor adoption
+
+**Scope:** Lighter than 3/4 — `search_notes` already returns snippets and has a default limit. Just adds cursor pagination and identical-query refusal. No verbose changes (full bodies via `get_note` continues to be the explicit path).
+
+**Detailed plan:** as above.
+
+## PR 6 — `list_concepts` + `list_domains` cursor adoption
+
+**Why batched:** Both are low-content list endpoints with similar shapes. One PR, two tools.
+
+**Scope:**
+- `list_domains` gets a default `limit: 100` (was unlimited).
+- Both tools accept `cursor` and return one when `truncated: true`.
+- `list_concepts` already has limit 50 — preserved.
+
+**Detailed plan:** as above.
+
+## PR 7 — `get_context` reason-string opt-in for `depth: "full"`
+
+**Scope:**
+- `depth: "full"` gated behind a reason-string parameter (e.g. `fullReason: "<≥12 chars>"`). Without it, the server downgrades to `standard` and emits a hint.
+- `depth: "minimal"` and `depth: "standard"` unchanged.
+- The `tagCloud` computation in `getContext` is the actual cost being gated.
+
+**Detailed plan:** as above.
+
+## PR 8 — Migration notes + tool-description updates + cleanup
+
+**Scope:**
+- `docs/mcp-setup.md` — caller-facing notes on cursor, reason-string, breaking changes.
+- `tool-registry.ts` — pass over every tool description to mention cursor / pagination where applicable, in agent-readable language.
+- Re-run the audit script, append the post-rollout numbers to `docs/superpowers/specs/audit-2026-05-04-mcp-response-sizes.md` for delta documentation.
+- Close issue #50.
+
+**Detailed plan:** as above.
+
+---
+
+# Locked Decisions (2026-05-10)
+
+Locked pre-PR-1 in a scoping session. The spec doc (Task 1.5) restates these as normative; this section preserves the rationale. Changes ripple expensively, so lock-in is the gate.
+
+1. **Cursor TTL = 300s.** ✅ Long enough for normal multi-page agent loops; short enough that stale cursors don't pile up.
+2. **HMAC secret = per-process, no persistence.** ✅ Cursors are inherently in-session; persisting would add storage + rotation complexity for no real benefit. Cursors die on server restart, which is acceptable.
+3. **Reason-string minimum = 12 chars.** ✅ Real friction against the lazy `verbose: "x"` pattern without being painful (~two short words). Going to 20 wouldn't catch much more — agents adapt.
+4. **Verbose-content tools = `get_context (full)` + `search_memory`.** ✅ `search_notes` deliberately excluded — `get_note` is already an explicit two-step path for full bodies, which is the better protocol pattern than verbose-flag.
+5. **`query_graph` LIMIT: default 100, caller cap 1000.** ✅ ⚠️ **Behavior change.** Today `SELECT * FROM docs` is unbounded. After PR 4, the same query returns 100 rows + a cursor. Power users who write `LIMIT 5000` get capped at 1000. PR 4 commit message + PR 8 migration notes must call this out explicitly.
+
+---
+
+# Self-Review (run before opening PR 1)
+
+After this plan is committed:
+
+**1. Spec coverage of issue #50.** Walk through each "Likely sources of bloat" hypothesis in #50:
+- ✅ `search_notes` — covered by PR 5.
+- ✅ `get_context` — covered by PR 7.
+- ✅ `query_graph` — covered by PR 4.
+- ✅ `list_concepts` / `list_domains` — covered by PR 6.
+- ✅ `search_memory` — covered by PR 3.
+
+**2. Placeholder scan.** Searched this document for "TBD", "TODO", "implement later", "fill in later" — only intentional `<fill>` placeholders in the audit-results task (filled at run time, not at plan-write time).
+
+**3. Type consistency.** Functions referenced in this plan:
+- `measureResponse(response): ResponseMeasurement` — defined Task 1.2, used Task 1.3.
+- `runAudit({ vault }): AuditReport` — defined Task 1.3, called by tests in Task 1.3 and CLI in Task 1.4.
+- `issueCursor / validateCursor / parseVerbose` — described in PR 2 outline; signatures locked there, not assumed by PR 1.
+
+No type drift across tasks within PR 1.
+
+**4. Untracked-files hygiene.** `git status` at the start of PR 1 must not stage:
+- `.gstack/`
+- `.claude/scheduled_tasks.lock`
+- `docs/refactor-flatten-spoke-dirs.md`
+
+These are persistent cross-session artifacts. The plan's commits are scoped to specific paths, never `git add -A`.

--- a/docs/superpowers/specs/2026-05-04-mcp-context-efficiency.md
+++ b/docs/superpowers/specs/2026-05-04-mcp-context-efficiency.md
@@ -78,12 +78,17 @@ The signed payload (before encoding) is:
   `ttlSeconds` on every redemption.
 - **`ttlSeconds`**: fixed at **300** for all cursors (locked decision).
 
-Encoded as `base64url(payload) + "." + base64url(hmac_sha256(secret, payload))`.
+Encoded as `base64url(payload) + "." + base64url(hmac_sha256(secret, payload))`,
+where `base64url` is the unpadded RFC 4648 §5 variant (no trailing `=`).
+Unpadded keeps cursors compact and URL-safe in any context.
 
 The HMAC secret is **per-process, regenerated on every server start**
-(locked decision). Cursors do not survive `mcp-server` restarts; agents
-hitting an expired/invalid cursor get a structured error and start over
-from page 1. This is acceptable because cursor TTL is 300s anyway.
+(locked decision). Cursors do not survive `mcp-server` restarts;
+agents hitting an invalid cursor get one of the four distinct error
+codes documented below ("Cursor error codes") and restart from page
+1. This is acceptable because cursor TTL is 300s anyway. See
+"Multi-process cursor scope" below for the implications when more
+than one MCP server runs against the same vault.
 
 ### queryHash canonicalization
 
@@ -92,56 +97,157 @@ formatting, every tool computes:
 
 ```
 queryHash = sha256(
-  JSON.stringify(
-    sortKeys({ ...normalizedArgs, _owner: ownerOrEmptyString })
-  )
+  JSON.stringify({
+    args:  sortKeys(normalize(callerArgs)),
+    owner: ownerOrEmptyString
+  })
 )
 ```
 
-Where `normalizedArgs`:
-- excludes the `cursor` field (which is meta, not part of the query
-  identity);
-- excludes any `verbose` field (verbose changes the *response shape*,
-  not the *query identity* — we want both verbose and non-verbose
-  re-issues of the same query to count as identical);
-- normalizes string-vs-undefined for optional fields (omitted ↔ empty
-  ↔ null all collapse to omitted);
-- normalizes number ranges where applicable (e.g. `limit: 0` ↔
-  `limit: undefined`).
+Note: `args` and `owner` live in **disjoint top-level keys**, not a
+merged object. This forecloses two failure modes: (a) a future tool
+adding an `_owner` arg colliding with a flat `_owner` injection, and
+(b) prototype pollution from a malicious arg key like `__proto__` if
+the canonicalizer used `Object.assign`. The canonicalizer must use
+`Object.create(null)` (or an equivalent prototype-free dict) for any
+intermediate object.
 
-`sortKeys` is a recursive deep-sort so `{a:1,b:2}` and `{b:2,a:1}` hash
-identically.
+Where `normalize(callerArgs)`:
+- excludes the `cursor` field (meta, not part of the query identity);
+- excludes the `verbose` field (verbose changes the *response shape*
+  for the current call only; see "Reason-string verbose" for how
+  newly-set verbose interacts with identical-query refusal);
+- treats `undefined`, `null`, and missing keys as identical (collapse
+  to missing);
+- treats empty string `""` as missing for optional string fields;
+- normalizes number ranges (`limit: 0` ↔ `limit: undefined`);
+- **rejects unhashable JS values** before normalization with a
+  `INVALID_ARG` tool error (not a silent collision): `NaN`, `+Infinity`,
+  `-Infinity`, `BigInt`, functions, symbols, circular references. These
+  either crash `JSON.stringify` or collapse to `null`, causing hash
+  collisions across genuinely distinct queries;
+- **NFC-normalizes** every string value via `String.prototype.normalize("NFC")`
+  before hashing, so visually-identical Unicode forms hash identically
+  (e.g. `"café"` precomposed vs `"café"` combining-accent).
+
+`sortKeys` is a recursive deep-sort over object keys (arrays preserve
+their order — array element ordering is part of the query identity).
 
 ### Server-side identical-query refusal
 
-When a tool returns a cursor (i.e. results were capped), the server
-stores `(tool, queryHash, owner, issuedAt, lastCursor)` in an in-memory
-LRU (size 256). On a subsequent call:
+When a tool returns a cursor (results were capped), the server stores
+`(tool, queryHash, owner, issuedAt)` in an in-memory LRU (size 256).
+On a subsequent call:
 
 | Condition | Behavior |
 |-----------|----------|
-| Same `(tool, queryHash, owner)` within `ttlSeconds`, NO cursor passed | Return `{ error: "CURSOR_REQUIRED", message: "Identical query within ${ttl}s — pass cursor or refine.", cursor: <reissued token> }`. Agent must consume the cursor to advance, OR change at least one query argument. |
-| Same `(tool, queryHash, owner)`, cursor passed and validated | Serve next page; advance LRU entry's `offset`. |
-| Different `queryHash` (refined query) | Treat as a new query; previous cursor expires from LRU naturally. |
-| TTL expired | Treat as new query; emit a soft `cursorNote: "previous cursor expired after Xs"` field in the response so agents can debug. |
+| Same `(tool, queryHash, owner)` within `ttlSeconds`, NO cursor passed, NO newly-set `verbose` | Return `{ error: "CURSOR_REQUIRED", message: "Identical query within ${ttl}s — pass the cursor you received on the previous response, or refine the query." }`. **No cursor is reissued in the error** — see the rationale below. |
+| Same `(tool, queryHash, owner)`, NO cursor passed, BUT `verbose` is newly set | Treat as a new query and serve page 1 with the verbose-mode response shape. Rationale: the agent went from "give me snippets" to "now I need full content for these results"; refusing that would create a refusal loop. The `verbose` flag itself is **not** part of `queryHash` (so a subsequent identical+verbose retry IS still refused). |
+| Cursor passed and HMAC-validates | Serve next page; HMAC-signed `offset` is the source of truth. LRU is consulted only to update `lastCursor` for the refusal-detection path; missing LRU entry is fine. |
+| Different `queryHash` (refined query) | Treat as a new query; previous LRU entry expires naturally. |
+| TTL expired | Distinct error code: `CURSOR_EXPIRED` (see "Cursor error codes" below). |
 
-LRU is in-process Map with size cap 256 and explicit per-call expiry
-sweep. Cleared on process restart (acceptable — cursors are TTL-bound
-to 300s anyway).
+**No cursor reissue on `CURSOR_REQUIRED`.** Embedding a fresh cursor in
+the refusal response would defeat the "structurally impossible to
+retry" property: the agent could ignore the original cursor, hit
+`CURSOR_REQUIRED`, and use the *reissued* cursor without ever having
+inspected the data — same blind-retry pattern this protocol exists to
+prevent. The agent must either echo back the cursor it already
+received on the previous response, or change at least one query
+argument.
+
+**Refusal is best-effort, not a guarantee.** The LRU is sized at 256
+entries with eviction on the standard read-or-write LRU rule (every
+access bumps an entry to most-recently-used). A server under load
+that issues 257+ distinct cursors within `ttlSeconds` will evict the
+oldest entry; an identical re-query at that point will *not* be
+refused. The HMAC-signed cursor TTL remains the binding security
+constraint — refusal is a best-effort guard against agent bugs, not a
+load-bearing security boundary.
+
+### Cursor error codes
+
+The previous "everything is `CURSOR_REQUIRED`" rule collapsed four
+distinct failure modes into one error, leaving agents unable to
+distinguish "I'm doing this wrong" from "the server restarted." PR 2
+must surface them as separate codes:
+
+| Code | Meaning | Agent action |
+|------|---------|--------------|
+| `CURSOR_REQUIRED` | Identical-query refusal: same `(tool, queryHash, owner)` within TTL, no cursor passed. | Echo back the cursor from the previous response, or refine the query. |
+| `CURSOR_EXPIRED` | Cursor TTL exceeded. | Restart pagination from page 1; the underlying data may have changed. |
+| `CURSOR_INVALID_SIGNATURE` | HMAC verification failed (forged cursor, or cursor from a different process — see "Multi-process" below). | Restart pagination from page 1. Repeated failures indicate a configuration issue. |
+| `CURSOR_WRONG_TOOL` | Cursor presented to a tool that didn't issue it (cross-tool replay). | Restart pagination from page 1. Likely an agent bug. |
+
+All four are returned as `{ error: "<code>", message: "<human-readable>" }`
+tool envelopes — no cursor field on any of them.
+
+### Multi-process cursor scope
+
+Cursors are bound to the **specific MCP server process** that issued
+them: the HMAC secret is per-process (see "Token shape" above), so a
+cursor from process A presented to process B fails HMAC verification
+and returns `CURSOR_INVALID_SIGNATURE`. Clients that front multiple
+MCP servers against the same vault (e.g. Claude desktop + Claude Code
+running side-by-side, or a load-balanced setup described in
+`docs/hub-spoke-setup.md`) must route follow-up cursor-bearing calls
+to the same process.
+
+This rollout does **not** provide a cross-process cursor sharing
+mechanism. A future rollout could derive a vault-level HMAC secret
+stored under `.schist/` to allow cross-process validity; the cost is
+rotation complexity and a persisted secret on disk. Out of scope here.
 
 ### Tool-specific cursor adoption
 
-| Tool | `queryHash` includes | `offset` semantics | Next-page SQL shape |
-|------|----------------------|--------------------|----------------------|
-| `search_notes` | `query`, `limit`, `tags?`, `status?`, `owner` | Row offset into the FTS5 result set, ordered by FTS5 rank then `date DESC`. | Existing `search_notes` SQL + `LIMIT :limit OFFSET :offset`. |
-| `search_memory` | `query?`, `owner?`, `entry_type?`, `date_from?`, `date_to?`, `limit`, ownerOrEmpty | Row offset into the memory result set, ordered by `date DESC, id DESC`. | Existing memory query + `LIMIT :limit OFFSET :offset`. |
-| `query_graph` | normalized SQL string, `params?`, ownerOrEmpty | Row offset; SQL gets `LIMIT :limit OFFSET :offset` *injected* when not present (see "Default limits" below). | Caller's SQL with server-managed `LIMIT/OFFSET` appended. |
-| `list_concepts` | `q?`, `domain?`, `limit`, ownerOrEmpty | Row offset, ordered by `slug ASC`. | Existing `list_concepts` SQL + `LIMIT :limit OFFSET :offset`. |
-| `list_domains` | `limit`, ownerOrEmpty | Row offset, ordered by `slug ASC`. | Domains query + `LIMIT :limit OFFSET :offset`. |
+The table below lists **current** primary `ORDER BY` (verified against
+`mcp-server/src/sqlite-reader.ts` on 2026-05-10) plus the **stable
+tiebreaker** each implementation PR must add. OFFSET-based pagination
+is non-deterministic without a tiebreaker — duplicate primary-sort
+values cause skipped or repeated rows across pages. Adding a
+secondary `id ASC` (or equivalent) is **not** a breaking change to the
+primary sort.
 
-`get_note` does NOT use cursors — it's an explicit single-doc fetch.
-`get_context` does NOT use cursors — its response is a fixed-shape
-summary, not a paginated list.
+| Tool | `queryHash` includes | Current primary ORDER BY | Required secondary tiebreaker (PR adds) | Next-page SQL shape |
+|------|----------------------|---------------------------|------------------------------------------|----------------------|
+| `search_notes` | `query`, `limit`, `tags?`, `status?`, `scope?`, owner | **None today** (line 111). FTS5 natural relevance order. | `ORDER BY bm25(docs_fts), docs.id ASC` (FTS5 rank surfaced via `bm25(docs_fts)` for stability). | Existing SQL + new `ORDER BY` clause + `LIMIT :limit OFFSET :offset`. |
+| `search_memory` (FTS path) | `query?`, `owner?`, `entry_type?`, `date_from?`, `date_to?`, `limit`, owner | **None today** (line 429). FTS5 natural relevance order. | `ORDER BY bm25(agent_memory_fts), m.id ASC`. | Existing FTS SQL + new `ORDER BY` + `LIMIT :limit OFFSET :offset`. |
+| `search_memory` (non-FTS path) | (same as FTS path) | `ORDER BY created_at DESC` (line 439). | `ORDER BY created_at DESC, id ASC`. | Existing SQL + `, id ASC` tiebreaker + `LIMIT :limit OFFSET :offset`. |
+| `query_graph` | normalized SQL string, `params?`, owner | Whatever caller's SQL specifies. | Server wraps as subquery — see "query_graph cursor wrapping" below. | `SELECT * FROM (<caller_sql>) AS user_query LIMIT :limit OFFSET :offset`. |
+| `list_concepts` | `q?`, `domain?`, `limit`, owner | `ORDER BY edgeCount DESC` (line 186). | `ORDER BY edgeCount DESC, c.slug ASC`. | Existing SQL + `, slug ASC` tiebreaker + `LIMIT :limit OFFSET :offset`. |
+| `list_domains` | `limit`, owner | `ORDER BY parent_slug NULLS FIRST, slug` (line 525). | (Already deterministic — `slug` is unique. No change needed.) | Existing SQL + `LIMIT :limit OFFSET :offset`. |
+
+`get_note` does NOT use cursors — single-doc fetch by ID.
+`get_context` does NOT use cursors — fixed-shape summary, not a list.
+
+#### `query_graph` cursor wrapping
+
+To make pagination implementable safely over arbitrary user SQL — no
+regex-on-raw-SQL pitfalls (comment fake-outs, string literals, CTEs,
+UNIONs, multi-statement) — the server **wraps** the caller's SQL as a
+subquery:
+
+```sql
+SELECT * FROM (<caller_sql>) AS user_query LIMIT :limit OFFSET :offset
+```
+
+- `:limit` is server-controlled: the caller's `limit` arg (capped at
+  1000) or the default 100. The cursor's `offset` field rides on this
+  outer LIMIT.
+- The caller's own `LIMIT` / `OFFSET` / `ORDER BY` clauses live inside
+  the subquery and are respected verbatim. A caller passing `SELECT *
+  FROM docs LIMIT 5` gets exactly 5 rows (no pagination needed since
+  `5 < limit`). A caller passing `SELECT * FROM docs ORDER BY date DESC`
+  gets server-paginated results in date-descending order.
+- The existing `query_graph` guards (SELECT/WITH-only, no
+  INSERT/UPDATE/etc., enforced via `sqlite-reader.ts:208-211`) still
+  reject mutating statements before wrapping.
+- Caller's SQL with a trailing `;` or multi-statement input is
+  rejected by `better-sqlite3.prepare()` as it is today — no change.
+
+This approach removes the spec's prior "detect caller LIMIT and cap"
+requirement entirely. The subquery wrap is a single deterministic
+rewrite; no parser, no regex, no edge cases.
 
 ---
 
@@ -152,15 +258,46 @@ Tools that have a "give me more" mode replace `verbose: boolean` with
 
 **Validation rules (locked):**
 
-- The string must be **≥ 12 characters** after trimming whitespace.
-  Rejects lazy `verbose: "x"` workarounds while still allowing a short
-  but meaningful reason like `"need full body for code review"`.
-- The string is logged to the MCP server's stderr at INFO level:
-  `[verbose] <tool> by <owner|anonymous>: <reason>`. Provides an
-  auditable trail of when expensive paths actually fire.
-- Empty string, whitespace-only string, or omitted field → not verbose.
-  No silent fallback; `verbose: true` (boolean) is rejected as a type
-  error so callers can't accidentally re-introduce the boolean pattern.
+- The string must be **≥ 12 Unicode code points** after trimming
+  whitespace. Measured via `[...str.trim()].length`, **not**
+  `str.length` (which counts UTF-16 code units — `"🔍🔍🔍🔍🔍🔍"` is 12
+  UTF-16 units but only 6 code points). Code points are the right unit:
+  graphemes are over-permissive (zero-width-joiners) and bytes are
+  over-restrictive (CJK reasons would need to be artificially padded).
+- "Whitespace" means anything matching `/^\s*$/u`. This catches NBSP
+  (` `), zero-width space (`​`), BOM (`﻿`), and any
+  other Unicode whitespace class.
+- `verbose: true` (boolean) is rejected as a type error — callers
+  can't accidentally re-introduce the boolean pattern.
+- Empty string, whitespace-only string, or omitted field → not
+  verbose. No silent fallback.
+
+**Logging (locked):**
+
+The accepted reason is logged to the MCP server's stderr at INFO level:
+
+```
+[verbose] <tool> by <owner|anonymous>: <JSON.stringify(reason)>
+```
+
+The reason is passed through `JSON.stringify` (which escapes newlines,
+control chars, and any non-printable bytes) before writing to stderr.
+Logging `reason` raw is a log-injection vector: an agent-controlled
+string like `"benign\n[error] root pwned"` would inject a fake stderr
+line. `JSON.stringify` is sufficient escape — it produces a quoted,
+single-line string in all cases. The same escape applies to `owner`
+if it's caller-controlled.
+
+**Rate-limit note (PR 2 + PR 3 + PR 7):**
+
+A determined agent will discover the magic 12-code-point pad and pass
+the same reason on every call, turning the audit log into noise. PR 2
+adds a counter per `(tool, owner, sha256(reason))` over the last 60
+seconds; if a single triple exceeds 30 hits/min, subsequent calls
+within that window get a soft warning in the response (`verboseNote:
+"reason pattern is frequent — consider sampling at operator level"`)
+but are not refused. Hard rate-limiting is out of scope for this
+rollout.
 
 **Tools adopting reason-string verbose (locked):**
 
@@ -186,12 +323,12 @@ Tools that have a "give me more" mode replace `verbose: boolean` with
 
 | Tool | Current default | Proposed default | Caller cap | Reasoning |
 |------|-----------------|------------------|------------|-----------|
-| `search_notes` | `limit: 20` | `limit: 20` (unchanged) | 100 | Already healthy at the audit-baseline corpus (8KB/2K tokens). |
-| `list_concepts` | `limit: 50` | `limit: 50` (unchanged) | 200 | Already healthy (4KB/1K tokens at 25 concepts). |
+| `search_notes` | `limit: 20` | `limit: 20` (unchanged) | 100 | Already healthy at the 2026-05-10 baseline (8 KB / ~2.4K tokens). |
+| `list_concepts` | `limit: 50` | `limit: 50` (unchanged) | 200 | Already healthy (4 KB / ~1K tokens at 25 concepts). |
 | `list_domains` | **no limit** | **`limit: 100`** | 500 | Domains tend to be tiny but the unbounded default is a footgun for a vault that grows them. |
-| `query_graph` | **no default LIMIT** | **`LIMIT 100` injected when caller omits LIMIT** | **caller cap 1000** | Today `SELECT * FROM docs` is unbounded. Audit showed 241KB / 60K tokens on a 70-doc vault. Linear scaling makes this the highest-priority change. **⚠️ This is a behavior change** — see Compatibility below. |
-| `get_context` | tiered (minimal / standard / full) | tiered, `full` requires verbose reason | n/a | Tiering is fine; the cost of `full` is the tagCloud computation, gated via reason-string. |
-| `search_memory` | `limit: 50`, full content | `limit: 50`, snippet content; full content requires verbose reason | 200 | 41KB/10K tokens dropped to ~12KB/3K tokens estimated under snippet mode. |
+| `query_graph` | **no default LIMIT** | **Server-wrapped subquery: outer `LIMIT 100`** | **outer `LIMIT` 1000** via caller `limit` arg | Today `SELECT * FROM docs` is unbounded; baseline showed 242 KB / ~64K tokens on a 70-doc vault. Server wraps as `SELECT * FROM (<caller_sql>) LIMIT :limit OFFSET :offset` so the outer LIMIT is the cap regardless of what's inside. Caller's own inner LIMIT/ORDER BY/OFFSET are respected verbatim. **⚠️ This is a behavior change** — see Compatibility below. |
+| `get_context` | tiered (minimal / standard / full) | tiered, `full` requires verbose reason | n/a | Tiering is fine; cost of `full` is the tagCloud computation, gated via reason-string. |
+| `search_memory` | `limit: 50`, full content | `limit: 50`, snippet content; full content requires verbose reason | 200 | 42 KB / ~10.6K tokens baseline drops to ~12 KB / ~3K tokens estimated under snippet mode. |
 
 `get_note` has no `limit` (single doc fetch by ID) and is unchanged.
 
@@ -212,15 +349,20 @@ Tools that have a "give me more" mode replace `verbose: boolean` with
 
 There is exactly **one** user-visible breaking change:
 
-- **`query_graph` injecting `LIMIT 100` when caller omits LIMIT.**
-  Today, a caller running `SELECT * FROM docs` on a 1000-doc vault
-  gets 1000 rows. Post-PR-4, the same call gets 100 rows + a cursor.
-  Power users who included `LIMIT 5000` get capped at 1000.
+- **`query_graph` server-wraps every caller query as a paginated
+  subquery.** Today, a caller running `SELECT * FROM docs` on a
+  1000-doc vault gets all 1000 rows. Post-PR-4, the same call gets
+  100 rows + a cursor; the outer LIMIT (caller's `limit` arg, default
+  100, max 1000) caps the result regardless of what the caller's SQL
+  itself says. A caller who wants ≥1000 rows must paginate via the
+  cursor.
 
-The `CURSOR_REQUIRED` error is *technically* also new behavior — but
-it only triggers when an agent retries an identical query within 300s
-without consuming the cursor. That pattern is the agent bug we want to
-fail loudly, not graceful behavior we want to preserve.
+The new cursor error codes (`CURSOR_REQUIRED`, `CURSOR_EXPIRED`,
+`CURSOR_INVALID_SIGNATURE`, `CURSOR_WRONG_TOOL`) are *technically* also
+new behavior — but they only trigger on agent retry patterns this
+protocol exists to surface. The previous behavior was "agent silently
+re-queries forever"; the new behavior is "agent gets a labelled error."
+That's a strict improvement, not a regression.
 
 ### Migration steps (PR 8)
 
@@ -249,29 +391,59 @@ deliberately excluded:
   HMAC secret rotates per process; agents handle restart by re-running
   page 1.
 - **Modifying `get_note`'s contract.** Single-doc fetches are
-  intentionally explicit.
+  intentionally explicit. **Caveat:** `get_note` returns the full body
+  with no size cap. A vault containing a multi-megabyte note will
+  return the entire body in one tool call — a worse blast radius than
+  pre-rollout `query_graph` for that one note. The 2026-05-10 baseline
+  didn't measure `get_note` because there's no obvious "worst case"
+  note ID to probe. If multi-MB notes become real, a follow-up
+  rollout could add a body-length cap with reason-string opt-in for
+  full retrieval; that's out of scope for this rollout.
 
 ---
 
 ## Self-review checklist
 
-Used to validate the spec before opening PR 1:
+Used to validate the spec before opening PR 1, refined after the
+2026-05-10 PR-#56 review pass that surfaced 10 ambiguities. Re-validate
+this checklist before starting each PR 2–7 plan.
 
 - [x] Every implementation PR (2–8) has a section it can point at:
-  - PR 2 → "Cursor protocol" + "Reason-string verbose" (defines what
-    the shared modules expose).
+  - PR 2 → "Cursor protocol" + "queryHash canonicalization" + "Cursor
+    error codes" + "Reason-string verbose" + rate-limit note.
   - PR 3 → "search_memory" rows in cursor-adoption table + Default
-    limits + Reason-string adopters.
-  - PR 4 → "query_graph" rows + Default limits + Compatibility
-    breaking change.
-  - PR 5 → "search_notes" rows in cursor-adoption table.
+    limits + Reason-string adopters + verbose-newly-set bypass.
+  - PR 4 → "query_graph" rows + "query_graph cursor wrapping" subsection
+    + Default limits + Compatibility breaking change.
+  - PR 5 → "search_notes" rows + tiebreaker requirement.
   - PR 6 → "list_concepts" + "list_domains" rows + Default limits.
   - PR 7 → "get_context" reason-string adopters.
   - PR 8 → "Migration steps" section.
-- [x] Cursor format specified concretely enough for PR 2 to implement
-  from the spec alone.
-- [x] Reason-string rules unambiguous: ≥12 chars after trim, logged
-  to stderr, no silent fallback, boolean rejected.
-- [x] Compatibility section names the breaking change (query_graph
-  default LIMIT) explicitly and proposes mitigation in PR 8.
+- [x] Cursor token shape specified concretely (unpadded base64url, JWT-like
+  dot separator, per-process HMAC) for PR 2 to implement from spec alone.
+- [x] `queryHash` canonicalization addresses NaN/±Infinity/BigInt
+  rejection, prototype-pollution defense, NFC Unicode normalization,
+  disjoint `args`/`owner` namespacing.
+- [x] Reason-string rules unambiguous: ≥12 Unicode code points
+  (`[...str].length`, not `str.length`), `JSON.stringify`-escaped on
+  stderr log, boolean rejected, whitespace via `/^\s*$/u`.
+- [x] Cursor error codes split into `CURSOR_REQUIRED` /
+  `CURSOR_EXPIRED` / `CURSOR_INVALID_SIGNATURE` / `CURSOR_WRONG_TOOL`
+  with distinct agent actions.
+- [x] No cursor reissue on `CURSOR_REQUIRED` — agent must echo the
+  original cursor or refine the query.
+- [x] LRU refusal labelled as best-effort (not a security boundary);
+  HMAC TTL is the binding constraint.
+- [x] Multi-process cursor scope addressed (per-process secret;
+  future cross-process derivation out of scope).
+- [x] `verbose`-newly-set bypasses identical-query refusal so agents
+  can upgrade snippet → full content without a refusal loop.
+- [x] `query_graph` cursor wrapping uses subquery rewrite, not regex
+  on caller SQL — no comment/CTE/UNION edge cases.
+- [x] Tool-specific ORDER BY rows match current code as of 2026-05-10
+  (verified against `mcp-server/src/sqlite-reader.ts`); each cursor
+  PR adds an explicit `id ASC` tiebreaker.
+- [x] Compatibility section names the breaking change
+  (`query_graph` subquery wrap) and proposes mitigation in PR 8.
+- [x] Out-of-scope acknowledges `get_note`'s unbounded body return.
 - [x] No `TBD` / `<fill>` placeholders left in this document.

--- a/docs/superpowers/specs/2026-05-04-mcp-context-efficiency.md
+++ b/docs/superpowers/specs/2026-05-04-mcp-context-efficiency.md
@@ -1,0 +1,277 @@
+# MCP Context Efficiency — Design Spec
+
+**Tracks:** [yibeichan/schist#50](https://github.com/yibeichan/schist/issues/50)
+**Implementation plan:** `docs/superpowers/plans/2026-05-04-mcp-context-efficiency.md`
+**Audit baseline:** `docs/superpowers/specs/audit-2026-05-04-mcp-response-sizes.md`
+
+This spec is the contract every implementation PR (2–8 in the rollout
+plan) references during review. It locks in protocol decisions before
+any tool changes.
+
+---
+
+## Goal
+
+Reduce agent context burn from MCP tool responses, especially as the
+vault grows. Adopt cursor-based pagination and reason-string opt-ins so
+agents can't fall back to default-bloat behavior.
+
+The 2026-05-10 audit established the targets. `query_graph` and
+`search_memory` together account for >270KB / >70K tokens of single-call
+worst case on a 70-doc vault — both will scale linearly with the corpus
+and clear typical context limits within a few hundred docs.
+
+---
+
+## Core principles
+
+> **Enforcement belongs in the protocol, not the prompt.** Agents take
+> the path of least resistance — passive hints get ignored, boolean
+> opt-ins drift toward always-on. (m13v on #50, schist memory #67.)
+
+Two operational consequences:
+
+1. **Cursor tokens, not truncation flags.** When results are capped,
+   return a structured cursor that must be consumed to advance. The
+   server stores recent `(queryHash, owner)` pairs and refuses to
+   re-serve identical queries without cursor consumption — blind retries
+   become *structurally* impossible, not just discouraged.
+
+2. **Reason strings, not boolean opt-ins.** Where verbose / full-body
+   access is needed, gate it behind `verbose: "<reason string>"` instead
+   of `verbose: true`. Adds friction against lazy default-creep and
+   produces an auditable log of when expensive paths are actually used.
+
+Everything below is the concrete protocol implementing these two
+principles.
+
+---
+
+## Cursor protocol
+
+### Token shape
+
+A cursor is an opaque-to-the-agent, HMAC-signed JSON payload. The
+server emits it as a single base64url string in the response. Agents
+echo it back verbatim on the follow-up call.
+
+The signed payload (before encoding) is:
+
+```json
+{
+  "tool": "search_notes",
+  "queryHash": "<sha256 hex of canonicalized (args + owner)>",
+  "offset": 20,
+  "issuedAt": 1717459200,
+  "ttlSeconds": 300
+}
+```
+
+- **`tool`**: the tool that issued the cursor. Refused if presented to
+  any other tool — prevents cross-tool cursor reuse.
+- **`queryHash`**: SHA-256 of the canonical-JSON serialization of the
+  call's normalized arguments plus the active owner. Tool-specific
+  details below.
+- **`offset`**: zero-indexed position the cursor advances to (i.e. the
+  first row of the *next* page).
+- **`issuedAt`**: unix seconds; cursor age is checked against
+  `ttlSeconds` on every redemption.
+- **`ttlSeconds`**: fixed at **300** for all cursors (locked decision).
+
+Encoded as `base64url(payload) + "." + base64url(hmac_sha256(secret, payload))`.
+
+The HMAC secret is **per-process, regenerated on every server start**
+(locked decision). Cursors do not survive `mcp-server` restarts; agents
+hitting an expired/invalid cursor get a structured error and start over
+from page 1. This is acceptable because cursor TTL is 300s anyway.
+
+### queryHash canonicalization
+
+To make the hash stable across argument-order variations and JSON
+formatting, every tool computes:
+
+```
+queryHash = sha256(
+  JSON.stringify(
+    sortKeys({ ...normalizedArgs, _owner: ownerOrEmptyString })
+  )
+)
+```
+
+Where `normalizedArgs`:
+- excludes the `cursor` field (which is meta, not part of the query
+  identity);
+- excludes any `verbose` field (verbose changes the *response shape*,
+  not the *query identity* — we want both verbose and non-verbose
+  re-issues of the same query to count as identical);
+- normalizes string-vs-undefined for optional fields (omitted ↔ empty
+  ↔ null all collapse to omitted);
+- normalizes number ranges where applicable (e.g. `limit: 0` ↔
+  `limit: undefined`).
+
+`sortKeys` is a recursive deep-sort so `{a:1,b:2}` and `{b:2,a:1}` hash
+identically.
+
+### Server-side identical-query refusal
+
+When a tool returns a cursor (i.e. results were capped), the server
+stores `(tool, queryHash, owner, issuedAt, lastCursor)` in an in-memory
+LRU (size 256). On a subsequent call:
+
+| Condition | Behavior |
+|-----------|----------|
+| Same `(tool, queryHash, owner)` within `ttlSeconds`, NO cursor passed | Return `{ error: "CURSOR_REQUIRED", message: "Identical query within ${ttl}s — pass cursor or refine.", cursor: <reissued token> }`. Agent must consume the cursor to advance, OR change at least one query argument. |
+| Same `(tool, queryHash, owner)`, cursor passed and validated | Serve next page; advance LRU entry's `offset`. |
+| Different `queryHash` (refined query) | Treat as a new query; previous cursor expires from LRU naturally. |
+| TTL expired | Treat as new query; emit a soft `cursorNote: "previous cursor expired after Xs"` field in the response so agents can debug. |
+
+LRU is in-process Map with size cap 256 and explicit per-call expiry
+sweep. Cleared on process restart (acceptable — cursors are TTL-bound
+to 300s anyway).
+
+### Tool-specific cursor adoption
+
+| Tool | `queryHash` includes | `offset` semantics | Next-page SQL shape |
+|------|----------------------|--------------------|----------------------|
+| `search_notes` | `query`, `limit`, `tags?`, `status?`, `owner` | Row offset into the FTS5 result set, ordered by FTS5 rank then `date DESC`. | Existing `search_notes` SQL + `LIMIT :limit OFFSET :offset`. |
+| `search_memory` | `query?`, `owner?`, `entry_type?`, `date_from?`, `date_to?`, `limit`, ownerOrEmpty | Row offset into the memory result set, ordered by `date DESC, id DESC`. | Existing memory query + `LIMIT :limit OFFSET :offset`. |
+| `query_graph` | normalized SQL string, `params?`, ownerOrEmpty | Row offset; SQL gets `LIMIT :limit OFFSET :offset` *injected* when not present (see "Default limits" below). | Caller's SQL with server-managed `LIMIT/OFFSET` appended. |
+| `list_concepts` | `q?`, `domain?`, `limit`, ownerOrEmpty | Row offset, ordered by `slug ASC`. | Existing `list_concepts` SQL + `LIMIT :limit OFFSET :offset`. |
+| `list_domains` | `limit`, ownerOrEmpty | Row offset, ordered by `slug ASC`. | Domains query + `LIMIT :limit OFFSET :offset`. |
+
+`get_note` does NOT use cursors — it's an explicit single-doc fetch.
+`get_context` does NOT use cursors — its response is a fixed-shape
+summary, not a paginated list.
+
+---
+
+## Reason-string verbose
+
+Tools that have a "give me more" mode replace `verbose: boolean` with
+`verbose: string`.
+
+**Validation rules (locked):**
+
+- The string must be **≥ 12 characters** after trimming whitespace.
+  Rejects lazy `verbose: "x"` workarounds while still allowing a short
+  but meaningful reason like `"need full body for code review"`.
+- The string is logged to the MCP server's stderr at INFO level:
+  `[verbose] <tool> by <owner|anonymous>: <reason>`. Provides an
+  auditable trail of when expensive paths actually fire.
+- Empty string, whitespace-only string, or omitted field → not verbose.
+  No silent fallback; `verbose: true` (boolean) is rejected as a type
+  error so callers can't accidentally re-introduce the boolean pattern.
+
+**Tools adopting reason-string verbose (locked):**
+
+- **`get_context`** for `depth: "full"` — currently `full` triggers
+  `tagCloud` computation. Without a reason, the server downgrades to
+  `standard` and emits a soft hint. Gating is cheap and the cost is
+  computational, not just bytes.
+- **`search_memory`** for full-content return. Default response carries
+  a content snippet (first ~200 chars). Full `content` field requires
+  `verbose: "<reason ≥12 chars>"`.
+
+**Tools deliberately excluded:**
+
+- **`search_notes`** does not need verbose. Full bodies are obtained
+  via `get_note`, which is already an explicit two-step protocol — the
+  better pattern than a verbose flag.
+- All `list_*` and `query_graph` tools — their response shape is the
+  natural unit; "verbose mode" doesn't make sense semantically.
+
+---
+
+## Default limits
+
+| Tool | Current default | Proposed default | Caller cap | Reasoning |
+|------|-----------------|------------------|------------|-----------|
+| `search_notes` | `limit: 20` | `limit: 20` (unchanged) | 100 | Already healthy at the audit-baseline corpus (8KB/2K tokens). |
+| `list_concepts` | `limit: 50` | `limit: 50` (unchanged) | 200 | Already healthy (4KB/1K tokens at 25 concepts). |
+| `list_domains` | **no limit** | **`limit: 100`** | 500 | Domains tend to be tiny but the unbounded default is a footgun for a vault that grows them. |
+| `query_graph` | **no default LIMIT** | **`LIMIT 100` injected when caller omits LIMIT** | **caller cap 1000** | Today `SELECT * FROM docs` is unbounded. Audit showed 241KB / 60K tokens on a 70-doc vault. Linear scaling makes this the highest-priority change. **⚠️ This is a behavior change** — see Compatibility below. |
+| `get_context` | tiered (minimal / standard / full) | tiered, `full` requires verbose reason | n/a | Tiering is fine; the cost of `full` is the tagCloud computation, gated via reason-string. |
+| `search_memory` | `limit: 50`, full content | `limit: 50`, snippet content; full content requires verbose reason | 200 | 41KB/10K tokens dropped to ~12KB/3K tokens estimated under snippet mode. |
+
+`get_note` has no `limit` (single doc fetch by ID) and is unchanged.
+
+---
+
+## Compatibility / migration
+
+### What stays the same
+
+- Existing MCP clients call these tools without `cursor` and without
+  `verbose`. Both fields are added as **optional inputs** in
+  tool-registry schemas, so unaware callers continue working.
+- All response shapes get a new optional `cursor` field. Clients that
+  ignore it get the first page only — same as today's truncated-by-limit
+  behavior.
+
+### The breaking change
+
+There is exactly **one** user-visible breaking change:
+
+- **`query_graph` injecting `LIMIT 100` when caller omits LIMIT.**
+  Today, a caller running `SELECT * FROM docs` on a 1000-doc vault
+  gets 1000 rows. Post-PR-4, the same call gets 100 rows + a cursor.
+  Power users who included `LIMIT 5000` get capped at 1000.
+
+The `CURSOR_REQUIRED` error is *technically* also new behavior — but
+it only triggers when an agent retries an identical query within 300s
+without consuming the cursor. That pattern is the agent bug we want to
+fail loudly, not graceful behavior we want to preserve.
+
+### Migration steps (PR 8)
+
+- Update every tool's `description` string in `tool-registry.ts` to
+  mention pagination and (where relevant) reason-string verbose, so
+  agents read the new contract from the input schema itself.
+- Update `docs/mcp-setup.md` with the new convention, including a
+  worked example of cursor consumption and a callout for the
+  `query_graph` LIMIT change.
+- Call out the `query_graph` change explicitly in the PR 4 commit
+  message and in release notes.
+
+---
+
+## Out-of-scope for this rollout
+
+Calling these out so future readers know they were considered and
+deliberately excluded:
+
+- **Authentication / authorization changes.** The existing capability
+  gate already covers writes; cursors are read-side only.
+- **Streaming responses.** Would require MCP protocol-level changes.
+- **Cross-session caching.** Cursors are per-process by design (locked
+  decision #2). Persistent caching is orthogonal to context efficiency.
+- **Cursor durability across server restart.** TTL is 300s and the
+  HMAC secret rotates per process; agents handle restart by re-running
+  page 1.
+- **Modifying `get_note`'s contract.** Single-doc fetches are
+  intentionally explicit.
+
+---
+
+## Self-review checklist
+
+Used to validate the spec before opening PR 1:
+
+- [x] Every implementation PR (2–8) has a section it can point at:
+  - PR 2 → "Cursor protocol" + "Reason-string verbose" (defines what
+    the shared modules expose).
+  - PR 3 → "search_memory" rows in cursor-adoption table + Default
+    limits + Reason-string adopters.
+  - PR 4 → "query_graph" rows + Default limits + Compatibility
+    breaking change.
+  - PR 5 → "search_notes" rows in cursor-adoption table.
+  - PR 6 → "list_concepts" + "list_domains" rows + Default limits.
+  - PR 7 → "get_context" reason-string adopters.
+  - PR 8 → "Migration steps" section.
+- [x] Cursor format specified concretely enough for PR 2 to implement
+  from the spec alone.
+- [x] Reason-string rules unambiguous: ≥12 chars after trim, logged
+  to stderr, no silent fallback, boolean rejected.
+- [x] Compatibility section names the breaking change (query_graph
+  default LIMIT) explicitly and proposes mitigation in PR 8.
+- [x] No `TBD` / `<fill>` placeholders left in this document.

--- a/docs/superpowers/specs/audit-2026-05-04-mcp-response-sizes.md
+++ b/docs/superpowers/specs/audit-2026-05-04-mcp-response-sizes.md
@@ -1,0 +1,84 @@
+# MCP Tool Response Size Audit — 2026-05-04 Baseline
+
+**Vault audited:** `~/schist-vault` (HPC spoke, post-flatten)
+**Audit script:** `scripts/audit_mcp_response_sizes.ts`
+**Reproduce:** `cd mcp-server && npm run audit -- --vault <path> [--search-query <q>]`
+
+This file is the canonical historical record of MCP tool response sizes.
+**Append new dated tables, do not overwrite.** Each implementation PR (3–7
+in the rollout plan) re-runs the audit and appends its post-change numbers
+so the rollout's effect is visible in one diff.
+
+## 2026-05-10 — pre-rollout baseline
+
+| Tool | Bytes | ≈ Tokens | Entries | Notes |
+|------|-------|----------|---------|-------|
+| `search_notes` (query="session") | 8,346 | 2,087 | 20 | FTS5 snippet, default `limit: 20` (cap hit) |
+| `list_concepts` (no opts) | 3,946 | 987 | 25 | Default `limit: 50`; corpus has 25 concepts so all fit |
+| `list_domains` (no opts) | 2 | 1 | 0 | **No limit.** Returned `[]` — vault.yaml has no `domains:` block |
+| `query_graph` (`SELECT * FROM docs`) | **241,756** | **60,439** | 1 (array of rows) | **No default LIMIT.** 70-doc vault → ~245KB blob; ≈60K tokens |
+| `get_context` (minimal) | 49 | 12 | 1 | Counts only |
+| `get_context` (standard) | 1,864 | 466 | 1 | + `recent` + `hotConcepts` |
+| `get_context` (full) | 2,788 | 697 | 1 | + `tagCloud` (top 30 tags) |
+| `search_memory` (limit=50) | **41,023** | **10,256** | 50 | **Returns full `content` field**, ~820 B/entry on this corpus |
+
+## Per-tool observations
+
+- **`query_graph` is the worst-case footgun.** A 70-doc vault produces a
+  ~245KB response (~60K tokens — about 30% of an Opus 200K context window
+  in one tool call). At 700 docs the same query would clear 2.4MB / 600K
+  tokens, exceeding any current LLM context. PR 4 must default-LIMIT this
+  to 100 and cap caller `LIMIT` at 1000.
+
+- **`search_memory` is the second-highest target.** 50 entries × ~820 B
+  = 41KB / 10K tokens per call. The full `content` field is the bulk —
+  most query patterns only need a snippet to triage relevance. PR 3
+  switches default to a snippet (~200 chars) and gates full content
+  behind a `verbose: "<reason>"` opt-in.
+
+- **`search_notes` is already in good shape** at the corpus level (`limit: 20`
+  + FTS5 snippets keep one call to ~8KB / ~2K tokens). PR 5's job is just
+  cursor pagination + identical-query refusal; no shape change.
+
+- **`list_concepts` is fine** at 4KB / ~1K tokens for 25 entries. The 50-cap
+  is comfortable headroom; cursor support arrives in PR 6 for vaults that
+  grow past 50 concepts.
+
+- **`list_domains` returned an empty array** because `~/schist-vault/vault.yaml`
+  has no top-level `domains:` block. The 2-byte response (`[]`) is real data,
+  not an error envelope. PR 6 still adds a default `limit: 100` so the
+  unbounded-by-default case can't bite a vault that grows domains later.
+
+- **`get_context` is healthy across all depths.** `minimal` (49 B) is the
+  obvious agent-default; `standard` (1.8KB) is reasonable; `full` (2.8KB)
+  adds tagCloud. PR 7 gates `full` behind a reason string — the cost
+  isn't the byte size, it's the tagCloud computation itself, which we
+  don't want defaulted on.
+
+## Reproduction notes
+
+- **Vault corpus at audit time:** `docs: 70 · concepts: 25 · edges: 21`
+  (from `SELECT (SELECT COUNT(*) FROM docs), (SELECT COUNT(*) FROM concepts), (SELECT COUNT(*) FROM edges)` against the live `.schist/schist.db`).
+- **Memory DB at audit time:** ≥50 entries (default `limit: 50` was hit).
+- **Branch HEAD (mcp-server):** `0208fa7` (`feat(audit): make search_notes
+  query configurable via --search-query`).
+- **Node version:** v22.16.0.
+- **Platform:** RHEL 8 ORCD HPC node. Required env override:
+  `LD_LIBRARY_PATH=/orcd/software/core/001/spack/pkg/gcc/12.2.0/yt6vabm/lib64:$LD_LIBRARY_PATH`
+  to load `better-sqlite3`'s prebuilt binary (system libstdc++ only ships
+  through `GLIBCXX_3.4.25`; binding needs `GLIBCXX_3.4.29`). CI on stock
+  Linux x86_64 doesn't need this.
+- **Search query for `search_notes`:** `"session"` — chosen because it
+  hits ≥20 notes in this vault and exercises the FTS5 cap.
+
+## Re-audit checklist (for PRs 3–7)
+
+After each implementation PR, append a dated section to this file:
+
+```
+## YYYY-MM-DD — after PR <N> (<scope>)
+```
+
+Re-run the same command (same vault, same `--search-query`) and tabulate
+the deltas next to the 2026-05-10 baseline. Highlight any tool that grew
+unexpectedly — efficiency PRs should never make response sizes worse.

--- a/docs/superpowers/specs/audit-2026-05-04-mcp-response-sizes.md
+++ b/docs/superpowers/specs/audit-2026-05-04-mcp-response-sizes.md
@@ -11,57 +11,72 @@ so the rollout's effect is visible in one diff.
 
 ## 2026-05-10 — pre-rollout baseline
 
-| Tool | Bytes | ≈ Tokens | Entries | Notes |
-|------|-------|----------|---------|-------|
-| `search_notes` (query="session") | 8,346 | 2,087 | 20 | FTS5 snippet, default `limit: 20` (cap hit) |
-| `list_concepts` (no opts) | 3,946 | 987 | 25 | Default `limit: 50`; corpus has 25 concepts so all fit |
+| Tool | Bytes | Tokens | Entries | Notes |
+|------|-------|--------|---------|-------|
+| `search_notes` (query="session") | 8,346 | 2,357 | 20 | FTS5 snippet, default `limit: 20` (cap hit) |
+| `list_concepts` (no opts) | 3,946 | 965 | 25 | Default `limit: 50`; corpus has 25 concepts so all fit |
 | `list_domains` (no opts) | 2 | 1 | 0 | **No limit.** Returned `[]` — vault.yaml has no `domains:` block |
-| `query_graph` (`SELECT * FROM docs`) | **241,756** | **60,439** | 1 (array of rows) | **No default LIMIT.** 70-doc vault → ~245KB blob; ≈60K tokens |
-| `get_context` (minimal) | 49 | 12 | 1 | Counts only |
-| `get_context` (standard) | 1,864 | 466 | 1 | + `recent` + `hotConcepts` |
-| `get_context` (full) | 2,788 | 697 | 1 | + `tagCloud` (top 30 tags) |
-| `search_memory` (limit=50) | **41,023** | **10,256** | 50 | **Returns full `content` field**, ~820 B/entry on this corpus |
+| `query_graph` (`SELECT * FROM docs`) | **241,756** | **64,284** | 1 (array of rows) | **No default LIMIT.** 70-doc vault → ~245KB blob; ≈64K tokens |
+| `get_context` (minimal) | 49 | 16 | 1 | Counts only |
+| `get_context` (standard) | 1,864 | 596 | 1 | + `recent` + `hotConcepts` |
+| `get_context` (full) | 2,788 | 879 | 1 | + `tagCloud` (top 30 tags) |
+| `search_memory` (limit=50) | **41,755** | **10,620** | 50 | **Returns full `content` field**, ~835 B/entry on this corpus |
+
+Tokens are counted via `gpt-tokenizer` (`o200k_base`, GPT-4o's BPE).
+Anthropic's tokenizer isn't available as a local library; `o200k_base`
+is a close proxy — typically within ±10% of Claude's count for English /
+JSON text. The audit's purpose is relative sizing across tools, where
+this proxy is more than accurate enough.
 
 ## Per-tool observations
 
 - **`query_graph` is the worst-case footgun.** A 70-doc vault produces a
-  ~245KB response (~60K tokens — about 30% of an Opus 200K context window
-  in one tool call). At 700 docs the same query would clear 2.4MB / 600K
-  tokens, exceeding any current LLM context. PR 4 must default-LIMIT this
-  to 100 and cap caller `LIMIT` at 1000.
+  ~245KB response (~64K tokens — about 32% of an Opus 200K context
+  window in one tool call). At 700 docs the same query would clear
+  ~2.4MB / ~640K tokens, exceeding any current LLM context. PR 4 must
+  default-LIMIT this to 100 and cap caller `LIMIT` at 1000.
 
-- **`search_memory` is the second-highest target.** 50 entries × ~820 B
-  = 41KB / 10K tokens per call. The full `content` field is the bulk —
-  most query patterns only need a snippet to triage relevance. PR 3
-  switches default to a snippet (~200 chars) and gates full content
-  behind a `verbose: "<reason>"` opt-in.
+- **`search_memory` is the second-highest target.** 50 entries × ~835 B
+  = 42KB / ~10.6K tokens per call. The full `content` field is the
+  bulk — most query patterns only need a snippet to triage relevance.
+  PR 3 switches default to a snippet (~200 chars) and gates full
+  content behind a `verbose: "<reason>"` opt-in.
 
-- **`search_notes` is already in good shape** at the corpus level (`limit: 20`
-  + FTS5 snippets keep one call to ~8KB / ~2K tokens). PR 5's job is just
-  cursor pagination + identical-query refusal; no shape change.
+- **`search_notes` is already in good shape** at the corpus level
+  (`limit: 20` + FTS5 snippets keep one call to ~8KB / ~2.4K tokens).
+  PR 5's job is cursor pagination + identical-query refusal; no shape
+  change. PR 5 must also add a stable ORDER BY (today the query has none —
+  FTS5 rank ordering isn't deterministic enough for OFFSET pagination).
 
-- **`list_concepts` is fine** at 4KB / ~1K tokens for 25 entries. The 50-cap
-  is comfortable headroom; cursor support arrives in PR 6 for vaults that
-  grow past 50 concepts.
+- **`list_concepts` is fine** at 4KB / ~1K tokens for 25 entries. The
+  50-cap is comfortable headroom; cursor support arrives in PR 6 for
+  vaults that grow past 50 concepts. Current ORDER BY is `edgeCount DESC`
+  (not `slug ASC`); the spec's cursor-adoption table records that.
 
-- **`list_domains` returned an empty array** because `~/schist-vault/vault.yaml`
-  has no top-level `domains:` block. The 2-byte response (`[]`) is real data,
-  not an error envelope. PR 6 still adds a default `limit: 100` so the
-  unbounded-by-default case can't bite a vault that grows domains later.
+- **`list_domains` returned an empty array** (null observation). The
+  2-byte response (`[]`) is real data, not an error envelope —
+  `~/schist-vault/vault.yaml` simply has no top-level `domains:` block.
+  PR 6 still adds a default `limit: 100` so the unbounded-by-default
+  case can't bite a vault that grows domains later.
 
-- **`get_context` is healthy across all depths.** `minimal` (49 B) is the
-  obvious agent-default; `standard` (1.8KB) is reasonable; `full` (2.8KB)
-  adds tagCloud. PR 7 gates `full` behind a reason string — the cost
-  isn't the byte size, it's the tagCloud computation itself, which we
-  don't want defaulted on.
+- **`get_context` is healthy across all depths.** `minimal` (49 B) is
+  the obvious agent-default; `standard` (1.9KB) is reasonable; `full`
+  (2.8KB) adds tagCloud. PR 7 gates `full` behind a reason string —
+  the cost isn't the byte size, it's the tagCloud computation itself,
+  which we don't want defaulted on.
 
 ## Reproduction notes
 
 - **Vault corpus at audit time:** `docs: 70 · concepts: 25 · edges: 21`
   (from `SELECT (SELECT COUNT(*) FROM docs), (SELECT COUNT(*) FROM concepts), (SELECT COUNT(*) FROM edges)` against the live `.schist/schist.db`).
 - **Memory DB at audit time:** ≥50 entries (default `limit: 50` was hit).
-- **Branch HEAD (mcp-server):** `0208fa7` (`feat(audit): make search_notes
-  query configurable via --search-query`).
+- **Branch HEAD (mcp-server):** baseline finalized at the tokenizer-swap
+  commit; `search_memory` bytes will vary slightly across sessions if
+  memory entries are written between runs (this audit's 41,755 B
+  reflects four entries added on 2026-05-10 by the session that
+  produced this doc).
+- **Tokenizer:** `gpt-tokenizer` 3.4.0 (`o200k_base`), pure-JS, pinned
+  in `mcp-server/devDependencies`.
 - **Node version:** v22.16.0.
 - **Platform:** RHEL 8 ORCD HPC node. Required env override:
   `LD_LIBRARY_PATH=/orcd/software/core/001/spack/pkg/gcc/12.2.0/yt6vabm/lib64:$LD_LIBRARY_PATH`

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -23,6 +23,7 @@
         "@types/jest": "^30.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.6.0",
+        "gpt-tokenizer": "^3.4.0",
         "jest": "^30.3.0",
         "ts-jest": "^29.4.9",
         "tsx": "^4.21.0",
@@ -3506,6 +3507,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/gpt-tokenizer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/gpt-tokenizer/-/gpt-tokenizer-3.4.0.tgz",
+      "integrity": "sha512-wxFLnhIXTDjYebd9A9pGl3e31ZpSypbpIJSOswbgop5jLte/AsZVDvjlbEuVFlsqZixVKqbcoNmRlFDf6pz/UQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -25,10 +25,11 @@
         "@types/node": "^25.6.0",
         "jest": "^30.3.0",
         "ts-jest": "^29.4.9",
+        "tsx": "^4.21.0",
         "typescript": "^6.0.2"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -559,6 +560,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@hono/node-server": {
@@ -2527,6 +2970,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2967,6 +3452,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/github-from-package": {
@@ -4912,6 +5410,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -5648,6 +6156,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -38,7 +38,8 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
+    "audit": "tsx ../scripts/audit_mcp_response_sizes.ts"
   },
   "jest": {
     "preset": "ts-jest/presets/default-esm",
@@ -73,6 +74,7 @@
     "@types/node": "^25.6.0",
     "jest": "^30.3.0",
     "ts-jest": "^29.4.9",
+    "tsx": "^4.21.0",
     "typescript": "^6.0.2"
   },
   "bin": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -53,7 +53,8 @@
       "^.+\\.tsx?$": [
         "ts-jest",
         {
-          "useESM": true
+          "useESM": true,
+          "tsconfig": "tsconfig.test.json"
         }
       ]
     }

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -39,7 +39,7 @@
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
-    "audit": "tsx ../scripts/audit_mcp_response_sizes.ts"
+    "audit": "NODE_PATH=./node_modules tsx ../scripts/audit_mcp_response_sizes.ts"
   },
   "jest": {
     "preset": "ts-jest/presets/default-esm",
@@ -48,7 +48,8 @@
       ".ts"
     ],
     "moduleNameMapper": {
-      "^(\\.{1,2}/.*)\\.js$": "$1"
+      "^(\\.{1,2}/.*)\\.js$": "$1",
+      "^gpt-tokenizer$": "<rootDir>/node_modules/gpt-tokenizer/esm/main.js"
     },
     "transform": {
       "^.+\\.tsx?$": [
@@ -72,6 +73,7 @@
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.6.0",
+    "gpt-tokenizer": "^3.4.0",
     "jest": "^30.3.0",
     "ts-jest": "^29.4.9",
     "tsx": "^4.21.0",

--- a/mcp-server/tests/audit-script.test.ts
+++ b/mcp-server/tests/audit-script.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "@jest/globals";
 import { measureResponse, runAudit } from "../../scripts/audit_mcp_response_sizes.js";
+import { encode } from "gpt-tokenizer";
 import * as fs from "fs/promises";
 import * as path from "path";
 import * as os from "os";
@@ -12,10 +13,27 @@ describe("measureResponse", () => {
     expect(result.bytes).toBe(36);
   });
 
-  it("returns approximate token count using 4-bytes-per-token heuristic", () => {
+  it("returns a positive integer token count for non-empty responses", () => {
+    // We don't hardcode the count — that would couple the test to one
+    // specific tokenizer's BPE table. Instead assert the relationship
+    // we actually care about: tokens are positive, integer, and smaller
+    // than the byte count for any JSON-shaped ASCII content (BPE merges
+    // common substrings like `":"`, `","`, `"}"` into single tokens).
     const result = measureResponse({ a: "x".repeat(40) });
-    // {"a":"xxxx...xxxx"} = 48 bytes ≈ 12 tokens
-    expect(result.approxTokens).toBe(12);
+    expect(Number.isInteger(result.approxTokens)).toBe(true);
+    expect(result.approxTokens).toBeGreaterThan(0);
+    expect(result.approxTokens).toBeLessThan(result.bytes);
+  });
+
+  it("delegates to the configured tokenizer (gpt-tokenizer / o200k_base)", () => {
+    // Lock the wiring so a regression that silently reverts to bytes/4
+    // is caught. The tokenizer's exact value at any given input may
+    // shift across tokenizer-library versions, so we compute the
+    // expected value the same way the implementation does, rather than
+    // hardcoding a constant.
+    const payload = { id: "x", title: "y", snippet: "z" };
+    const expected = encode(JSON.stringify(payload)).length;
+    expect(measureResponse(payload).approxTokens).toBe(expected);
   });
 
   it("handles array responses (e.g. searchNotes return)", () => {

--- a/mcp-server/tests/audit-script.test.ts
+++ b/mcp-server/tests/audit-script.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "@jest/globals";
+import { measureResponse } from "../../scripts/audit_mcp_response_sizes.js";
+
+describe("measureResponse", () => {
+  it("returns byte length of JSON-serialized response", () => {
+    const result = measureResponse({ id: "x", title: "y", snippet: "z" });
+    // {"id":"x","title":"y","snippet":"z"} = 36 bytes
+    expect(result.bytes).toBe(36);
+  });
+
+  it("returns approximate token count using 4-bytes-per-token heuristic", () => {
+    const result = measureResponse({ a: "x".repeat(40) });
+    // {"a":"xxxx...xxxx"} = 48 bytes ≈ 12 tokens
+    expect(result.approxTokens).toBe(12);
+  });
+
+  it("handles array responses (e.g. searchNotes return)", () => {
+    const result = measureResponse([{ id: "a" }, { id: "b" }]);
+    // [{"id":"a"},{"id":"b"}] = 23 bytes
+    expect(result.bytes).toBe(23);
+    expect(result.entryCount).toBe(2);
+  });
+
+  it("reports entryCount: 1 for non-array responses", () => {
+    const result = measureResponse({ noteCount: 0 });
+    expect(result.entryCount).toBe(1);
+  });
+});

--- a/mcp-server/tests/audit-script.test.ts
+++ b/mcp-server/tests/audit-script.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "@jest/globals";
-import { measureResponse } from "../../scripts/audit_mcp_response_sizes.js";
+import { describe, it, expect, beforeAll, afterAll } from "@jest/globals";
+import { measureResponse, runAudit } from "../../scripts/audit_mcp_response_sizes.js";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+import { execSync } from "child_process";
 
 describe("measureResponse", () => {
   it("returns byte length of JSON-serialized response", () => {
@@ -24,5 +28,86 @@ describe("measureResponse", () => {
   it("reports entryCount: 1 for non-array responses", () => {
     const result = measureResponse({ noteCount: 0 });
     expect(result.entryCount).toBe(1);
+  });
+});
+
+describe("runAudit (end-to-end)", () => {
+  let tmpVault: string;
+  let tmpMemoryDb: string;
+  let originalMemoryDb: string | undefined;
+
+  beforeAll(async () => {
+    tmpVault = await fs.mkdtemp(path.join(os.tmpdir(), "schist-audit-"));
+    tmpMemoryDb = path.join(tmpVault, "agent-state.db");
+
+    // Isolate the memory DB so the test never touches the user's real
+    // ~/.openclaw/memory/agent-state.db. Stash the prior value so afterAll
+    // can restore the env exactly as we found it.
+    originalMemoryDb = process.env.SCHIST_MEMORY_DB;
+    process.env.SCHIST_MEMORY_DB = tmpMemoryDb;
+
+    execSync(`schist init ${tmpVault} --name audit-test`, { stdio: "pipe" });
+    for (let i = 0; i < 5; i++) {
+      const noteFile = path.join(tmpVault, "notes", `2026-05-04-fixture-${i}.md`);
+      await fs.mkdir(path.dirname(noteFile), { recursive: true });
+      await fs.writeFile(
+        noteFile,
+        `---\ntitle: Fixture ${i}\ndate: 2026-05-04\nstatus: draft\ntags: [audit]\n---\n\nBody for fixture note ${i}, ${"x".repeat(200)}.\n`
+      );
+    }
+    execSync(`git -C ${tmpVault} add -A && git -C ${tmpVault} commit -m fixtures`, { stdio: "pipe" });
+    execSync(`schist-ingest --vault ${tmpVault} --db ${tmpVault}/.schist/schist.db`, { stdio: "pipe" });
+  });
+
+  afterAll(async () => {
+    if (originalMemoryDb === undefined) delete process.env.SCHIST_MEMORY_DB;
+    else process.env.SCHIST_MEMORY_DB = originalMemoryDb;
+    await fs.rm(tmpVault, { recursive: true, force: true });
+  });
+
+  it("produces a report covering every tool in the audit set", async () => {
+    const report = await runAudit({ vault: tmpVault });
+    expect(report.tools).toEqual(
+      expect.arrayContaining([
+        "search_notes",
+        "list_concepts",
+        "list_domains",
+        "query_graph",
+        "get_context_minimal",
+        "get_context_standard",
+        "get_context_full",
+        "search_memory",
+      ])
+    );
+  });
+
+  it("reports search_notes byte count > 0 against fixture vault", async () => {
+    const report = await runAudit({ vault: tmpVault });
+    const sn = report.measurements.search_notes;
+    expect(sn.bytes).toBeGreaterThan(0);
+    expect(sn.entryCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("returns non-error responses for read-side tools (catches broken native bindings)", async () => {
+    // Without this, the audit "succeeds" even when better-sqlite3 fails to
+    // load and every tool returns { error, message } — measureResponse
+    // dutifully measures the error envelope and bytes>0/entryCount>=1
+    // both still pass. Probe two read tools that should always return
+    // arrays on a fresh fixture vault.
+    const tools = await import("../../mcp-server/dist/tools.js");
+    const probes: Array<[string, unknown]> = [
+      ["list_concepts", await tools.list_concepts(tmpVault, {})],
+      ["list_domains", await tools.list_domains(tmpVault, {})],
+    ];
+    for (const [name, resp] of probes) {
+      if (resp && typeof resp === "object" && "error" in resp) {
+        const err = resp as { error: string; message?: string };
+        throw new Error(
+          `${name} returned error envelope, indicating a broken sqlite stack: ` +
+          `${err.error}: ${err.message ?? ""}`
+        );
+      }
+      expect(Array.isArray(resp)).toBe(true);
+    }
   });
 });

--- a/mcp-server/tests/audit-script.test.ts
+++ b/mcp-server/tests/audit-script.test.ts
@@ -34,19 +34,36 @@ describe("measureResponse", () => {
 describe("runAudit (end-to-end)", () => {
   let tmpVault: string;
   let tmpMemoryDb: string;
-  let originalMemoryDb: string | undefined;
+  // Snapshot of any SCHIST_* env vars present at suite start. Restored
+  // verbatim in afterAll so the suite is hermetic against the surrounding
+  // shell (developer machines often have SCHIST_AGENT_NAME / SCHIST_IDENTITY
+  // set; without isolation those leak into searchNotes scope-inherit, the
+  // ingest script's identity resolution, etc).
+  const schistEnvKeys = [
+    "SCHIST_AGENT_ID",
+    "SCHIST_AGENT_NAME",
+    "SCHIST_IDENTITY",
+    "SCHIST_INGEST_SCRIPT",
+    "SCHIST_MEMORY_DB",
+    "SCHIST_VAULT_PATH",
+  ] as const;
+  const originalEnv: Record<string, string | undefined> = {};
+
+  // Inherit stderr so ENOENT / permission errors from the spawned schist /
+  // schist-ingest binaries surface in the test output instead of being
+  // swallowed by the failed-execSync wrapper.
+  const stdio: ["pipe", "pipe", "inherit"] = ["pipe", "pipe", "inherit"];
 
   beforeAll(async () => {
+    for (const k of schistEnvKeys) {
+      originalEnv[k] = process.env[k];
+      delete process.env[k];
+    }
     tmpVault = await fs.mkdtemp(path.join(os.tmpdir(), "schist-audit-"));
     tmpMemoryDb = path.join(tmpVault, "agent-state.db");
-
-    // Isolate the memory DB so the test never touches the user's real
-    // ~/.openclaw/memory/agent-state.db. Stash the prior value so afterAll
-    // can restore the env exactly as we found it.
-    originalMemoryDb = process.env.SCHIST_MEMORY_DB;
     process.env.SCHIST_MEMORY_DB = tmpMemoryDb;
 
-    execSync(`schist init ${tmpVault} --name audit-test`, { stdio: "pipe" });
+    execSync(`schist init ${tmpVault} --name audit-test`, { stdio });
     for (let i = 0; i < 5; i++) {
       const noteFile = path.join(tmpVault, "notes", `2026-05-04-fixture-${i}.md`);
       await fs.mkdir(path.dirname(noteFile), { recursive: true });
@@ -55,13 +72,15 @@ describe("runAudit (end-to-end)", () => {
         `---\ntitle: Fixture ${i}\ndate: 2026-05-04\nstatus: draft\ntags: [audit]\n---\n\nBody for fixture note ${i}, ${"x".repeat(200)}.\n`
       );
     }
-    execSync(`git -C ${tmpVault} add -A && git -C ${tmpVault} commit -m fixtures`, { stdio: "pipe" });
-    execSync(`schist-ingest --vault ${tmpVault} --db ${tmpVault}/.schist/schist.db`, { stdio: "pipe" });
+    execSync(`git -C ${tmpVault} add -A && git -C ${tmpVault} commit -m fixtures`, { stdio });
+    execSync(`schist-ingest --vault ${tmpVault} --db ${tmpVault}/.schist/schist.db`, { stdio });
   });
 
   afterAll(async () => {
-    if (originalMemoryDb === undefined) delete process.env.SCHIST_MEMORY_DB;
-    else process.env.SCHIST_MEMORY_DB = originalMemoryDb;
+    for (const k of schistEnvKeys) {
+      if (originalEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = originalEnv[k];
+    }
     await fs.rm(tmpVault, { recursive: true, force: true });
   });
 
@@ -92,14 +111,23 @@ describe("runAudit (end-to-end)", () => {
     // Without this, the audit "succeeds" even when better-sqlite3 fails to
     // load and every tool returns { error, message } — measureResponse
     // dutifully measures the error envelope and bytes>0/entryCount>=1
-    // both still pass. Probe two read tools that should always return
-    // arrays on a fresh fixture vault.
+    // both still pass. Probe one tool per distinct DB / executor path so
+    // a broken binding can't silently fail any subset:
+    //   - list_concepts / list_domains / search_memory: array return
+    //   - query_graph:                                   { columns, rows, rowCount }
+    //   - search_memory:                                  separate memory DB file
     const tools = await import("../../mcp-server/dist/tools.js");
-    const probes: Array<[string, unknown]> = [
-      ["list_concepts", await tools.list_concepts(tmpVault, {})],
-      ["list_domains", await tools.list_domains(tmpVault, {})],
+    type ShapeCheck = (resp: unknown) => boolean;
+    const isArrayShape: ShapeCheck = (r) => Array.isArray(r);
+    const isQueryGraphShape: ShapeCheck = (r) =>
+      !!r && typeof r === "object" && Array.isArray((r as { rows?: unknown }).rows);
+    const probes: Array<[string, unknown, ShapeCheck]> = [
+      ["list_concepts", await tools.list_concepts(tmpVault, {}), isArrayShape],
+      ["list_domains", await tools.list_domains(tmpVault, {}), isArrayShape],
+      ["query_graph", await tools.query_graph(tmpVault, { sql: "SELECT 1 AS x" }), isQueryGraphShape],
+      ["search_memory", await tools.search_memory(tmpVault, { limit: 1 }), isArrayShape],
     ];
-    for (const [name, resp] of probes) {
+    for (const [name, resp, shapeOk] of probes) {
       if (resp && typeof resp === "object" && "error" in resp) {
         const err = resp as { error: string; message?: string };
         throw new Error(
@@ -107,7 +135,18 @@ describe("runAudit (end-to-end)", () => {
           `${err.error}: ${err.message ?? ""}`
         );
       }
-      expect(Array.isArray(resp)).toBe(true);
+      expect(shapeOk(resp)).toBe(true);
     }
+  });
+
+  it("honors searchQuery override (not just the default)", async () => {
+    // The default "fixture" path is exercised by the two specs above. This
+    // pins the override pathway so a future refactor can't silently drop
+    // the parameter — e.g. by accidentally re-hardcoding "fixture" inside
+    // runAudit. The fixture corpus contains no "nonexistent-token-zzz"
+    // notes, so search_notes must return an empty result (0 entries) when
+    // the override is honored.
+    const report = await runAudit({ vault: tmpVault, searchQuery: "nonexistent-token-zzz" });
+    expect(report.measurements.search_notes.entryCount).toBe(0);
   });
 });

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "declaration": true,
     "types": ["node", "jest"]
   },
   "include": ["src/**/*"]

--- a/mcp-server/tsconfig.test.json
+++ b/mcp-server/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".."
+  },
+  "include": ["src/**/*", "tests/**/*", "../scripts/**/*"]
+}

--- a/mcp-server/tsconfig.test.json
+++ b/mcp-server/tsconfig.test.json
@@ -1,7 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": ".."
+    "rootDir": "..",
+    "baseUrl": ".",
+    "paths": {
+      "gpt-tokenizer": ["./node_modules/gpt-tokenizer"]
+    }
   },
   "include": ["src/**/*", "tests/**/*", "../scripts/**/*"]
 }

--- a/scripts/audit_mcp_response_sizes.ts
+++ b/scripts/audit_mcp_response_sizes.ts
@@ -25,4 +25,73 @@ export function measureResponse(response: unknown): ResponseMeasurement {
   return { bytes, approxTokens, entryCount };
 }
 
-// CLI driver appended in Task 1.3.
+import * as tools from "../mcp-server/dist/tools.js";
+
+export interface AuditReport {
+  vault: string;
+  generatedAt: string;
+  tools: string[];
+  measurements: Record<string, ResponseMeasurement>;
+}
+
+export async function runAudit(opts: { vault: string }): Promise<AuditReport> {
+  const measurements: Record<string, ResponseMeasurement> = {};
+
+  // search_notes — typical "find what I worked on" query.
+  measurements.search_notes = measureResponse(
+    await tools.search_notes(opts.vault, { query: "fixture" })
+  );
+
+  // list_concepts — default limit 50 in current code.
+  measurements.list_concepts = measureResponse(
+    await tools.list_concepts(opts.vault, {})
+  );
+
+  // list_domains — currently unbounded.
+  measurements.list_domains = measureResponse(
+    await tools.list_domains(opts.vault, {})
+  );
+
+  // query_graph — SELECT * FROM docs is the worst-case from #50.
+  measurements.query_graph = measureResponse(
+    await tools.query_graph(opts.vault, { sql: "SELECT * FROM docs" })
+  );
+
+  // get_context — measure all three depths so the spec sees deltas.
+  for (const depth of ["minimal", "standard", "full"] as const) {
+    measurements[`get_context_${depth}`] = measureResponse(
+      await tools.get_context(opts.vault, { depth })
+    );
+  }
+
+  // search_memory — default limit 50, returns full content (highest ROI target).
+  measurements.search_memory = measureResponse(
+    await tools.search_memory(opts.vault, { limit: 50 })
+  );
+
+  return {
+    vault: opts.vault,
+    generatedAt: new Date().toISOString(),
+    tools: Object.keys(measurements),
+    measurements,
+  };
+}
+
+// CLI entry. Only fires when the script is invoked directly (e.g. via the
+// mcp-server "audit" npm script); the test harness imports this module
+// without ever matching this URL.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const vaultIdx = process.argv.indexOf("--vault");
+  if (vaultIdx === -1) {
+    console.error("Usage: tsx scripts/audit_mcp_response_sizes.ts --vault <path>");
+    process.exit(2);
+  }
+  const vault = process.argv[vaultIdx + 1];
+  runAudit({ vault }).then(
+    (r) => console.log(JSON.stringify(r, null, 2)),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    }
+  );
+}

--- a/scripts/audit_mcp_response_sizes.ts
+++ b/scripts/audit_mcp_response_sizes.ts
@@ -7,9 +7,14 @@
  * Output: JSON report on stdout. Convert to a markdown table in
  * docs/superpowers/specs/audit-2026-05-04-mcp-response-sizes.md.
  *
- * The token approximation is intentionally crude (bytes/4). The point is
- * to compare relative sizes across tools, not to predict exact LLM cost.
+ * Tokens are counted via gpt-tokenizer (o200k_base, GPT-4o's BPE).
+ * Anthropic's tokenizer isn't available as a local library; o200k_base
+ * is a close proxy — typically within ±10% of Claude's count for
+ * English/JSON text. The point of the audit is relative sizing across
+ * tools, where this proxy is more than accurate enough.
  */
+
+import { encode } from "gpt-tokenizer";
 
 export interface ResponseMeasurement {
   bytes: number;
@@ -20,7 +25,7 @@ export interface ResponseMeasurement {
 export function measureResponse(response: unknown): ResponseMeasurement {
   const json = JSON.stringify(response);
   const bytes = Buffer.byteLength(json, "utf-8");
-  const approxTokens = Math.round(bytes / 4);
+  const approxTokens = encode(json).length;
   const entryCount = Array.isArray(response) ? response.length : 1;
   return { bytes, approxTokens, entryCount };
 }

--- a/scripts/audit_mcp_response_sizes.ts
+++ b/scripts/audit_mcp_response_sizes.ts
@@ -34,12 +34,18 @@ export interface AuditReport {
   measurements: Record<string, ResponseMeasurement>;
 }
 
-export async function runAudit(opts: { vault: string }): Promise<AuditReport> {
+export async function runAudit(opts: {
+  vault: string;
+  searchQuery?: string;
+}): Promise<AuditReport> {
   const measurements: Record<string, ResponseMeasurement> = {};
+  const searchQuery = opts.searchQuery ?? "fixture";
 
-  // search_notes — typical "find what I worked on" query.
+  // search_notes — typical "find what I worked on" query. The default
+  // hits the test-fixture corpus; live audits should pass a query
+  // representative of the target vault to exercise the FTS5 path.
   measurements.search_notes = measureResponse(
-    await tools.search_notes(opts.vault, { query: "fixture" })
+    await tools.search_notes(opts.vault, { query: searchQuery })
   );
 
   // list_concepts — default limit 50 in current code.
@@ -83,11 +89,15 @@ export async function runAudit(opts: { vault: string }): Promise<AuditReport> {
 if (import.meta.url === `file://${process.argv[1]}`) {
   const vaultIdx = process.argv.indexOf("--vault");
   if (vaultIdx === -1) {
-    console.error("Usage: tsx scripts/audit_mcp_response_sizes.ts --vault <path>");
+    console.error(
+      "Usage: tsx scripts/audit_mcp_response_sizes.ts --vault <path> [--search-query <q>]"
+    );
     process.exit(2);
   }
   const vault = process.argv[vaultIdx + 1];
-  runAudit({ vault }).then(
+  const sqIdx = process.argv.indexOf("--search-query");
+  const searchQuery = sqIdx === -1 ? undefined : process.argv[sqIdx + 1];
+  runAudit({ vault, searchQuery }).then(
     (r) => console.log(JSON.stringify(r, null, 2)),
     (err) => {
       console.error(err);

--- a/scripts/audit_mcp_response_sizes.ts
+++ b/scripts/audit_mcp_response_sizes.ts
@@ -1,0 +1,28 @@
+/**
+ * Reproducible audit of MCP tool response sizes.
+ *
+ * Usage (from repo root, via mcp-server's npm script):
+ *   cd mcp-server && npm run audit -- --vault <path>
+ *
+ * Output: JSON report on stdout. Convert to a markdown table in
+ * docs/superpowers/specs/audit-2026-05-04-mcp-response-sizes.md.
+ *
+ * The token approximation is intentionally crude (bytes/4). The point is
+ * to compare relative sizes across tools, not to predict exact LLM cost.
+ */
+
+export interface ResponseMeasurement {
+  bytes: number;
+  approxTokens: number;
+  entryCount: number;
+}
+
+export function measureResponse(response: unknown): ResponseMeasurement {
+  const json = JSON.stringify(response);
+  const bytes = Buffer.byteLength(json, "utf-8");
+  const approxTokens = Math.round(bytes / 4);
+  const entryCount = Array.isArray(response) ? response.length : 1;
+  return { bytes, approxTokens, entryCount };
+}
+
+// CLI driver appended in Task 1.3.


### PR DESCRIPTION
## Summary

PR 1 of the multi-PR #50 rollout. **No behavior change** — purely audit harness, baseline measurements, design spec, and the multi-PR rollout plan that PRs 2–8 reference.

- **Reproducible audit script** at `scripts/audit_mcp_response_sizes.ts` with byte/token measurements per MCP tool. Invoked via `cd mcp-server && npm run audit -- --vault <path>`. TDD'd against a fixture vault built from `schist init` + a few notes; integration tests hit a real DB (no mocks), per project convention.
- **2026-05-10 baseline** captured against the live HPC `~/schist-vault` (70 docs · 25 concepts · 21 edges) at `docs/superpowers/specs/audit-2026-05-04-mcp-response-sizes.md`. Headline numbers:
  - `query_graph` (`SELECT * FROM docs`): **241KB / ~60K tokens** — the worst-case footgun.
  - `search_memory` (limit=50, full content): **41KB / ~10K tokens**.
  - `search_notes` (cap hit at limit=20): 8KB / ~2K tokens.
  - All other tools healthy (≤4KB each).
- **Design spec** at `docs/superpowers/specs/2026-05-04-mcp-context-efficiency.md` locks the protocol contract: cursor token shape, queryHash canonicalization, server-side identical-query refusal, per-tool cursor adoption, reason-string verbose rules (≥12 chars after trim, stderr-logged, boolean rejected), and the one breaking change (`query_graph` default LIMIT 100 / caller cap 1000).
- **Multi-PR rollout plan** at `docs/superpowers/plans/2026-05-04-mcp-context-efficiency.md` covers PRs 2–8: shared infra (PR 2), then tool-family adoption (PRs 3–7), then migration notes (PR 8).

Built on m13v's #50 comment (schist memory entry #67): _enforcement belongs in the protocol, not the prompt_.

## Test plan

- [x] `npm test` in `mcp-server/` — 84 passed / 84
- [x] `uv run pytest cli/tests/` — 311 passed, 1 skipped
- [x] Audit script runs cleanly against a fresh fixture vault (covered by `tests/audit-script.test.ts`)
- [x] Audit script runs cleanly against the live HPC vault (results captured in the baseline doc)
- [x] Spec self-review: every PR 2–8 has a referenceable section (checklist at the bottom of the spec)

## HPC reproducer note

Audit was run on an ORCD HPC RHEL 8 node with `LD_LIBRARY_PATH` override for `better-sqlite3`'s prebuilt binary (`/lib64/libstdc++.so.6` ships through `GLIBCXX_3.4.25`; binding needs `GLIBCXX_3.4.29`). CI on stock Linux x86_64 doesn't need this. Documented in the baseline reproduction-notes section.

## Refs

Closes the audit + spec milestone of #50. Implementation lands in PR 2 onwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)