### PR TITLE
chore(release): bump to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to schist are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - Unreleased
+## [Unreleased]
+
+## [0.2.0] - 2026-05-23
 
 ### Added
 - `schist doctor` command — one-command health check for schist setup (Python, Node, Git, vault, SQLite, hooks, MCP config)

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schist"
-version = "0.1.0"
+version = "0.2.0"
 description = "Agent-first knowledge graph: git is truth, SQLite is query, humans just watch"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "schist"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-frontmatter" },

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schist/mcp-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server for schist: agent-first knowledge graph with git + SQLite",
   "author": "schist contributors",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Version bumps + CHANGELOG date for the **0.2.0 release**. Tag `v0.2.0` will follow once this PR merges to main, triggering PyPI + npm publish per `docs/RELEASE.md`.

## Files

- `cli/pyproject.toml`: `0.1.0` → `0.2.0`
- `cli/uv.lock`: regenerated via `uv lock`
- `mcp-server/package.json`: `0.1.0` → `0.2.0`
- `CHANGELOG.md`: `[0.2.0] - Unreleased` → `[0.2.0] - 2026-05-23`, new `[Unreleased]` section seeded above

## Release scope per #99

- [x] schist doctor + schist init --print-mcp-config + getting-started guide (landed in earlier PRs)
- [x] README rewrite + CONTRIBUTING.md (octopus, 2026-05-17)
- [x] MCP cursor protocol rollout (#50) — complete (8/8 PRs)
- [x] #120 spoke-push fix (PR #121)
- [x] Pre-release hardening: cursor protocol (#125), spoke-sync (#126)

## Release checklist (per docs/RELEASE.md)

- [x] Version bumps in cli/pyproject.toml and mcp-server/package.json
- [x] CHANGELOG.md updated (date set; new Unreleased seeded)
- [x] CI passes on main (#125, #126 just merged green)
- [ ] Git tag v0.2.0 (after this PR merges)
- [ ] release.yml workflow publishes to PyPI + npm

## Test plan

- [x] All 377 tests pass on main
- [x] `npm run build` clean
- [x] `uv lock` regenerated successfully

## Refs

Closes #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)