### PR TITLE
fix(cli): tighten pre-commit secret regex + stale-hook upgrade path (#103)

### DIFF
--- a/cli/schist/__main__.py
+++ b/cli/schist/__main__.py
@@ -95,6 +95,12 @@ def main():
     sync_sub.add_parser('pull', help='Pull updates from hub')
     sync_sub.add_parser('push', help='Push local changes to hub')
 
+    # hooks
+    p_hooks = sub.add_parser('hooks', help='Manage installed git hooks')
+    hooks_sub = p_hooks.add_subparsers(dest='hooks_action')
+    hooks_sub.add_parser('reinstall',
+                         help='Refresh pre-commit and post-commit hooks from canonical templates')
+
     args = parser.parse_args()
 
     if not args.command:
@@ -127,6 +133,15 @@ def main():
             sync.sync_push(args, vault_path, db_path)
         else:
             print('Usage: schist sync {pull|push}', file=sys.stderr)
+            sys.exit(1)
+        sys.exit(0)
+
+    # hooks sub-dispatch
+    if args.command == 'hooks':
+        if args.hooks_action == 'reinstall':
+            sync.hooks_reinstall(args, vault_path, db_path)
+        else:
+            print('Usage: schist hooks reinstall', file=sys.stderr)
             sys.exit(1)
         sys.exit(0)
 

--- a/cli/schist/__main__.py
+++ b/cli/schist/__main__.py
@@ -98,8 +98,14 @@ def main():
     # hooks
     p_hooks = sub.add_parser('hooks', help='Manage installed git hooks')
     hooks_sub = p_hooks.add_subparsers(dest='hooks_action')
-    hooks_sub.add_parser('reinstall',
-                         help='Refresh pre-commit and post-commit hooks from canonical templates')
+    p_hooks_reinstall = hooks_sub.add_parser(
+        'reinstall',
+        help='Refresh pre-commit and post-commit hooks from canonical templates',
+    )
+    p_hooks_reinstall.add_argument(
+        '--force', action='store_true',
+        help='Also overwrite hooks marked `# schist-hook-version: pinned` (opt-out marker)',
+    )
 
     args = parser.parse_args()
 

--- a/cli/schist/doctor.py
+++ b/cli/schist/doctor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import sqlite3
 import subprocess
@@ -177,6 +178,67 @@ def check_post_commit_hook(vault_path: Optional[str]) -> CheckResult:
         return CheckResult("PASS", "Post-commit hook", "installed")
     return CheckResult("FAIL", "Post-commit hook", "not installed",
                        f"Run `schist init {vault_path}` to install hooks.")
+
+
+_HOOK_VERSION_RE = re.compile(r"^# schist-hook-version:\s*(\S+)\s*$", re.MULTILINE)
+
+
+def _installed_hook_version(hook_path: Path) -> Optional[str]:
+    """Read the `# schist-hook-version:` marker from an installed hook.
+
+    Returns the version token as a string (`"2"`, `"pinned"`, etc.), or None if
+    the hook file is missing or has no marker (legacy unversioned hook).
+    """
+    try:
+        text = hook_path.read_text()
+    except (OSError, UnicodeDecodeError):
+        return None
+    m = _HOOK_VERSION_RE.search(text)
+    return m.group(1) if m else None
+
+
+def check_hooks_freshness(vault_path: Optional[str]) -> CheckResult:
+    """Compare installed pre/post-commit hooks against the canonical templates.
+
+    Warns when a vault is running a stale hook template — e.g. a spoke that
+    was init'd before the pre-commit regex was tightened (issue #103). Users
+    who intentionally customized their hooks can set the version line to
+    `# schist-hook-version: pinned` to silence the warning.
+    """
+    if not vault_path:
+        return CheckResult("SKIP", "Hooks freshness", "skipped (no vault)")
+    if not (Path(vault_path) / ".git").exists():
+        return CheckResult("SKIP", "Hooks freshness", "skipped (not a git repo)")
+
+    # Local import to keep this module's import graph cheap when sync.py is not
+    # the entry point. sync.py imports many things including subprocess/shutil.
+    from . import sync as sync_mod
+
+    current = str(sync_mod.HOOK_VERSION)
+    hooks_dir = Path(vault_path) / ".git" / "hooks"
+    stale = []
+    pinned = []
+    for name in ("pre-commit", "post-commit"):
+        installed = _installed_hook_version(hooks_dir / name)
+        if installed is None:
+            stale.append(f"{name}: legacy (no version marker)")
+        elif installed == "pinned":
+            pinned.append(name)
+        elif installed != current:
+            stale.append(f"{name}: v{installed} (current: v{current})")
+
+    if stale:
+        return CheckResult(
+            "WARN", "Hooks freshness",
+            "; ".join(stale),
+            fix=f"Run `schist --vault {vault_path} hooks reinstall` to update.",
+        )
+    if pinned:
+        return CheckResult(
+            "PASS", "Hooks freshness",
+            f"current (v{current}); pinned: {', '.join(pinned)}",
+        )
+    return CheckResult("PASS", "Hooks freshness", f"current (v{current})")
 
 
 def check_hooks_path(vault_path: Optional[str]) -> CheckResult:
@@ -387,6 +449,7 @@ def run_doctor(vault_path: Optional[str], db_path: Optional[str],
         check_schist_yaml(vault_path),
         check_sqlite(vault_path, db_path),
         check_post_commit_hook(vault_path),
+        check_hooks_freshness(vault_path),
         check_hooks_path(vault_path),
         check_ingest_available(vault_path),
         check_spoke(vault_path),

--- a/cli/schist/doctor.py
+++ b/cli/schist/doctor.py
@@ -180,19 +180,33 @@ def check_post_commit_hook(vault_path: Optional[str]) -> CheckResult:
                        f"Run `schist init {vault_path}` to install hooks.")
 
 
-_HOOK_VERSION_RE = re.compile(r"^# schist-hook-version:\s*(\S+)\s*$", re.MULTILINE)
+# Match the marker line and tolerate an optional trailing `# comment` so users
+# who annotate the line ("# schist-hook-version: 2  # bumped 2026-05-19") still
+# parse as v2 rather than falling through to "legacy".
+_HOOK_VERSION_RE = re.compile(
+    r"^# schist-hook-version:\s*(\S+)\s*(?:#.*)?$", re.MULTILINE
+)
+
+
+class HookReadError(RuntimeError):
+    """Raised when a hook file exists but cannot be read (e.g. permissions)."""
 
 
 def _installed_hook_version(hook_path: Path) -> Optional[str]:
     """Read the `# schist-hook-version:` marker from an installed hook.
 
-    Returns the version token as a string (`"2"`, `"pinned"`, etc.), or None if
-    the hook file is missing or has no marker (legacy unversioned hook).
+    Returns the version token as a string (`"2"`, `"pinned"`, etc.), None if
+    the hook is missing or has no marker (legacy unversioned hook). Raises
+    HookReadError when the file exists but is unreadable — that case must NOT
+    collapse into "legacy" because the recommended fix (`hooks reinstall`)
+    would also fail.
     """
     try:
         text = hook_path.read_text()
-    except (OSError, UnicodeDecodeError):
+    except FileNotFoundError:
         return None
+    except (OSError, UnicodeDecodeError) as e:
+        raise HookReadError(f"cannot read {hook_path}: {e}") from e
     m = _HOOK_VERSION_RE.search(text)
     return m.group(1) if m else None
 
@@ -218,8 +232,13 @@ def check_hooks_freshness(vault_path: Optional[str]) -> CheckResult:
     hooks_dir = Path(vault_path) / ".git" / "hooks"
     stale = []
     pinned = []
+    unreadable = []
     for name in ("pre-commit", "post-commit"):
-        installed = _installed_hook_version(hooks_dir / name)
+        try:
+            installed = _installed_hook_version(hooks_dir / name)
+        except HookReadError as e:
+            unreadable.append(f"{name}: {e}")
+            continue
         if installed is None:
             stale.append(f"{name}: legacy (no version marker)")
         elif installed == "pinned":
@@ -227,6 +246,12 @@ def check_hooks_freshness(vault_path: Optional[str]) -> CheckResult:
         elif installed != current:
             stale.append(f"{name}: v{installed} (current: v{current})")
 
+    if unreadable:
+        return CheckResult(
+            "FAIL", "Hooks freshness",
+            "; ".join(unreadable),
+            fix="Check filesystem permissions on .git/hooks/ — schist cannot read the installed hooks.",
+        )
     if stale:
         return CheckResult(
             "WARN", "Hooks freshness",

--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -98,6 +98,20 @@ exit 0
 """
 
 
+def _atomic_write_hook(hook_path: Path, body: str) -> None:
+    """Write `body` to `hook_path` atomically + executable.
+
+    A naive `write_text` then `chmod` leaves a window where a concurrent git
+    invocation could `exec` a half-written shell script. We write to a sibling
+    `.tmp` file (same directory ⇒ same filesystem ⇒ rename is atomic on POSIX)
+    and `os.replace` over the target.
+    """
+    tmp = hook_path.with_name(hook_path.name + ".tmp")
+    tmp.write_text(body)
+    tmp.chmod(0o755)
+    os.replace(tmp, hook_path)
+
+
 def _install_local_hooks(vault_path) -> None:
     """Write the post-commit and pre-commit hooks into a working-tree repo.
 
@@ -108,28 +122,59 @@ def _install_local_hooks(vault_path) -> None:
     """
     hooks_dir = Path(vault_path) / ".git" / "hooks"
     hooks_dir.mkdir(parents=True, exist_ok=True)
-    post = hooks_dir / "post-commit"
-    post.write_text(POST_COMMIT_HOOK)
-    post.chmod(0o755)
-    pre = hooks_dir / "pre-commit"
-    pre.write_text(PRE_COMMIT_HOOK)
-    pre.chmod(0o755)
+    _atomic_write_hook(hooks_dir / "post-commit", POST_COMMIT_HOOK)
+    _atomic_write_hook(hooks_dir / "pre-commit", PRE_COMMIT_HOOK)
+
+
+_HOOK_VERSION_LINE = re.compile(r"^# schist-hook-version:\s*(\S+)", re.MULTILINE)
+
+
+def _hook_pinned(hook_path: Path) -> bool:
+    """Return True iff the hook carries a `# schist-hook-version: pinned`
+    marker — the opt-out signal users set on intentionally-customized hooks.
+    """
+    try:
+        text = hook_path.read_text()
+    except (FileNotFoundError, OSError, UnicodeDecodeError):
+        return False
+    m = _HOOK_VERSION_LINE.search(text)
+    return bool(m and m.group(1) == "pinned")
 
 
 def hooks_reinstall(args, vault_path: str, db_path: str) -> None:
     """Re-write pre-commit and post-commit hooks from the canonical templates.
 
     Refreshes spokes that were init'd before HOOK_VERSION was bumped (issue
-    #103). Overwrites any local modifications — users who customized their
-    hooks should keep a copy before running this.
+    #103). Hooks carrying `# schist-hook-version: pinned` are skipped unless
+    `--force` is passed — that marker is the documented opt-out for users who
+    intentionally customized their hook bodies.
     """
     target = Path(vault_path)
     if not (target / ".git").exists():
         print(f"Error: {vault_path} is not a git repository", file=sys.stderr)
         sys.exit(1)
-    _install_local_hooks(str(target))
-    print(f"Reinstalled pre-commit and post-commit hooks at {target}/.git/hooks/")
-    print(f"Hook template version: {HOOK_VERSION}")
+
+    hooks_dir = target / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    force = getattr(args, "force", False)
+    skipped = []
+    written = []
+    for name, body in (("pre-commit", PRE_COMMIT_HOOK), ("post-commit", POST_COMMIT_HOOK)):
+        path = hooks_dir / name
+        if not force and _hook_pinned(path):
+            skipped.append(name)
+            continue
+        _atomic_write_hook(path, body)
+        written.append(name)
+
+    if written:
+        print(f"Reinstalled hooks: {', '.join(written)} (template v{HOOK_VERSION})")
+    for name in skipped:
+        print(
+            f"Skipped {name}: marked `# schist-hook-version: pinned`. "
+            f"Pass --force to overwrite.",
+            file=sys.stderr,
+        )
 
 
 def init_spoke(args, vault_path: str, db_path: str) -> None:

--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -40,6 +40,7 @@ sys.exit(main())
 
 POST_COMMIT_HOOK = r"""#!/bin/sh
 # schist post-commit hook — re-ingest vault into SQLite after every commit
+# schist-hook-version: 2
 
 VAULT_ROOT=$(git rev-parse --show-toplevel)
 DB_PATH="$VAULT_ROOT/.schist/schist.db"
@@ -62,10 +63,22 @@ python3 "$INGEST" --vault "$VAULT_ROOT" --db "$DB_PATH"
 """
 
 
+# Bump HOOK_VERSION when you change PRE_COMMIT_HOOK or POST_COMMIT_HOOK so that
+# `schist doctor` can detect spokes running stale hook templates. The matching
+# `# schist-hook-version: N` line lives inside each hook script body. A user
+# who has intentionally customized their hook can replace the version line
+# with `# schist-hook-version: pinned` to silence the staleness warning.
+HOOK_VERSION = 2
+
 PRE_COMMIT_HOOK = r"""#!/bin/sh
 # schist pre-commit hook — reject staged files containing secrets
+# schist-hook-version: 2
 
-PATTERNS='sk-[A-Za-z0-9_-]{20,}|ghp_[A-Za-z0-9]{20,}|ghs_[A-Za-z0-9]{20,}|AKIA[A-Z0-9]{16}|-----BEGIN|password\s*=|api_key\s*='
+# Patterns intentionally require a left boundary on token prefixes so substrings
+# like "task-..." inside a filename don't trigger on "sk-...", and require a
+# quoted value for password/api_key so docs prose ("set `password = <value>`")
+# doesn't trip the guard. See issue #103 for the false-positive cases.
+PATTERNS="(^|[^A-Za-z0-9])sk-[A-Za-z0-9_-]{20,}|(^|[^A-Za-z0-9])ghp_[A-Za-z0-9]{20,}|(^|[^A-Za-z0-9])ghs_[A-Za-z0-9]{20,}|(^|[^A-Za-z0-9])AKIA[A-Z0-9]{16}|-----BEGIN [A-Z ]+PRIVATE KEY-----|password\s*=\s*[\"'][^\"' ]+[\"']|api_key\s*=\s*[\"'][^\"' ]+[\"']"
 
 STAGED_FILES=$(git diff --cached --name-only)
 if [ -z "$STAGED_FILES" ]; then
@@ -90,7 +103,8 @@ def _install_local_hooks(vault_path) -> None:
 
     Shared by standalone and spoke init so either flavor of vault gets the
     SQLite auto-rebuild and the staged-secret guard. Caller must have already
-    created `<vault>/.git/`.
+    created `<vault>/.git/`. Also called by `schist hooks reinstall` to refresh
+    spokes initialized with an older hook template (issue #103).
     """
     hooks_dir = Path(vault_path) / ".git" / "hooks"
     hooks_dir.mkdir(parents=True, exist_ok=True)
@@ -100,6 +114,22 @@ def _install_local_hooks(vault_path) -> None:
     pre = hooks_dir / "pre-commit"
     pre.write_text(PRE_COMMIT_HOOK)
     pre.chmod(0o755)
+
+
+def hooks_reinstall(args, vault_path: str, db_path: str) -> None:
+    """Re-write pre-commit and post-commit hooks from the canonical templates.
+
+    Refreshes spokes that were init'd before HOOK_VERSION was bumped (issue
+    #103). Overwrites any local modifications — users who customized their
+    hooks should keep a copy before running this.
+    """
+    target = Path(vault_path)
+    if not (target / ".git").exists():
+        print(f"Error: {vault_path} is not a git repository", file=sys.stderr)
+        sys.exit(1)
+    _install_local_hooks(str(target))
+    print(f"Reinstalled pre-commit and post-commit hooks at {target}/.git/hooks/")
+    print(f"Hook template version: {HOOK_VERSION}")
 
 
 def init_spoke(args, vault_path: str, db_path: str) -> None:

--- a/cli/tests/test_doctor.py
+++ b/cli/tests/test_doctor.py
@@ -13,6 +13,7 @@ import yaml
 from schist.doctor import (
     CheckResult,
     check_git,
+    check_hooks_freshness,
     check_hooks_path,
     check_ingest_available,
     check_mcp_config,
@@ -27,6 +28,7 @@ from schist.doctor import (
     check_vault_is_git,
     run_doctor,
 )
+from schist.sync import HOOK_VERSION, POST_COMMIT_HOOK, PRE_COMMIT_HOOK
 
 
 # ---------------------------------------------------------------------------
@@ -214,6 +216,65 @@ class TestCheckPostCommitHook:
         (tmp_path / ".git").mkdir()
         r = check_post_commit_hook(str(tmp_path))
         assert r.status == "FAIL"
+
+
+class TestCheckHooksFreshness:
+    """Issue #103 — detect spokes still running an older hook template so
+    fixes to the secret regex actually reach existing installations."""
+
+    def _install_hook(self, vault: Path, name: str, body: str) -> None:
+        hooks = vault / ".git" / "hooks"
+        hooks.mkdir(parents=True, exist_ok=True)
+        (hooks / name).write_text(body)
+
+    def test_no_path(self):
+        r = check_hooks_freshness(None)
+        assert r.status == "SKIP"
+
+    def test_not_a_git_repo(self, tmp_path):
+        r = check_hooks_freshness(str(tmp_path))
+        assert r.status == "SKIP"
+
+    def test_current_versions_pass(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        self._install_hook(tmp_path, "pre-commit", PRE_COMMIT_HOOK)
+        self._install_hook(tmp_path, "post-commit", POST_COMMIT_HOOK)
+        r = check_hooks_freshness(str(tmp_path))
+        assert r.status == "PASS"
+        assert f"v{HOOK_VERSION}" in r.message
+
+    def test_legacy_unversioned_hook_warns(self, tmp_path):
+        """A spoke init'd before HOOK_VERSION was introduced has no marker —
+        must surface as stale so the user knows to reinstall."""
+        (tmp_path / ".git").mkdir()
+        self._install_hook(tmp_path, "pre-commit",
+                           "#!/bin/sh\n# legacy hook with no version marker\nexit 0\n")
+        self._install_hook(tmp_path, "post-commit", POST_COMMIT_HOOK)
+        r = check_hooks_freshness(str(tmp_path))
+        assert r.status == "WARN"
+        assert "legacy" in r.message
+        assert r.fix is not None
+        assert "hooks reinstall" in r.fix
+
+    def test_old_versioned_hook_warns(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        self._install_hook(tmp_path, "pre-commit",
+                           "#!/bin/sh\n# schist-hook-version: 1\nexit 0\n")
+        self._install_hook(tmp_path, "post-commit", POST_COMMIT_HOOK)
+        r = check_hooks_freshness(str(tmp_path))
+        assert r.status == "WARN"
+        assert "v1" in r.message
+        assert f"v{HOOK_VERSION}" in r.message
+
+    def test_pinned_marker_silences_warning(self, tmp_path):
+        """User who customized their hook can opt out with `pinned`."""
+        (tmp_path / ".git").mkdir()
+        self._install_hook(tmp_path, "pre-commit",
+                           "#!/bin/sh\n# schist-hook-version: pinned\n# my custom patterns\nexit 0\n")
+        self._install_hook(tmp_path, "post-commit", POST_COMMIT_HOOK)
+        r = check_hooks_freshness(str(tmp_path))
+        assert r.status == "PASS"
+        assert "pinned" in r.message
 
 
 class TestCheckHooksPath:

--- a/cli/tests/test_pre_commit_hook.py
+++ b/cli/tests/test_pre_commit_hook.py
@@ -87,9 +87,17 @@ def test_real_secrets_blocked(vault: Path, content: str) -> None:
     assert "Potential secret detected" in result.stdout + result.stderr
 
 
-def test_hook_carries_version_marker() -> None:
+def test_pre_commit_hook_carries_version_marker() -> None:
     """Doctor's freshness check parses this marker — it must be present."""
     assert f"# schist-hook-version: {HOOK_VERSION}" in PRE_COMMIT_HOOK
+
+
+def test_post_commit_hook_carries_version_marker() -> None:
+    """Both hook templates carry a version marker; bumping HOOK_VERSION must
+    update both literals in lockstep. This test catches drift."""
+    from schist.sync import POST_COMMIT_HOOK
+
+    assert f"# schist-hook-version: {HOOK_VERSION}" in POST_COMMIT_HOOK
 
 
 def test_hook_version_is_an_int() -> None:
@@ -97,3 +105,110 @@ def test_hook_version_is_an_int() -> None:
     should be an int so bumps are unambiguous."""
     assert isinstance(HOOK_VERSION, int)
     assert HOOK_VERSION >= 2  # was 1 (unversioned) before issue #103
+
+
+class TestHooksReinstall:
+    """Direct tests for the `schist hooks reinstall` command path.
+
+    The end-to-end CLI is exercised via __main__, but the sync.hooks_reinstall
+    function is the unit under test — covers happy path, missing-.git error,
+    pinned-skip, --force override, and the atomic-rename invariant."""
+
+    def _vault(self, tmp_path: Path) -> Path:
+        v = tmp_path / "v"
+        v.mkdir()
+        (v / ".git").mkdir()
+        (v / ".git" / "hooks").mkdir()
+        return v
+
+    def _args(self, force: bool = False):
+        from argparse import Namespace
+        return Namespace(force=force)
+
+    def test_happy_path_writes_both_hooks(self, tmp_path: Path) -> None:
+        from schist.sync import hooks_reinstall, PRE_COMMIT_HOOK, POST_COMMIT_HOOK
+
+        v = self._vault(tmp_path)
+        hooks_reinstall(self._args(), str(v), "")
+        assert (v / ".git" / "hooks" / "pre-commit").read_text() == PRE_COMMIT_HOOK
+        assert (v / ".git" / "hooks" / "post-commit").read_text() == POST_COMMIT_HOOK
+        # Atomic-rename leaves no stray .tmp siblings.
+        leftover = list((v / ".git" / "hooks").glob("*.tmp"))
+        assert leftover == [], f"unexpected .tmp leftovers: {leftover}"
+
+    def test_not_a_git_repo_exits(self, tmp_path: Path) -> None:
+        from schist.sync import hooks_reinstall
+
+        with pytest.raises(SystemExit) as exc:
+            hooks_reinstall(self._args(), str(tmp_path), "")
+        assert exc.value.code == 1
+
+    def test_pinned_hook_is_skipped(self, tmp_path: Path, capsys) -> None:
+        from schist.sync import hooks_reinstall, PRE_COMMIT_HOOK
+
+        v = self._vault(tmp_path)
+        pinned_body = "#!/bin/sh\n# schist-hook-version: pinned\n# my custom guard\nexit 0\n"
+        (v / ".git" / "hooks" / "pre-commit").write_text(pinned_body)
+
+        hooks_reinstall(self._args(force=False), str(v), "")
+
+        # pre-commit untouched
+        assert (v / ".git" / "hooks" / "pre-commit").read_text() == pinned_body
+        # post-commit refreshed
+        from schist.sync import POST_COMMIT_HOOK
+        assert (v / ".git" / "hooks" / "post-commit").read_text() == POST_COMMIT_HOOK
+        # User sees the skip notice
+        err = capsys.readouterr().err
+        assert "Skipped pre-commit" in err
+        assert "pinned" in err
+        assert "--force" in err
+
+    def test_force_overwrites_pinned(self, tmp_path: Path) -> None:
+        from schist.sync import hooks_reinstall, PRE_COMMIT_HOOK
+
+        v = self._vault(tmp_path)
+        (v / ".git" / "hooks" / "pre-commit").write_text(
+            "#!/bin/sh\n# schist-hook-version: pinned\nexit 0\n"
+        )
+        hooks_reinstall(self._args(force=True), str(v), "")
+        assert (v / ".git" / "hooks" / "pre-commit").read_text() == PRE_COMMIT_HOOK
+
+
+def test_version_marker_with_trailing_comment_parses() -> None:
+    """Users sometimes annotate the marker — doctor's regex must tolerate
+    `# schist-hook-version: 2 # bumped 2026-05-19` rather than collapsing to
+    'legacy'."""
+    from schist.doctor import _installed_hook_version
+    import tempfile
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
+        f.write("#!/bin/sh\n# schist-hook-version: 2  # bumped 2026-05-19\nexit 0\n")
+        path = Path(f.name)
+    try:
+        assert _installed_hook_version(path) == "2"
+    finally:
+        path.unlink()
+
+
+def test_unreadable_hook_raises_distinct_error(tmp_path: Path) -> None:
+    """A permission-locked hook must NOT collapse into 'legacy' — that would
+    suggest the user run `hooks reinstall`, which would also fail with the
+    same permission error. doctor.HookReadError keeps the failure visible."""
+    from schist.doctor import _installed_hook_version, HookReadError
+
+    hook = tmp_path / "pre-commit"
+    hook.write_text("#!/bin/sh\nexit 0\n")
+    hook.chmod(0o000)  # unreadable
+
+    try:
+        with pytest.raises(HookReadError):
+            _installed_hook_version(hook)
+    finally:
+        hook.chmod(0o644)  # so pytest can clean up
+
+
+def test_missing_hook_returns_none() -> None:
+    """FileNotFoundError stays distinct from PermissionError — missing hook
+    is None (check_post_commit_hook reports it separately), not a HookReadError."""
+    from schist.doctor import _installed_hook_version
+
+    assert _installed_hook_version(Path("/nonexistent/hook")) is None

--- a/cli/tests/test_pre_commit_hook.py
+++ b/cli/tests/test_pre_commit_hook.py
@@ -1,0 +1,99 @@
+"""Corpus tests for the pre-commit secret-detection regex (issue #103).
+
+The hook ships as a shell template baked into `cli/schist/sync.py`. These tests
+install it into a real git repo and confirm the staged-secret guard accepts
+benign content (false positives that previously burned users) and still rejects
+real-looking secrets.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from schist.sync import PRE_COMMIT_HOOK, HOOK_VERSION
+
+
+# Strings that previously tripped the hook even though they contain no secret.
+# Each is something the user reported in #103 or is a representative analogue.
+SHOULD_NOT_MATCH = [
+    "risk-hedge",
+    "concepts/2026-05-18-brain-state-vs-task-context-terminology.md",
+    "task-some-long-concept-slug-with-dashes",
+    "task-vs-task",
+    "-----BEGIN draft outline-----",
+    "-----BEGIN OUTLINE-----",
+    "set `password = <your-password>` in your env file",
+    "the api_key = <placeholder> example in the docs",
+]
+
+# Strings the hook MUST reject. If any of these silently pass, the secret guard
+# has lost coverage of a real attack surface.
+SHOULD_MATCH = [
+    "sk-proj-abcdef0123456789abcdef0123456789",
+    "API_TOKEN=sk-proj-abcdef0123456789abcdef0123456789",
+    "ghp_1234567890abcdefABCDEF1234567890abcdef",
+    "ghs_1234567890abcdefABCDEF1234567890abcdef",
+    "AKIAIOSFODNN7EXAMPLE",
+    "-----BEGIN RSA PRIVATE KEY-----",
+    "-----BEGIN OPENSSH PRIVATE KEY-----",
+    'password = "hunter2"',
+    "api_key = 'sk-redacted-but-quoted-value-here'",
+]
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    """A git repo with the canonical pre-commit hook installed."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=repo, check=True)
+    hook = repo / ".git" / "hooks" / "pre-commit"
+    hook.write_text(PRE_COMMIT_HOOK)
+    hook.chmod(0o755)
+    return repo
+
+
+def _try_commit(vault: Path, filename: str, content: str) -> subprocess.CompletedProcess:
+    (vault / filename).write_text(content)
+    subprocess.run(["git", "add", filename], cwd=vault, check=True)
+    return subprocess.run(
+        ["git", "commit", "-m", "test"],
+        cwd=vault, capture_output=True, text=True,
+    )
+
+
+@pytest.mark.parametrize("content", SHOULD_NOT_MATCH)
+def test_benign_content_commits(vault: Path, content: str) -> None:
+    """Free text and doc prose must not trigger the secret guard."""
+    result = _try_commit(vault, "note.md", content + "\n")
+    assert result.returncode == 0, (
+        f"Hook falsely rejected benign content {content!r}: {result.stdout}{result.stderr}"
+    )
+
+
+@pytest.mark.parametrize("content", SHOULD_MATCH)
+def test_real_secrets_blocked(vault: Path, content: str) -> None:
+    """Recognizable secret formats must still be rejected."""
+    result = _try_commit(vault, "secret.md", content + "\n")
+    assert result.returncode != 0, (
+        f"Hook silently accepted secret pattern {content!r}"
+    )
+    assert "Potential secret detected" in result.stdout + result.stderr
+
+
+def test_hook_carries_version_marker() -> None:
+    """Doctor's freshness check parses this marker — it must be present."""
+    assert f"# schist-hook-version: {HOOK_VERSION}" in PRE_COMMIT_HOOK
+
+
+def test_hook_version_is_an_int() -> None:
+    """`schist doctor` compares HOOK_VERSION as a token string but the constant
+    should be an int so bumps are unambiguous."""
+    assert isinstance(HOOK_VERSION, int)
+    assert HOOK_VERSION >= 2  # was 1 (unversioned) before issue #103

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -1,5 +1,6 @@
 #!/bin/sh
 # schist post-commit hook — re-ingest vault into SQLite after every commit
+# schist-hook-version: 2
 
 VAULT_ROOT=$(git rev-parse --show-toplevel)
 DB_PATH="$VAULT_ROOT/.schist/schist.db"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,7 +1,12 @@
 #!/bin/sh
 # schist pre-commit hook — reject staged files containing secrets
+# schist-hook-version: 2
 
-PATTERNS='sk-[A-Za-z0-9_-]{20,}|ghp_[A-Za-z0-9]{20,}|ghs_[A-Za-z0-9]{20,}|AKIA[A-Z0-9]{16}|-----BEGIN|password\s*=|api_key\s*='
+# Patterns intentionally require a left boundary on token prefixes so substrings
+# like "task-..." inside a filename don't trigger on "sk-...", and require a
+# quoted value for password/api_key so docs prose ("set `password = <value>`")
+# doesn't trip the guard. See issue #103 for the false-positive cases.
+PATTERNS="(^|[^A-Za-z0-9])sk-[A-Za-z0-9_-]{20,}|(^|[^A-Za-z0-9])ghp_[A-Za-z0-9]{20,}|(^|[^A-Za-z0-9])ghs_[A-Za-z0-9]{20,}|(^|[^A-Za-z0-9])AKIA[A-Z0-9]{16}|-----BEGIN [A-Z ]+PRIVATE KEY-----|password\s*=\s*[\"'][^\"' ]+[\"']|api_key\s*=\s*[\"'][^\"' ]+[\"']"
 
 STAGED_FILES=$(git diff --cached --name-only)
 if [ -z "$STAGED_FILES" ]; then


### PR DESCRIPTION
Closes #103.

## Summary

Two related fixes for `cli/schist/sync.py`'s pre-commit hook template:

**(a) Tighter regex**
- `sk-` / `ghp_` / `ghs_` / `AKIA` now require a left boundary (`^` or non-alphanumeric) so substrings inside `task-some-long-...` paths don't match.
- `-----BEGIN` narrowed to `-----BEGIN [A-Z ]+PRIVATE KEY-----` so `-----BEGIN draft-----` decorations are ignored.
- `password\s*=` and `api_key\s*=` now require a quoted value, so docs prose like ``set `password = <your-value>` in your env`` no longer trips.
- Switched the PATTERNS shell variable from single- to double-quoted so `["']` (character class containing a literal single quote) is representable.

**(b) Upgrade path for existing spokes**
- Added `HOOK_VERSION = 2` in `sync.py` and embedded `# schist-hook-version: 2` markers inside both hook bodies.
- New `schist hooks reinstall` subcommand re-runs `_install_local_hooks` against the active vault.
- New doctor check `check_hooks_freshness` parses the marker, WARNs on legacy unversioned hooks or older versions, with a fix line pointing at `hooks reinstall`. Users who intentionally customize their hooks can change the marker to `# schist-hook-version: pinned` to silence the warning.

## Test plan

- [x] **Corpus test** (`cli/tests/test_pre_commit_hook.py`, 19 cases): installs the hook in a tmp git repo and confirms every issue-#103 false positive now commits cleanly while every recognizable secret format still rejects. Covers `risk-hedge`, `concepts/2026-05-18-brain-state-vs-task-context-terminology.md`, `-----BEGIN draft outline-----`, ``set `password = <your-password>` in your env file``, etc.
- [x] **Doctor tests** (`cli/tests/test_doctor.py::TestCheckHooksFreshness`, 5 cases): PASS for current versions, WARN for legacy unversioned or older N, PASS for `pinned`, SKIP for non-vault paths.
- [x] **Full CLI suite**: 339 passed, 1 skipped.
- [x] **End-to-end smoke**: legacy hook → `doctor` reports `[WARN] Hooks freshness: pre-commit: legacy (no version marker)` → `schist hooks reinstall` → `doctor` reports `[PASS] Hooks freshness: current (v2)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)