### PR TITLE
refactor(mcp): remove writeEnabled capability gate (closes #72, #73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Node.js minimum version relaxed from >=22 to >=20 (no Node 22-specific features used)
+- MCP server no longer requires `request_capabilities` before write tools — the gate provided no real access control and added friction in shared-MCP deployments (PR #76, closes #72, #73). Memory-write authorization continues to be enforced at the data layer by `validateOwner` against `SCHIST_AGENT_ID` / `SCHIST_ALLOWED_AGENTS`. Vault-write identity enforcement is tracked in #63.
+
+### Removed
+- `request_capabilities` MCP meta-tool. Calling it now returns `VALIDATION_ERROR: Unknown tool: request_capabilities` (PR #76).
 
 ## [0.1.0] - Unreleased
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ See [schema/SCHEMA.md](./schema/SCHEMA.md) for the markdown schema specification
 - No delete, no force-push, no history rewrite via MCP
 - Pre-commit hook rejects commits containing secrets/API keys
 - Web viewer is static only — no server-side execution
-- Write tools gated behind explicit `request_capabilities` unlock
+- Write authorization enforced by `validateOwner` against `SCHIST_AGENT_ID` / `SCHIST_ALLOWED_AGENTS`
 - `query_graph` rejects non-SELECT SQL
 
 ## Requirements

--- a/docs/cross-project-memory.md
+++ b/docs/cross-project-memory.md
@@ -65,12 +65,10 @@ new memory entries; see the Identity section below.
 ## Tool surface
 
 The memory subsystem exposes six MCP tools. All tools are listed by
-`ListTools`; write tools require `request_capabilities({capability:
-"write"})` before calls succeed. The gate is at invocation time, not
-listing time — see `docs/mcp-setup.md` "Tool exposure model" for the
-full rationale.
+`ListTools` and callable without any opt-in meta-tool — see
+`docs/mcp-setup.md` "Tool exposure model" for the full rationale.
 
-**Read (callable immediately):**
+**Read:**
 
 - `search_memory` — full-text search with optional `owner`, `entry_type`,
   `date_from`, `date_to`, `limit` filters. FTS5 indexes the `content` and
@@ -79,7 +77,7 @@ full rationale.
 - `list_domains` — list the research domain taxonomy (separate from memory,
   included here because it shares the read surface).
 
-**Write (callable after `request_capabilities`):**
+**Write:**
 
 - `add_memory` — store a new entry. Required: `owner`, `entry_type` (one of
   `decision | lesson | blocker | completion | observation`), `content`.
@@ -94,10 +92,6 @@ The `owner` field on write is enforced against the configured agent
 identity (see [Identity](#identity-schist_agent_id-vs-schist_allowed_agents)
 below). Writes without identity configured fail with `CONFIG_ERROR`; writes
 with a mismatched owner fail with `VALIDATION_ERROR`. Reads are unrestricted.
-
-The `request_capabilities` success response now lists every write tool
-that becomes callable — both vault and memory — in its `message` and
-`tools` fields.
 
 ## Identity: `SCHIST_AGENT_ID` vs `SCHIST_ALLOWED_AGENTS`
 
@@ -218,7 +212,6 @@ future CLI flag) — FTS is for recall, not for structured lookups.
 > cwd: /home/user/code/my-other-project  (git repo)
 > project slug: my-other-project
 
-MCP: request_capabilities({capability: "write"})
 MCP: add_memory({
   owner: "sansan",
   entry_type: "lesson",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -198,7 +198,7 @@ schist search --vault ~/my-vault "test"
 # View vault summary
 schist context --vault ~/my-vault --depth minimal
 
-# Connect from MCP: call get_context, then request_capabilities({capability: "write"})
+# Connect from MCP: call get_context to see the vault, then call any read/write tool directly
 ```
 
 All four commands should return without error. `schist doctor` should show PASS for every check.

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -28,36 +28,30 @@ SCHIST_VAULT_PATH=/path/to/vault node dist/index.js
 
 <!-- Implementation: mcp-server/src/tool-registry.ts + src/index.ts -->
 
-The server lists **all** tools at `ListTools` time — read, write, memory,
-and the capability meta-tool. Write-capable tools are gated at **call
-time**, not at listing time: an agent that calls a write tool without
-first calling `request_capabilities` gets a `VALIDATION_ERROR`.
+The server lists **all** tools at `ListTools` time and accepts calls to
+any of them unconditionally. There is no opt-in meta-tool.
 
-Always-listed tools (callable immediately):
+Read tools:
 
-- `get_context`, `search_notes` — vault read
+- `get_context`, `search_notes`, `get_note`, `list_concepts`, `query_graph` — vault read
 - `search_memory`, `get_agent_state`, `list_domains` — memory read
-- `request_capabilities` — meta-tool to unlock write invocations
 
-Always-listed tools (callable only after `request_capabilities({capability: "write"})`):
+Write tools:
 
-- `get_note`, `create_note`, `add_connection`, `list_concepts`, `query_graph` — vault write
+- `create_note`, `add_connection`, `assign_domain` — vault write
 - `add_memory`, `set_agent_state`, `delete_agent_state`, `add_concept_alias` — memory write
 
-To enable write invocations:
+**Where authorization lives.** Writes are authorized at the data layer by
+`validateOwner` (see `mcp-server/src/agent-identity.ts`), which checks the
+incoming `owner` against `SCHIST_AGENT_ID` / `SCHIST_ALLOWED_AGENTS`. A
+mismatched or missing owner produces `CONFIG_ERROR` or `VALIDATION_ERROR`.
+Reads are unrestricted.
 
-```json
-{"name": "request_capabilities", "arguments": {"capability": "write"}}
-```
-
-**Why list everything up-front.** MCP clients like Claude Code cache
-tool discovery at session start and never re-fetch. If write tools were
-only listed after the capability unlock (the pre-v0.1.0 design), those
-clients would never see them — `add_memory` and friends would be
-unreachable from Claude Code even after a successful `request_capabilities`
-call. Listing all tools unconditionally costs a few kB in the one-time
-ListTools response in exchange for making write tools actually usable.
-The call-time gate preserves the explicit-opt-in model.
+**Why no capability meta-tool.** Earlier versions required agents to call
+`request_capabilities({capability: "write"})` before writes would succeed.
+That gate was unauthenticated (any caller could flip it) and provided no
+real access control — it was a UX speed bump that conflicted with both
+agent ergonomics and the actual authorization model. Removed in #72.
 
 ## Post-commit ingestion
 

--- a/docs/planning/2026-05-17-schist-retrieve-mcp-tool.md
+++ b/docs/planning/2026-05-17-schist-retrieve-mcp-tool.md
@@ -70,8 +70,10 @@ manually orchestrating multiple schist calls.
 
 ### Step 1: Add tool definition to `tool-registry.ts`
 
-New entry in `makeReadTools()` — this is a READ tool and does NOT require
-the capability gate. All agents can call it at session start.
+New entry in `makeReadTools()` — this is a READ tool. (As of #72 the
+capability gate has been removed entirely; all tools are callable
+without any opt-in. Write authorization is enforced at the data layer
+by `validateOwner`.) All agents can call it at session start.
 
 ### Step 2: Implement handler in `tools.ts`
 

--- a/docs/superpowers/plans/2026-05-04-mcp-context-efficiency.md
+++ b/docs/superpowers/plans/2026-05-04-mcp-context-efficiency.md
@@ -572,8 +572,10 @@ Most are already sensible; `list_domains` and `query_graph` are the changes.]
 
 ## Out-of-scope for this rollout
 
-- Authentication / authorization changes (the existing capability gate
-  already covers writes).
+- Authentication / authorization changes (write auth is enforced by
+  `validateOwner` against `SCHIST_AGENT_ID` / `SCHIST_ALLOWED_AGENTS`;
+  the pre-#72 `request_capabilities` gate was removed as it provided no
+  real access control).
 - Streaming responses (would require MCP protocol-level changes).
 - Caching tool responses across sessions (out of scope; orthogonal).
 ```

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -150,7 +150,9 @@ async function main() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("[schist] MCP server ready (stdio) — write authorization is enforced by validateOwner against SCHIST_AGENT_ID / SCHIST_ALLOWED_AGENTS.");
+  console.error("[schist] MCP server ready (stdio).");
+  console.error("[schist] Memory writes are authorized by validateOwner against SCHIST_AGENT_ID / SCHIST_ALLOWED_AGENTS.");
+  console.error("[schist] Vault writes (create_note, add_connection, assign_domain) do not yet enforce identity — see issue #63.");
 }
 
 main().catch((e) => {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -26,11 +26,7 @@ import {
   list_domains,
 } from "./tools.js";
 import type { VaultConfig } from "./types.js";
-import {
-  listAllTools,
-  makeWriteTools,
-  makeMemoryWriteTools,
-} from "./tool-registry.js";
+import { listAllTools } from "./tool-registry.js";
 
 function resolveVaultPath(): string {
   const envVault = process.env.SCHIST_VAULT_PATH;
@@ -75,9 +71,6 @@ async function main() {
     { capabilities: { tools: {} } }
   );
 
-  // Lazy capability state: starts read-only, expanded on request_capabilities
-  let writeEnabled = false;
-
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return { tools: listAllTools(config) };
   });
@@ -88,98 +81,58 @@ async function main() {
 
     let result: unknown;
 
-    // Meta-tool: enable write capabilities for this session
-    if (name === "request_capabilities") {
-      if (toolArgs.capability === "write") {
-        writeEnabled = true;
-        const unlocked = [
-          ...makeWriteTools(config).map((t) => t.name),
-          ...makeMemoryWriteTools(config).map((t) => t.name),
-        ];
-        result = {
-          ok: true,
-          message: `Write capability enabled. Invocation now permitted for: ${unlocked.join(", ")}.`,
-          tools: unlocked,
-        };
-      } else {
-        result = { error: "VALIDATION_ERROR", message: `Unknown capability: ${String(toolArgs.capability)}` };
+    try {
+      switch (name) {
+        case "search_notes":
+          result = await search_notes(vaultRoot, toolArgs as Parameters<typeof search_notes>[1]);
+          break;
+        case "get_note":
+          result = await get_note(vaultRoot, toolArgs as Parameters<typeof get_note>[1]);
+          break;
+        case "create_note":
+          result = await create_note(vaultRoot, toolArgs as Parameters<typeof create_note>[1], config);
+          break;
+        case "add_connection":
+          result = await add_connection(vaultRoot, toolArgs as Parameters<typeof add_connection>[1]);
+          break;
+        case "assign_domain":
+          result = await assign_domain(vaultRoot, toolArgs as Parameters<typeof assign_domain>[1]);
+          break;
+        case "list_concepts":
+          result = await list_concepts(vaultRoot, toolArgs as Parameters<typeof list_concepts>[1]);
+          break;
+        case "query_graph":
+          result = await query_graph(vaultRoot, toolArgs as Parameters<typeof query_graph>[1]);
+          break;
+        case "get_context":
+          result = await get_context(vaultRoot, toolArgs as Parameters<typeof get_context>[1]);
+          break;
+        case "search_memory":
+          result = await search_memory(vaultRoot, toolArgs as Parameters<typeof search_memory>[1]);
+          break;
+        case "get_agent_state":
+          result = await get_agent_state(vaultRoot, toolArgs as Parameters<typeof get_agent_state>[1]);
+          break;
+        case "list_domains":
+          result = await list_domains(vaultRoot, toolArgs as Parameters<typeof list_domains>[1]);
+          break;
+        case "add_memory":
+          result = await add_memory(vaultRoot, toolArgs as Parameters<typeof add_memory>[1]);
+          break;
+        case "set_agent_state":
+          result = await set_agent_state(vaultRoot, toolArgs as Parameters<typeof set_agent_state>[1]);
+          break;
+        case "delete_agent_state":
+          result = await delete_agent_state(vaultRoot, toolArgs as Parameters<typeof delete_agent_state>[1]);
+          break;
+        case "add_concept_alias":
+          result = await add_concept_alias(vaultRoot, toolArgs as Parameters<typeof add_concept_alias>[1]);
+          break;
+        default:
+          result = { error: "VALIDATION_ERROR", message: `Unknown tool: ${name}` };
       }
-    } else {
-      try {
-        switch (name) {
-          case "search_notes":
-            result = await search_notes(vaultRoot, toolArgs as Parameters<typeof search_notes>[1]);
-            break;
-          case "get_note":
-            result = writeEnabled
-              ? await get_note(vaultRoot, toolArgs as Parameters<typeof get_note>[1])
-              : { error: "VALIDATION_ERROR", message: "get_note requires write capability. Call request_capabilities first." };
-            break;
-          case "create_note":
-            result = writeEnabled
-              ? await create_note(vaultRoot, toolArgs as Parameters<typeof create_note>[1], config)
-              : { error: "VALIDATION_ERROR", message: "create_note requires write capability. Call request_capabilities first." };
-            break;
-          case "add_connection":
-            result = writeEnabled
-              ? await add_connection(vaultRoot, toolArgs as Parameters<typeof add_connection>[1])
-              : { error: "VALIDATION_ERROR", message: "add_connection requires write capability. Call request_capabilities first." };
-            break;
-          case "assign_domain":
-            result = writeEnabled
-              ? await assign_domain(vaultRoot, toolArgs as Parameters<typeof assign_domain>[1])
-              : { error: "VALIDATION_ERROR", message: "assign_domain requires write capability. Call request_capabilities first." };
-            break;
-          case "list_concepts":
-            result = writeEnabled
-              ? await list_concepts(vaultRoot, toolArgs as Parameters<typeof list_concepts>[1])
-              : { error: "VALIDATION_ERROR", message: "list_concepts requires write capability. Call request_capabilities first." };
-            break;
-          case "query_graph":
-            result = writeEnabled
-              ? await query_graph(vaultRoot, toolArgs as Parameters<typeof query_graph>[1])
-              : { error: "VALIDATION_ERROR", message: "query_graph requires write capability. Call request_capabilities first." };
-            break;
-          case "get_context":
-            result = await get_context(vaultRoot, toolArgs as Parameters<typeof get_context>[1]);
-            break;
-          // Memory V2 — read (always available)
-          case "search_memory":
-            result = await search_memory(vaultRoot, toolArgs as Parameters<typeof search_memory>[1]);
-            break;
-          case "get_agent_state":
-            result = await get_agent_state(vaultRoot, toolArgs as Parameters<typeof get_agent_state>[1]);
-            break;
-          case "list_domains":
-            result = await list_domains(vaultRoot, toolArgs as Parameters<typeof list_domains>[1]);
-            break;
-          // Memory V2 — write (require writeEnabled)
-          case "add_memory":
-            result = writeEnabled
-              ? await add_memory(vaultRoot, toolArgs as Parameters<typeof add_memory>[1])
-              : { error: "VALIDATION_ERROR", message: "add_memory requires write capability. Call request_capabilities first." };
-            break;
-          case "set_agent_state":
-            result = writeEnabled
-              ? await set_agent_state(vaultRoot, toolArgs as Parameters<typeof set_agent_state>[1])
-              : { error: "VALIDATION_ERROR", message: "set_agent_state requires write capability." };
-            break;
-          case "delete_agent_state":
-            result = writeEnabled
-              ? await delete_agent_state(vaultRoot, toolArgs as Parameters<typeof delete_agent_state>[1])
-              : { error: "VALIDATION_ERROR", message: "delete_agent_state requires write capability." };
-            break;
-          case "add_concept_alias":
-            result = writeEnabled
-              ? await add_concept_alias(vaultRoot, toolArgs as Parameters<typeof add_concept_alias>[1])
-              : { error: "VALIDATION_ERROR", message: "add_concept_alias requires write capability." };
-            break;
-          default:
-            result = { error: "VALIDATION_ERROR", message: `Unknown tool: ${name}` };
-        }
-      } catch (e: unknown) {
-        result = { error: "INGEST_ERROR", message: String(e), details: e };
-      }
+    } catch (e: unknown) {
+      result = { error: "INGEST_ERROR", message: String(e), details: e };
     }
 
     return {
@@ -197,7 +150,7 @@ async function main() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("[schist] MCP server ready (stdio) — all tools listed; write tools require request_capabilities({capability: 'write'}) to invoke");
+  console.error("[schist] MCP server ready (stdio) — write authorization is enforced by validateOwner against SCHIST_AGENT_ID / SCHIST_ALLOWED_AGENTS.");
 }
 
 main().catch((e) => {

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -227,42 +227,18 @@ export function makeWriteTools(config: VaultConfig) {
   ];
 }
 
-export function makeCapabilityTool() {
-  return {
-    name: "request_capabilities",
-    description:
-      "Enable write-capable tools for this session. Pass capability='write' to " +
-      "allow invocation of: get_note, create_note, add_connection, list_concepts, " +
-      "query_graph, add_memory, set_agent_state, delete_agent_state, " +
-      "add_concept_alias. These tools are always listed by ListTools so MCP " +
-      "clients that cache discovery can see them; the gate here controls " +
-      "whether calls to them succeed. Read-only sessions (search + context) " +
-      "do not need to call this.",
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        capability: { type: "string", enum: ["write"] },
-      },
-      required: ["capability"],
-    },
-  };
-}
-
 /**
  * Return the full set of tool definitions exposed by the schist MCP server.
  *
- * All tools are listed unconditionally. Write-capable tools still require
- * `request_capabilities({capability: "write"})` to succeed at invocation
- * time — the capability gate is per-call, not per-list. This matters because
- * MCP clients like Claude Code cache tool discovery at session start and
- * never re-fetch; conditional listing made write tools unreachable for
- * those clients.
+ * All tools are listed unconditionally and callable without any opt-in
+ * meta-tool. Write authorization is enforced at the data layer by
+ * `validateOwner` (see `agent-identity.ts`), which checks the incoming
+ * `owner` against `SCHIST_AGENT_ID` / `SCHIST_ALLOWED_AGENTS`.
  */
 export function listAllTools(config: VaultConfig) {
   return [
     ...makeReadTools(config),
     ...makeMemoryReadTools(config),
-    makeCapabilityTool(),
     ...makeWriteTools(config),
     ...makeMemoryWriteTools(config),
   ];

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -231,9 +231,14 @@ export function makeWriteTools(config: VaultConfig) {
  * Return the full set of tool definitions exposed by the schist MCP server.
  *
  * All tools are listed unconditionally and callable without any opt-in
- * meta-tool. Write authorization is enforced at the data layer by
- * `validateOwner` (see `agent-identity.ts`), which checks the incoming
- * `owner` against `SCHIST_AGENT_ID` / `SCHIST_ALLOWED_AGENTS`.
+ * meta-tool. Authorization is split between two tiers:
+ *
+ *   - Memory writes (add_memory, set_agent_state, delete_agent_state,
+ *     add_concept_alias) call `validateOwner` (see `agent-identity.ts`)
+ *     against the configured SCHIST_AGENT_ID / SCHIST_ALLOWED_AGENTS.
+ *   - Vault writes (create_note, add_connection, assign_domain) do not
+ *     yet enforce identity — every commit attributes to source_agent: "mcp"
+ *     regardless of caller. Tracked as issue #63.
  */
 export function listAllTools(config: VaultConfig) {
   return [

--- a/mcp-server/tests/tool-listing.test.ts
+++ b/mcp-server/tests/tool-listing.test.ts
@@ -13,7 +13,7 @@ function testConfig(): VaultConfig {
 }
 
 describe("listAllTools — unconditional tool exposure", () => {
-  test("lists every read, write, memory, and capability tool", () => {
+  test("lists every read, write, and memory tool", () => {
     const names = listAllTools(testConfig()).map((t) => t.name).sort();
 
     const expected = [
@@ -29,7 +29,6 @@ describe("listAllTools — unconditional tool exposure", () => {
       "list_concepts",
       "list_domains",
       "query_graph",
-      "request_capabilities",
       "search_memory",
       "search_notes",
       "set_agent_state",
@@ -38,11 +37,10 @@ describe("listAllTools — unconditional tool exposure", () => {
     expect(names).toEqual(expected);
   });
 
-  test("write tools appear in the listing even without prior capability unlock", () => {
-    // listAllTools has no knowledge of writeEnabled state — it is invoked by
-    // the ListTools handler unconditionally. If this assertion ever regresses,
-    // MCP clients that cache tool discovery (Claude Code) will silently lose
-    // the ability to call any write tool.
+  test("write tools appear in the listing unconditionally", () => {
+    // MCP clients like Claude Code cache tool discovery at session start and
+    // never re-fetch; if writes ever stopped being listed, those clients would
+    // permanently lose the ability to call them.
     const names = listAllTools(testConfig()).map((t) => t.name);
 
     for (const tool of [
@@ -57,10 +55,11 @@ describe("listAllTools — unconditional tool exposure", () => {
     }
   });
 
-  test("request_capabilities description mentions invocation gate, not listing gate", () => {
-    const reqCap = listAllTools(testConfig()).find((t) => t.name === "request_capabilities");
-    expect(reqCap).toBeDefined();
-    // The description must convey that the gate is at call time, not list time.
-    expect(reqCap!.description?.toLowerCase()).toMatch(/invocation|calls? to|succeed/);
+  test("no request_capabilities meta-tool is exposed", () => {
+    // The pre-#72 design required agents to call request_capabilities before
+    // any write. It provided no security (unauthenticated) and was removed —
+    // validateOwner in agent-identity.ts is the real authorization layer.
+    const names = listAllTools(testConfig()).map((t) => t.name);
+    expect(names).not.toContain("request_capabilities");
   });
 });


### PR DESCRIPTION
## Summary

Removes the `request_capabilities` / `writeEnabled` meta-tool entirely. The gate was unauthenticated (any caller could flip it), provided no real access control, and added friction in shared-MCP deployments. Memory writes continue to be authorized at the data layer by `validateOwner` (see `mcp-server/src/agent-identity.ts`); **vault writes do not yet enforce identity — see #63**.

Closes #72.
Closes #73 — the latter is auto-resolved because `get_note`, `list_concepts`, and `query_graph` are no longer gated behind a write capability.

## Why

The gate originated in commit `8ffdad1` as a **token-savings optimization** — read-only sessions could skip listing write tools. That justification died with PR #30 (`7da6109`), which moved to "list all tools, gate at invocation" because Claude Code caches tool discovery and never re-fetches.

What remained after PR #30 was a UX speed bump that the startup log + tool descriptions framed as the security boundary. It wasn't. The real authorization happens at the data layer in `validateOwner`. The friction cost was non-trivial in shared-MCP deployments — agents that forgot the unlock wasted tokens hitting `VALIDATION_ERROR` on every first write.

## Changes

**Code:**
- `mcp-server/src/index.ts`: drop `writeEnabled` state, the `request_capabilities` handler, every gating ternary, and the unused imports. Split the startup log into three accurate lines (ready / memory-write coverage / vault-write gap → #63).
- `mcp-server/src/tool-registry.ts`: remove `makeCapabilityTool()`, drop it from `listAllTools()`. The new `listAllTools` comment describes the two-tier auth split: memory writes enforce via `validateOwner`; vault writes do not (#63).

**Tests:**
- `mcp-server/tests/tool-listing.test.ts`: remove `request_capabilities` from the expected listing; replace the gate-description test with a negative-assertion that pins removal.

**Docs:**
- `docs/mcp-setup.md`: rewrite "Tool exposure model" — no opt-in tool, all reads/writes callable directly.
- `docs/cross-project-memory.md`: drop the "callable after request_capabilities" framing.
- `docs/getting-started.md` + `README.md`: update the security-model bullets.
- `docs/planning/2026-05-17-schist-retrieve-mcp-tool.md` and `docs/superpowers/plans/2026-05-04-mcp-context-efficiency.md`: forward-looking statements updated.
- `CHANGELOG.md`: v0.2.0 entries for the gate removal — Changed (gate removed, memory-write enforcement intact, vault-write gap tracked in #63) + Removed (`request_capabilities` tool).

## Test plan

- [x] `npm run build` in `mcp-server/` — clean (no TS errors)
- [x] `npm test` in `mcp-server/` — 239/239 pass across 14 suites (pre-/review commit); 3/3 tool-listing tests still pass after the review fix
- [x] `pytest tests/` in `cli/` — 311 pass, 1 pre-existing skip
- [x] Final `grep -rn 'request_capabilities|writeEnabled|makeCapabilityTool'` over `mcp-server/src`, `mcp-server/tests`, `docs/`, `README.md`, `cli/` — only intentional references remain (the negative-assertion test, the doc paragraph explaining removal, and the CHANGELOG entry)
- [x] `/review` adversarial pass surfaced misleading auth-coverage claims; addressed in commit `6cb503b` (split startup log + rewrite `listAllTools` comment to honestly describe the two-tier auth)
- [ ] Smoke test: connect Claude Code to the rebuilt MCP server and confirm `mcp__schist__add_memory` works without a `request_capabilities` call

## Risk

- **Backwards compatibility:** any agent that calls `request_capabilities` will now get `VALIDATION_ERROR: Unknown tool: request_capabilities`. The actual authorization paths are unchanged:
  - Memory writes still respect `validateOwner` exactly as before.
  - Vault writes (`create_note`, `add_connection`, `assign_domain`) remain at their pre-#76 attribution behavior — `source_agent: "mcp"` is hard-coded, no `validateOwner` is called. **This is not a regression** (those tools never called `validateOwner`); but the absence of the friction gate makes the gap in #63 more visible. Closing #63 is the natural follow-up.
- **Security:** none from this PR. The gate provided no access control.

## Follow-ups

- **#63** — add `validateOwner` to vault writes. Real behavioral change (adds `owner` arg to 3 tool schemas; breaks moctopus's in-flight PRs #68–71 until they adopt the new arg).
- Follow-up issue for read-surface trust assumptions in shared-MCP deployments (filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)