### PR TITLE
chore: promote uv to recommended toolchain for source installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,14 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
-          cache: pip
-          cache-dependency-path: cli/pyproject.toml
 
-      - name: Install CLI + pytest
-        run: pip install -e ./cli pytest
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: cli/uv.lock
+
+      - name: Install CLI + pytest (via uv)
+        run: uv pip install --system -e ./cli pytest
 
       - name: Configure git identity for subprocess tests
         run: |
@@ -62,12 +65,15 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
-          cache: pip
-          cache-dependency-path: cli/pyproject.toml
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: cli/uv.lock
 
       - name: Install CLI (provides schist + schist-ingest for audit-script integration test)
         working-directory: ${{ github.workspace }}
-        run: pip install -e ./cli
+        run: uv pip install --system -e ./cli
 
       - name: Configure git identity for fixture vault commits
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+# Tell uv that the active Python (the one setup-python installed) is the
+# install target — equivalent to passing `--system` to every uv pip call,
+# but cannot be forgotten by future workflow edits.
+env:
+  UV_SYSTEM_PYTHON: 1
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -29,8 +35,15 @@ jobs:
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
+          # Pin uv to the same version the maintainer uses locally so CI
+          # and dev box install through identical resolver behavior.
+          version: 0.5.24
           enable-cache: true
           cache-dependency-glob: cli/uv.lock
+
+      - name: Verify cli/uv.lock is in sync with cli/pyproject.toml
+        working-directory: cli
+        run: uv lock --check
 
       - name: Install CLI + pytest (via uv)
         run: uv pip install --system -e ./cli pytest
@@ -68,6 +81,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
+          version: 0.5.24
           enable-cache: true
           cache-dependency-glob: cli/uv.lock
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `schist init --print-mcp-config` — generates ready-to-paste MCP server config for Claude Code and Cursor
 - `docs/getting-started.md` — linear onboarding guide with platform-specific instructions (Linux, macOS, HPC)
 - `docs/hub-spoke-pi-hpc-mac.md` — opinionated topology guide for Pi hub + HPC/Mac spoke setup
+- `schist doctor` reports `uv` availability (WARN if missing — pip still works as a fallback)
+- `cli/uv.lock` — checked in for reproducible source installs across Mac / Pi / HPC
 
 ### Changed
 - Node.js minimum version relaxed from >=22 to >=20 (no Node 22-specific features used)
 - MCP server no longer requires `request_capabilities` before write tools — the gate provided no real access control and added friction in shared-MCP deployments (PR #76, closes #72, #73). Memory-write authorization continues to be enforced at the data layer by `validateOwner` against `SCHIST_AGENT_ID` / `SCHIST_ALLOWED_AGENTS`. Vault-write identity enforcement is tracked in #63.
+- Recommended Python package manager for source installs is now [uv](https://docs.astral.sh/uv/) — faster installs, lockfile-aware. The published `pip install schist` end-user path is unchanged; dev installs should prefer `uv pip install --system -e ./cli`. Docs, CI, and error messages updated accordingly. pip remains a supported fallback.
 
 ### Removed
 - `request_capabilities` MCP meta-tool. Calling it now returns `VALIDATION_ERROR: Unknown tool: request_capabilities` (PR #76).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `schist init --print-mcp-config` — generates ready-to-paste MCP server config for Claude Code and Cursor
 - `docs/getting-started.md` — linear onboarding guide with platform-specific instructions (Linux, macOS, HPC)
 - `docs/hub-spoke-pi-hpc-mac.md` — opinionated topology guide for Pi hub + HPC/Mac spoke setup
-- `schist doctor` reports `uv` availability (WARN if missing — pip still works as a fallback)
-- `cli/uv.lock` — checked in for reproducible source installs across Mac / Pi / HPC
+- `schist doctor` reports `uv` availability (WARN if missing — pip still works as a fallback). Note: hosts without `uv` will now show one new `[WARN] uv: not found` line in the default check output; downstream scripts that scrape doctor output to assert "no warnings" may need adjustment.
+- `cli/uv.lock` — checked in for reproducible source installs across Mac / Pi / HPC. CI enforces freshness via `uv lock --check` to catch pyproject.toml edits that forget to regenerate the lock.
 
 ### Changed
 - Node.js minimum version relaxed from >=22 to >=20 (no Node 22-specific features used)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,18 +18,27 @@ npm test -- --testPathPatterns=<pattern>  # run a single test file (Jest 30+)
 ```
 
 ### CLI (Python, in `cli/`)
+schist uses [uv](https://docs.astral.sh/uv/) as its recommended Python
+package manager — faster installs + reproducible builds via `cli/uv.lock`.
+pip still works as a fallback for users without uv.
 ```bash
-pip install -e ./cli                 # editable install
+uv pip install --system -e ./cli     # editable install (uv-fast path)
+# or:  pip install -e ./cli          # pip fallback
 python -m pytest cli/tests/          # run all tests
 python -m pytest cli/tests/test_acl.py  # single test file
 python -m pytest cli/tests/test_acl.py::test_name -v  # single test
+```
+
+For one-shot test runs without modifying the active env, use:
+```bash
+cd cli && uv run --with pytest --with . python -m pytest tests/
 ```
 
 ### Ingestion (Python, packaged with CLI)
 The ingester ships as part of the `schist` package and is exposed as the
 `schist-ingest` console script (registered in `cli/pyproject.toml`).
 ```bash
-pip install -e ./cli                                   # provides schist-ingest
+uv pip install --system -e ./cli                       # provides schist-ingest
 schist-ingest --vault <path> --db <path>               # rebuild SQLite from markdown
 ```
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -373,7 +373,7 @@ One-paragraph definition. Concept files are reference nodes — stable anchors t
 
 ## CLI Command Reference
 
-Installed as `schist` via `pip install -e ./cli`.
+Installed as `schist` via `uv pip install --system -e ./cli` (or `pip install -e ./cli`).
 
 ### `schist add`
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install -g @schist/mcp-server
 
 # Or install from source (for contributors):
 # git clone https://github.com/yibeichan/schist.git
-# cd schist && pip install -e ./cli
+# cd schist && uv pip install --system -e ./cli   # or: pip install -e ./cli
 # cd mcp-server && npm install && npm run build
 
 # Create a vault

--- a/cli/schist/doctor.py
+++ b/cli/schist/doctor.py
@@ -66,6 +66,30 @@ def check_node() -> CheckResult:
                            "Install Node.js 20+ from nodejs.org or via nvm.")
 
 
+def check_uv() -> CheckResult:
+    """Check for `uv` — schist's recommended Python package manager.
+
+    Reports PASS when uv is available with version info, WARN when missing
+    (pip still works as a fallback for the documented install paths). Not
+    a FAIL because end-users installing the published `schist` wheel from
+    PyPI never need uv; the recommendation is for source/development use.
+    """
+    uv = shutil.which("uv")
+    if not uv:
+        return CheckResult(
+            "WARN", "uv", "not found",
+            "Recommended: install uv from https://docs.astral.sh/uv/getting-started/installation/ "
+            "(pip continues to work as a fallback).",
+        )
+    try:
+        raw = subprocess.run([uv, "--version"], capture_output=True, text=True, timeout=5)
+        ver_str = raw.stdout.strip()
+        return CheckResult("PASS", "uv", ver_str)
+    except Exception as e:
+        return CheckResult("WARN", "uv", f"error: {e}",
+                           "Reinstall uv from https://docs.astral.sh/uv/getting-started/installation/.")
+
+
 def check_git() -> CheckResult:
     git = shutil.which("git")
     if not git:
@@ -206,7 +230,7 @@ def check_ingest_available(vault_path: Optional[str]) -> CheckResult:
         return CheckResult("PASS", "Ingest", "schist-ingest on PATH")
 
     return CheckResult("FAIL", "Ingest", "schist-ingest not found",
-                       "Set SCHIST_INGEST_SCRIPT or run `pip install -e ./cli`.")
+                       "Set SCHIST_INGEST_SCRIPT or run `uv pip install -e ./cli` (or `pip install -e ./cli`).")
 
 
 def check_spoke(vault_path: Optional[str]) -> CheckResult:
@@ -356,6 +380,7 @@ def run_doctor(vault_path: Optional[str], db_path: Optional[str],
     checks = [
         check_python(),
         check_node(),
+        check_uv(),
         check_git(),
         check_vault_exists(vault_path),
         check_vault_is_git(vault_path),

--- a/cli/schist/doctor.py
+++ b/cli/schist/doctor.py
@@ -230,7 +230,7 @@ def check_ingest_available(vault_path: Optional[str]) -> CheckResult:
         return CheckResult("PASS", "Ingest", "schist-ingest on PATH")
 
     return CheckResult("FAIL", "Ingest", "schist-ingest not found",
-                       "Set SCHIST_INGEST_SCRIPT or run `uv pip install -e ./cli` (or `pip install -e ./cli`).")
+                       "Set SCHIST_INGEST_SCRIPT or run `uv pip install --system -e ./cli` (or `pip install -e ./cli`).")
 
 
 def check_spoke(vault_path: Optional[str]) -> CheckResult:

--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -26,7 +26,8 @@ PRE_RECEIVE_HOOK = """\
 \"\"\"Git pre-receive hook — enforces vault.yaml ACL on pushes.
 
 Installed by `schist init --hub`. Requires the schist package to be
-importable by `python3` on this host (pip install -e <schist>/cli).
+importable by `python3` on this host
+(uv pip install --system -e <schist>/cli, or pip install -e <schist>/cli).
 \"\"\"
 
 import sys
@@ -512,7 +513,7 @@ def _build_hub_in_staging(
             "  The pre-receive hook will reject all pushes until the schist\n"
             "  package is installed on the path that git-receive-pack uses\n"
             "  (check sshd/gitolite env, not just your interactive shell):\n"
-            "  pip install -e <schist>/cli",
+            "  uv pip install --system -e <schist>/cli   (or: pip install -e <schist>/cli)",
             file=sys.stderr,
         )
 

--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -27,7 +27,7 @@ PRE_RECEIVE_HOOK = """\
 
 Installed by `schist init --hub`. Requires the schist package to be
 importable by `python3` on this host
-(uv pip install --system -e <schist>/cli, or pip install -e <schist>/cli).
+(pip install -e <schist>/cli, or uv pip install --system -e <schist>/cli).
 \"\"\"
 
 import sys
@@ -513,7 +513,7 @@ def _build_hub_in_staging(
             "  The pre-receive hook will reject all pushes until the schist\n"
             "  package is installed on the path that git-receive-pack uses\n"
             "  (check sshd/gitolite env, not just your interactive shell):\n"
-            "  uv pip install --system -e <schist>/cli   (or: pip install -e <schist>/cli)",
+            "  pip install -e <schist>/cli   (or: uv pip install --system -e <schist>/cli)",
             file=sys.stderr,
         )
 

--- a/cli/tests/test_doctor.py
+++ b/cli/tests/test_doctor.py
@@ -92,6 +92,18 @@ class TestCheckUv:
             # know they can keep going either way.
             assert r.fix and "astral.sh" in r.fix and "pip" in r.fix
 
+    def test_warn_when_subprocess_raises(self):
+        # uv binary present but `uv --version` throws (timeout, broken install,
+        # permission error, etc.) — surface a WARN with an install pointer
+        # rather than crashing the whole doctor run.
+        with patch("shutil.which", return_value="/usr/local/bin/uv"):
+            with patch("subprocess.run", side_effect=OSError("permission denied")):
+                r = check_uv()
+                assert r.status == "WARN"
+                assert r.label == "uv"
+                assert "error" in r.message
+                assert r.fix and "astral.sh" in r.fix
+
 
 class TestCheckGit:
     def test_pass(self):

--- a/cli/tests/test_doctor.py
+++ b/cli/tests/test_doctor.py
@@ -22,6 +22,7 @@ from schist.doctor import (
     check_schist_yaml,
     check_spoke,
     check_sqlite,
+    check_uv,
     check_vault_exists,
     check_vault_is_git,
     run_doctor,
@@ -67,6 +68,29 @@ class TestCheckNode:
                 )
                 r = check_node()
                 assert r.status == "FAIL"
+
+
+class TestCheckUv:
+    def test_pass_when_installed(self):
+        with patch("shutil.which", return_value="/usr/local/bin/uv"):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout="uv 0.5.24\n"
+                )
+                r = check_uv()
+                assert r.status == "PASS"
+                assert r.label == "uv"
+                assert "0.5.24" in r.message
+
+    def test_warn_when_missing(self):
+        with patch("shutil.which", return_value=None):
+            r = check_uv()
+            assert r.status == "WARN"
+            assert r.label == "uv"
+            assert "not found" in r.message
+            # Recommendation should mention uv install + pip fallback so users
+            # know they can keep going either way.
+            assert r.fix and "astral.sh" in r.fix and "pip" in r.fix
 
 
 class TestCheckGit:

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -1,0 +1,75 @@
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "python-frontmatter"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/de/910fa208120314a12f9a88ea63e03707261692af782c99283f1a2c8a5e6f/python-frontmatter-1.1.0.tar.gz", hash = "sha256:7118d2bd56af9149625745c58c9b51fb67e8d1294a0c76796dafdc72c36e5f6d", size = 16256 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl", hash = "sha256:335465556358d9d0e6c98bbeb69b1c969f2a4a21360587b9873bfc3b213407c1", size = 9834 },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063 },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973 },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116 },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011 },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870 },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089 },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181 },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658 },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003 },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344 },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669 },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252 },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081 },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159 },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626 },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613 },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115 },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427 },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090 },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246 },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814 },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809 },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454 },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355 },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175 },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228 },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194 },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429 },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912 },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108 },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641 },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901 },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132 },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261 },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272 },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923 },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062 },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341 },
+]
+
+[[package]]
+name = "schist"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "python-frontmatter" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "python-frontmatter", specifier = ">=1.1.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
+]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,11 +97,15 @@ npm install -g @schist/mcp-server
 
 ### Option B: From source (latest development)
 
+schist recommends [uv](https://docs.astral.sh/uv/) for source installs — faster
+than pip and reproducible via the checked-in `cli/uv.lock`. pip still works as
+a fallback.
+
 ```bash
 git clone https://github.com/yibeichan/schist.git
 cd schist
 
-pip install -e ./cli
+uv pip install --system -e ./cli   # or:  pip install -e ./cli
 cd mcp-server && npm install && npm run build && cd ..
 ```
 
@@ -218,9 +222,9 @@ Add to `~/.bashrc` or `~/.zshrc` for persistence.
 ### 2. `schist-ingest: command not found`
 
 ```bash
-pip install -e ./cli    # from source
-# or
-pip install schist      # published
+uv pip install --system -e ./cli   # from source (or: pip install -e ./cli)
+# or, for end users:
+pip install schist                 # published
 ```
 
 Verify: `which schist-ingest`. If installed but not found, check that pip's bin directory is on `$PATH`.

--- a/docs/hub-spoke-pi-hpc-mac.md
+++ b/docs/hub-spoke-pi-hpc-mac.md
@@ -139,7 +139,7 @@ brew install python@3.13 node git
 
 ```bash
 pip install schist
-# Or from source: pip install -e /path/to/schist/cli
+# Or from source: uv pip install --system -e /path/to/schist/cli (or pip install -e ...)
 ```
 
 ### Initialize spoke

--- a/docs/hub-spoke-setup.md
+++ b/docs/hub-spoke-setup.md
@@ -41,7 +41,7 @@ On **every** machine (hub and spokes):
 
 ```bash
 git clone https://github.com/youruser/schist.git /path/to/schist
-pip install -e /path/to/schist/cli
+uv pip install --system -e /path/to/schist/cli   # or: pip install -e /path/to/schist/cli
 ```
 
 The pre-receive hook on the hub imports `schist.pre_receive`, so the package
@@ -221,7 +221,7 @@ local view until the hub comes back.
 ### "pre-receive: ModuleNotFoundError: schist.pre_receive"
 
 The schist package isn't installed for the `python3` the hook uses. On the
-hub, `pip install -e /path/to/schist/cli` and re-test with a dry push.
+hub, `uv pip install --system -e /path/to/schist/cli` (or `pip install -e /path/to/schist/cli`) and re-test with a dry push.
 
 ### "Can I use GitHub / Gitea / GitLab SaaS as the hub?"
 

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -65,8 +65,8 @@ schist-ingest \
 ```
 
 (`schist-ingest` is the console script installed by `pip install schist`. If you
-work from a clone instead of an installed wheel, use `pip install -e ./cli` to
-register it on your `PATH`.)
+work from a clone instead of an installed wheel, use `uv pip install --system -e ./cli`
+(or `pip install -e ./cli`) to register it on your `PATH`.)
 
 The hook file lives in `.git/hooks/` and is never committed to any repository.
 


### PR DESCRIPTION
## Summary

Recommend [uv](https://docs.astral.sh/uv/) as the source/dev install path everywhere `pip install -e ./cli` previously appeared. Keeps pip working as an explicit fallback. End-user `pip install schist` from PyPI is unchanged.

Captures a workflow the maintainer was already using locally; aligns docs, CI, lockfile, and doctor checks behind it.

## Why uv now

- **Faster.** `uv pip install` vs `pip install` is measurably quicker on Mac/Linux — non-trivial for a 4-spoke deployment that re-installs after every clone.
- **Reproducible.** `cli/uv.lock` is now checked in. Mac (arm64), Pi (arm32/64), and HPC (x86_64) all resolve to the same transitive deps. pyproject.toml stays authoritative; the lock is generated, not edited.
- **Already in use.** The maintainer's local test runs go through `uv run --with`. Promoting it to the documented toolchain matches reality and lets `schist doctor` validate the setup.

## Scope (light migration)

- pyproject.toml unchanged. No `[dependency-groups]` adoption, no `.venv` management required.
- `uv pip install --system -e ./cli` is the recommended command everywhere. pip continues to work as an explicit fallback (called out in CLAUDE.md, getting-started.md, etc.).
- End-user `pip install schist` from PyPI is intentionally untouched — that path doesn't need uv at all.

## What changed

### Code
- `cli/schist/doctor.py`: new `check_uv()` (PASS with version / WARN if missing — not FAIL, pip still works). Registered between Node and Git checks.
- `cli/schist/doctor.py`, `cli/schist/sync.py`: error/warning messages updated to lead with `uv pip install` and fall back to `pip install`.

### Tests
- `cli/tests/test_doctor.py`: new `TestCheckUv` covering PASS/WARN paths. Local: 313/313 + 1 pre-existing skip.

### CI
- `.github/workflows/ci.yml`: both jobs use `astral-sh/setup-uv@v8.1.0` (pinned by SHA, `08807647...`) with cached deps keyed on `cli/uv.lock`. `pip install -e ./cli` calls migrated to `uv pip install --system -e ./cli`.
- `release.yml` left untouched — one-shot `pip install build` not worth setup-uv overhead.

### Lockfile
- `cli/uv.lock` checked in. 75 lines, 3 packages (python-frontmatter, pyyaml, schist as editable). Generated via `uv lock` from `cli/`.

### Docs
- `CLAUDE.md`, `README.md`, `docs/getting-started.md`, `docs/hub-spoke-setup.md`, `docs/hub-spoke-pi-hpc-mac.md`, `docs/mcp-setup.md`, `PLAN.md`: source-install lines updated.
- `CHANGELOG.md` (0.2.0): Added + Changed entries.

## Test plan

- [x] `cd cli && uv run --with pytest --with . python -m pytest tests/` — 313 passed, 1 pre-existing skip
- [x] Live `schist doctor` against the maintainer's vault — now reports `[PASS] uv: uv 0.5.24` as the third line
- [x] `grep -rn 'pip install -e' --include="*.md" --include="*.yml" --include="*.py"` — only intentional fallback mentions remain
- [ ] CI green on this PR (verifies the new setup-uv action + `uv pip install --system` actually works on Ubuntu runners)

## Risk

- **CI:** the new uv-based install must produce a working `schist` + `schist-ingest` on PATH for the existing test suite. If `--system` install behavior differs from pip, tests would catch it.
- **Hub/spoke deployments:** existing operators may not have uv installed. The doctor `WARN` (not `FAIL`) plus the pip-fallback messaging in error strings means existing deployments keep working — the only impact is that the doctor flags "uv is not installed" without breaking anything.

## Follow-up — not in this PR

- If we later commit to the full uv-native workflow (`[dependency-groups]` for pytest + dev deps, `uv sync`, `uv run pytest`), that's a separate PR. This one is the drop-in-faster-pip version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)