### PR TITLE
fix(search): thread per-call owner through scope=inherit (#62)

### DIFF
--- a/docs/cross-project-memory.md
+++ b/docs/cross-project-memory.md
@@ -148,11 +148,22 @@ for vault writes (`sansan`, `eleven`, `claude`, etc.).
 `search_memory` can filter by owner, so cross-identity retrieval works if
 you need it.
 
-> **Read-path note (#62):** scope-inheritance for `search_notes` still
-> resolves the calling agent via `SCHIST_AGENT_NAME ?? SCHIST_AGENT_ID`.
-> Under a pure-allowlist deployment (only `SCHIST_ALLOWED_AGENTS` set),
-> scope-inherit searches fall back to `"global"`. Keep `SCHIST_AGENT_ID`
-> set per-process as a workaround until the read-path threading is fixed.
+> **Read-path identity (formerly #62):** `search_notes(scope: "inherit")`
+> resolves the calling agent in this order:
+>
+>     args.owner > SCHIST_AGENT_NAME > SCHIST_AGENT_ID > "" (→ "global")
+>
+> Under an allowlist-only deployment (only `SCHIST_ALLOWED_AGENTS` set, no
+> per-process env identity), pass `owner` per-call so scope-inherit resolves
+> to the calling agent rather than collapsing to `"global"`:
+>
+> ```json
+> { "query": "...", "scope": "inherit", "owner": "octopus" }
+> ```
+>
+> The `owner` arg is not validated against the allowlist — scope is a
+> convenience filter, not a privacy boundary (any agent can already query
+> any scope explicitly via `scope: "<name>"`).
 
 ## Project scoping: the `project:<slug>` tag convention
 

--- a/mcp-server/src/sqlite-reader.ts
+++ b/mcp-server/src/sqlite-reader.ts
@@ -67,7 +67,7 @@ function openDb(vaultRoot: string, opts?: { readonly?: boolean }): Database.Data
 export function searchNotes(
   vaultRoot: string,
   query: string,
-  opts?: { limit?: number; status?: string; tags?: string[]; scope?: string }
+  opts?: { limit?: number; status?: string; tags?: string[]; scope?: string; owner?: string }
 ): SearchResult[] {
   const db = openDb(vaultRoot);
   try {
@@ -95,9 +95,13 @@ export function searchNotes(
 
     if (opts?.scope) {
       if (opts.scope === "inherit") {
-        // Resolve calling scope: explicit param > agent default from vault.yaml > "global"
+        // Resolve calling scope: per-call owner > SCHIST_AGENT_NAME > SCHIST_AGENT_ID > "".
+        // Per-call owner is the only signal under SCHIST_ALLOWED_AGENTS-only
+        // deployments (shared MCP server, no per-process env identity); without
+        // it, scope-inherit silently collapses to "global" for every agent.
         const scopeMap = loadAgentScopeMap(vaultRoot);
-        const agentName = process.env.SCHIST_AGENT_NAME ?? process.env.SCHIST_AGENT_ID;
+        const agentName =
+          opts.owner ?? process.env.SCHIST_AGENT_NAME ?? process.env.SCHIST_AGENT_ID;
         const callingScope = scopeMap.get(agentName ?? "") ?? "global";
         sql += ` AND (docs.scope = 'global' OR docs.scope = ? OR docs.scope LIKE ? || '/%')`;
         params.push(callingScope, callingScope);

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -25,6 +25,7 @@ export function makeReadTools(config: VaultConfig) {
           status: { type: "string", enum: config.statuses },
           tags: { type: "array", items: { type: "string" } },
           scope: { type: "string", description: 'Filter by scope. Use "inherit" to search agent default scope + global.' },
+          owner: { type: "string", description: "Calling agent's id. Required for scope='inherit' under SCHIST_ALLOWED_AGENTS-only deployments where the env has no per-process identity; otherwise optional (falls back to SCHIST_AGENT_NAME / SCHIST_AGENT_ID)." },
         },
         required: ["query"],
       },

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -200,7 +200,7 @@ export async function maybeSpokePull(vaultRoot: string, timeoutMs = 5000): Promi
 
 export async function search_notes(
   vaultRoot: string,
-  args: { query: string; limit?: number; status?: string; tags?: string[]; scope?: string }
+  args: { query: string; limit?: number; status?: string; tags?: string[]; scope?: string; owner?: string }
 ): Promise<unknown> {
   try {
     return sqliteReader.searchNotes(vaultRoot, args.query, {
@@ -208,6 +208,7 @@ export async function search_notes(
       status: args.status,
       tags: args.tags,
       scope: args.scope,
+      owner: args.owner,
     });
   } catch (e: unknown) {
     return normalizeError(e, "INGEST_ERROR");

--- a/mcp-server/tests/sqlite-reader.test.ts
+++ b/mcp-server/tests/sqlite-reader.test.ts
@@ -1,4 +1,4 @@
-import { queryGraph } from "../src/sqlite-reader.js";
+import { queryGraph, searchNotes, resetAgentScopeMap } from "../src/sqlite-reader.js";
 import * as fs from "fs/promises";
 import * as path from "path";
 import * as os from "os";
@@ -68,5 +68,130 @@ describe("sqlite-reader", () => {
     expect(result.rows.length).toBeGreaterThan(0);
     expect(result.rows[0][1]).toBe("Test Note");
     expect(result.rowCount).toBeGreaterThan(0);
+  });
+});
+
+// ── searchNotes scope=inherit (#62) ───────────────────────────────────────
+
+async function makeScopedVault(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "schist-scope-test-"));
+  const dbDir = path.join(dir, ".schist");
+  await fs.mkdir(dbDir, { recursive: true });
+  const dbPath = path.join(dbDir, "schist.db");
+
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE docs (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      date TEXT,
+      status TEXT DEFAULT 'draft',
+      tags TEXT,
+      concepts TEXT,
+      domain TEXT,
+      body TEXT NOT NULL DEFAULT '',
+      scope TEXT DEFAULT 'global',
+      source TEXT,
+      created_at TEXT DEFAULT (datetime('now')),
+      updated_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE VIRTUAL TABLE docs_fts USING fts5(
+      title, body, tags, scope UNINDEXED, domain UNINDEXED,
+      content='docs', content_rowid='rowid'
+    );
+    CREATE TRIGGER docs_ai AFTER INSERT ON docs BEGIN
+      INSERT INTO docs_fts(rowid, title, body, tags, scope, domain)
+      VALUES (new.rowid, new.title, new.body, new.tags, new.scope, new.domain);
+    END;
+    INSERT INTO docs (id, title, body, scope) VALUES
+      ('notes/global.md',   'global haystack',   'shared knowledge', 'global'),
+      ('notes/octopus.md',  'octopus haystack',  'shared knowledge', 'octopus'),
+      ('notes/sansan.md',   'sansan haystack',   'shared knowledge', 'sansan');
+  `);
+  db.close();
+
+  await fs.writeFile(
+    path.join(dir, "vault.yaml"),
+    [
+      "name: scope-test",
+      "participants:",
+      "  - { name: octopus, default_scope: octopus }",
+      "  - { name: sansan,  default_scope: sansan }",
+      "",
+    ].join("\n")
+  );
+
+  return dir;
+}
+
+describe("searchNotes scope='inherit' identity resolution (#62)", () => {
+  const envKeys = ["SCHIST_AGENT_ID", "SCHIST_AGENT_NAME", "SCHIST_ALLOWED_AGENTS"] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of envKeys) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    resetAgentScopeMap();
+  });
+
+  afterEach(() => {
+    for (const k of envKeys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    resetAgentScopeMap();
+  });
+
+  it("per-call owner resolves to that agent's default scope (allowlist-only deployment)", async () => {
+    const vault = await makeScopedVault();
+    process.env.SCHIST_ALLOWED_AGENTS = "octopus,sansan";
+
+    const r = searchNotes(vault, "haystack", { scope: "inherit", owner: "octopus" });
+    const ids = r.map((x) => x.id).sort();
+    expect(ids).toEqual(["notes/global.md", "notes/octopus.md"]);
+    expect(ids).not.toContain("notes/sansan.md");
+  });
+
+  it("per-call owner wins over SCHIST_AGENT_ID env", async () => {
+    const vault = await makeScopedVault();
+    process.env.SCHIST_AGENT_ID = "octopus";
+
+    const r = searchNotes(vault, "haystack", { scope: "inherit", owner: "sansan" });
+    const ids = r.map((x) => x.id).sort();
+    expect(ids).toEqual(["notes/global.md", "notes/sansan.md"]);
+  });
+
+  it("falls back to SCHIST_AGENT_NAME when owner not passed", async () => {
+    const vault = await makeScopedVault();
+    process.env.SCHIST_AGENT_NAME = "sansan";
+
+    const r = searchNotes(vault, "haystack", { scope: "inherit" });
+    const ids = r.map((x) => x.id).sort();
+    expect(ids).toEqual(["notes/global.md", "notes/sansan.md"]);
+  });
+
+  it("falls back to SCHIST_AGENT_ID when neither owner nor SCHIST_AGENT_NAME set", async () => {
+    const vault = await makeScopedVault();
+    process.env.SCHIST_AGENT_ID = "octopus";
+
+    const r = searchNotes(vault, "haystack", { scope: "inherit" });
+    const ids = r.map((x) => x.id).sort();
+    expect(ids).toEqual(["notes/global.md", "notes/octopus.md"]);
+  });
+
+  it("documents the #62 regression: scope-inherit with no signals at all collapses to global", async () => {
+    // Allowlist-only deployment (no per-process AGENT_ID) calling search_notes
+    // without `owner` is the pre-fix bug shape. We don't *fix* that case here —
+    // the agent is the only one who knows its identity. Just document that the
+    // resolution silently returns global rather than throwing, so callers can
+    // detect the gap and start passing `owner`.
+    const vault = await makeScopedVault();
+    process.env.SCHIST_ALLOWED_AGENTS = "octopus,sansan";
+
+    const r = searchNotes(vault, "haystack", { scope: "inherit" });
+    const ids = r.map((x) => x.id).sort();
+    expect(ids).toEqual(["notes/global.md"]);
   });
 });


### PR DESCRIPTION
## Summary
- Adds optional \`owner\` arg to \`search_notes\` so scope-inherit can resolve the calling agent under allowlist-only deployments (shared MCP server, no per-process \`SCHIST_AGENT_ID\`). Without it, every agent's inherit search collapsed to \`scope = global\` regardless of identity — issue #62.
- New resolution order in \`searchNotes\`:

      args.owner > SCHIST_AGENT_NAME > SCHIST_AGENT_ID > \"\" (→ \"global\")

- \`owner\` is NOT validated against \`SCHIST_ALLOWED_AGENTS\` — scope is a convenience filter, not a privacy boundary (any agent can already query any scope explicitly via \`scope: \"<name>\"\`). Reads stay lenient; writes continue to use \`validateOwner\` from PR #61.
- Docs: \`docs/cross-project-memory.md\` replaces the #62 workaround note with the new resolution order + a JSON snippet showing \`owner\` on the call.

## Test plan
- [x] \`npm test\` — 198/198 (was 193; +5 scope-inherit tests covering per-call wins, env fallbacks, and the no-signal-still-collapses-to-global case).
- [x] \`npm run build\` — clean.
- [x] No behavior change when \`owner\` is omitted — env fallbacks unchanged.

## Follow-ups
- #63 — vault-write tools (\`create_note\`, \`add_connection\`, \`assign_domain\`) still skip agent-identity. Separate, larger work — schema + tool API change.

Closes #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)