### PR TITLE
fix(verbose): strip ZWNJ/ZWJ/WORD-JOINER before min-length check (#60)

### DIFF
--- a/mcp-server/src/protocol/verbose.ts
+++ b/mcp-server/src/protocol/verbose.ts
@@ -47,9 +47,12 @@ export function parseVerbose(input: unknown): ParseVerboseResult {
     };
   }
   // Whitespace-only or empty → not verbose, no error.
-  // \s covers ASCII whitespace + NBSP (U+00A0); we also strip ZWS (U+200B)
-  // and BOM (U+FEFF) which are invisible but not matched by \s in V8.
-  const stripped = input.replace(/[​﻿]/gu, "");
+  // \s covers ASCII whitespace + NBSP (U+00A0); we also strip invisible
+  // format-class chars not matched by \s in V8:
+  //   U+200B ZWS, U+200C ZWNJ, U+200D ZWJ, U+2060 WORD JOINER, U+FEFF BOM.
+  // Strip before length check so a string of 12 ZWJs can't satisfy the
+  // ≥12 code-point gate with no actual rationale.
+  const stripped = input.replace(/[​-‍⁠﻿]/gu, "");
   if (/^\s*$/u.test(stripped)) return { enabled: false };
 
   const trimmed = stripped.trim();

--- a/mcp-server/tests/protocol/verbose.test.ts
+++ b/mcp-server/tests/protocol/verbose.test.ts
@@ -33,6 +33,18 @@ describe("parseVerbose — not-verbose paths (no error)", () => {
   it("returns enabled:false for BOM-only string (U+FEFF)", () => {
     expect(parseVerbose("﻿".repeat(12))).toEqual({ enabled: false });
   });
+
+  it("returns enabled:false for ZWNJ-only string (U+200C)", () => {
+    expect(parseVerbose("‌".repeat(12))).toEqual({ enabled: false });
+  });
+
+  it("returns enabled:false for ZWJ-only string (U+200D)", () => {
+    expect(parseVerbose("‍".repeat(12))).toEqual({ enabled: false });
+  });
+
+  it("returns enabled:false for WORD-JOINER-only string (U+2060)", () => {
+    expect(parseVerbose("⁠".repeat(12))).toEqual({ enabled: false });
+  });
 });
 
 describe("parseVerbose — INVALID_ARG paths", () => {
@@ -84,6 +96,21 @@ describe("parseVerbose — INVALID_ARG paths", () => {
 
   it("counts surrounding-whitespace-stripped length", () => {
     const r = parseVerbose("           hi          "); // padded
+    expect(r.enabled).toBe(false);
+    if ("error" in r) expect(r.error.error).toBe("INVALID_ARG");
+  });
+
+  it("rejects mixed visible+zero-width when stripped length is <12 (ZWJ padding)", () => {
+    // "foo" + 9 × U+200D — looks like 12 chars but strips to 3 visible.
+    const r = parseVerbose("foo" + "‍".repeat(9));
+    expect(r.enabled).toBe(false);
+    if ("error" in r) expect(r.error.error).toBe("INVALID_ARG");
+  });
+
+  it("rejects mixed visible+zero-width when stripped length is <12 (mixed Cf padding)", () => {
+    // 4 visible + 8 mixed zero-widths (ZWS, ZWNJ, ZWJ, WJ, BOM) = 12 surface chars,
+    // 4 after strip. Must fail the ≥12 gate.
+    const r = parseVerbose("real" + "​‌‍⁠﻿​‌‍");
     expect(r.enabled).toBe(false);
     if ("error" in r) expect(r.error.error).toBe("INVALID_ARG");
   });


### PR DESCRIPTION
## Summary
- Extend the verbose-reason invisible-char strip from {U+200B, U+FEFF} to {U+200B-U+200D, U+2060, U+FEFF}, closing the bypass where 12 ZWJs satisfied the ≥12 code-point gate with no real rationale (issue #60).
- After strip, pure-invisible inputs hit the existing whitespace-only short-circuit (\`enabled: false\`, no error). Mixed visible+invisible inputs whose visible portion is <12 chars fall to \`INVALID_ARG\`.
- 5 new tests covering ZWNJ-only, ZWJ-only, WJ-only, and two mixed-padding cases.

## Test plan
- [x] \`npm test\` — 193/193 passing (was 188/188; +5 new).
- [x] \`npm test -- --testPathPatterns=verbose\` — 41/41 in the verbose suite.
- [x] No consumer wiring exists yet (PR #59 was infra-only), so behavior change is internal-only — the gate is tighter, no caller-observable regression.

Closes #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)