### PR TITLE
fix(ci): release.yml tag filter uses glob not regex

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,12 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+\.[0-9]+\.[0-9]+.*'  # Only match semver like v0.1.0, v1.2.3-rc.1
+      # GitHub Actions tag filters use glob, NOT regex. In glob, `.` is a
+      # literal character — no escape needed. The prior `\.` pattern was
+      # interpreted as a literal backslash + any-char, so v0.2.0's tag push
+      # didn't fire this workflow and we had to dispatch manually. The fixed
+      # pattern matches semver like v0.1.0, v1.2.3-rc.1, v2.0.0-beta.1.
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:  # Allow manual triggering
 
 permissions:


### PR DESCRIPTION
## Summary

Hit during the v0.2.0 release: `git push origin v0.2.0` did NOT fire `release.yml`, and we had to dispatch manually via `gh workflow run release.yml --ref v0.2.0`.

**Root cause:** the tag pattern was written in regex syntax:

\`\`\`yaml
tags:
  - 'v[0-9]+\.[0-9]+\.[0-9]+.*'
\`\`\`

GitHub Actions tag filters use **glob**, not regex. In glob, `.` is already a literal character — no escape needed. The `\.` was interpreted as "literal backslash + any single char," so legitimate semver tags like `v0.2.0` didn't match.

## Fix

One-character pattern change — drop the backslashes:

\`\`\`yaml
tags:
  - 'v[0-9]+.[0-9]+.[0-9]+*'
\`\`\`

This correctly matches:
- Release tags: `v0.1.0`, `v0.2.0`, `v1.2.3`
- Pre-release tags: `v1.2.3-rc.1`, `v2.0.0-beta.1`

The next semver tag push will fire the workflow automatically — no more manual dispatch step.

## Test plan

- [x] Diff verified against [GitHub Actions glob pattern docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)
- [x] Comment explains the gotcha so future readers don't reintroduce it
- [ ] Will be exercised on next release (v0.2.1+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)