### PR TITLE
feat(mcp-server): vault-write identity enforcement (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING:** Vault-write MCP tools (`create_note`, `add_connection`, `assign_domain`) now require an `owner` argument and validate it via `validateOwner` against `SCHIST_AGENT_ID` / `SCHIST_ALLOWED_AGENTS`, mirroring the memory-write policy from #61. The validated owner is stamped on `source_agent` frontmatter (replacing the hardcoded `"mcp"`) and the git commit message (`— by {owner}` instead of `— via MCP`). Closes #63. Callers must now pass `owner` on every vault write or receive `CONFIG_ERROR` / `VALIDATION_ERROR`; deployments must set `SCHIST_AGENT_ID` or `SCHIST_ALLOWED_AGENTS` in the MCP server's environment.
+
 ## [0.2.0] - 2026-05-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **BREAKING:** Vault-write MCP tools (`create_note`, `add_connection`, `assign_domain`) now require an `owner` argument and validate it via `validateOwner` against `SCHIST_AGENT_ID` / `SCHIST_ALLOWED_AGENTS`, mirroring the memory-write policy from #61. The validated owner is stamped on `source_agent` frontmatter (replacing the hardcoded `"mcp"`) and the git commit message (`— by {owner}` instead of `— via MCP`). Closes #63. Callers must now pass `owner` on every vault write or receive `CONFIG_ERROR` / `VALIDATION_ERROR`; deployments must set `SCHIST_AGENT_ID` or `SCHIST_ALLOWED_AGENTS` in the MCP server's environment.
+- **Bug fix:** `validateOwner` now canonicalizes the incoming owner by trimming whitespace before comparing against `SCHIST_ALLOWED_AGENTS` (which is itself trimmed at parse time). Pre-fix the trim was asymmetric — a caller sending `owner="atwood "` was rejected even when `"atwood"` was in the allowlist. The function now returns the canonical (trimmed) owner string; vault-write and memory-write tools assign it back so `source_agent` frontmatter, git commit subjects, and `agent_memory.owner` rows all store the canonical form (no silent key-splitting from trailing whitespace). Surfaced by adversarial review of #131.
+
+### Added
+- Startup warning when neither `SCHIST_AGENT_ID` nor `SCHIST_ALLOWED_AGENTS` is set — every write tool will return `CONFIG_ERROR` until one is configured. Replaces silent first-write failure with a loud signal at MCP server startup.
 
 ## [0.2.0] - 2026-05-23
 

--- a/mcp-server/src/agent-identity.ts
+++ b/mcp-server/src/agent-identity.ts
@@ -47,7 +47,22 @@ export function resolveActiveOwner(perCallOwner?: string): string {
   );
 }
 
-export function validateOwner(owner: string): void {
+/**
+ * Returns the canonical (whitespace-trimmed) owner string when validation
+ * passes. Callers should assign the return value back so the canonical form
+ * flows to downstream stamps (frontmatter `source_agent`, git commit subject,
+ * `agent_memory.owner` column) — otherwise a caller passing `"atwood "`
+ * would be accepted (the allowlist is trimmed at parse time) but store
+ * `"atwood "` in those side tables, splitting per-agent state across two
+ * keys that differ only by trailing whitespace. Pre-#131 the asymmetry
+ * went the other way: allowlist trimmed, owner not, so `"atwood "` was
+ * rejected. Both halves of that footgun are closed by canonicalizing here.
+ */
+export function validateOwner(owner: string): string {
+  // Coerce non-string inputs ('' if undefined / null) so the comparisons
+  // below behave predictably. The error messages still reflect the
+  // raw value the caller sent for diagnostic clarity.
+  const canonical = (typeof owner === "string" ? owner : "").trim();
   const allowedAgents = process.env.SCHIST_ALLOWED_AGENTS;
   if (allowedAgents !== undefined) {
     const allowed = allowedAgents
@@ -62,7 +77,7 @@ export function validateOwner(owner: string): void {
         { error: "CONFIG_ERROR" }
       );
     }
-    if (!allowed.includes(owner)) {
+    if (!allowed.includes(canonical)) {
       throw Object.assign(
         new Error(
           `Owner '${owner}' not in SCHIST_ALLOWED_AGENTS '${allowedAgents}'`
@@ -70,7 +85,7 @@ export function validateOwner(owner: string): void {
         { error: "VALIDATION_ERROR" }
       );
     }
-    return;
+    return canonical;
   }
   const agentId = process.env.SCHIST_AGENT_ID;
   if (!agentId) {
@@ -81,10 +96,11 @@ export function validateOwner(owner: string): void {
       { error: "CONFIG_ERROR" }
     );
   }
-  if (agentId !== owner) {
+  if (agentId !== canonical) {
     throw Object.assign(
       new Error(`Owner '${owner}' does not match SCHIST_AGENT_ID '${agentId}'`),
       { error: "VALIDATION_ERROR" }
     );
   }
+  return canonical;
 }

--- a/mcp-server/src/git-writer.ts
+++ b/mcp-server/src/git-writer.ts
@@ -135,11 +135,27 @@ async function withWriteLock(
   }
 }
 
+/**
+ * Commit-message attribution: `— by {owner}` when `owner` is provided (the
+ * normal MCP path, since tools.ts requires identity per #63), otherwise
+ * `— via MCP` for callers that haven't been wired through the identity
+ * gate yet. Newlines and excessive whitespace in the owner are stripped
+ * for the same reason as commit titles — the value flows into a single
+ * git `-m` line via execFile, so meta-character injection isn't possible,
+ * but linebreaks would still produce multi-paragraph commits.
+ */
+function attribution(owner: string | undefined): string {
+  if (!owner) return "via MCP";
+  const cleaned = owner.replace(/[\r\n]+/g, " ").replace(/\s+/g, " ").trim();
+  return cleaned.length > 0 ? `by ${cleaned}` : "via MCP";
+}
+
 export async function writeNote(
   vaultRoot: string,
   relPath: string,
   content: string,
-  commitTitle?: string
+  commitTitle?: string,
+  owner?: string
 ): Promise<WriteResult> {
   assertPathSafe(vaultRoot, relPath);
   // Prefer the caller-supplied title — gray-matter folds long or special-char
@@ -151,7 +167,7 @@ export async function writeNote(
   return withWriteLock(
     vaultRoot,
     relPath,
-    `feat(schist): write ${title} — via MCP`,
+    `feat(schist): write ${title} — ${attribution(owner)}`,
     async (absPath) => {
       await fs.writeFile(absPath, content, "utf-8");
     }
@@ -161,13 +177,14 @@ export async function writeNote(
 export async function appendToNote(
   vaultRoot: string,
   relPath: string,
-  addition: string
+  addition: string,
+  owner?: string
 ): Promise<WriteResult> {
   assertPathSafe(vaultRoot, relPath);
   return withWriteLock(
     vaultRoot,
     relPath,
-    `feat(schist): append to ${sanitizeCommitTitle(relPath)} — via MCP`,
+    `feat(schist): append to ${sanitizeCommitTitle(relPath)} — ${attribution(owner)}`,
     async (absPath) => {
       let existing = "";
       try {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -165,8 +165,7 @@ async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error("[schist] MCP server ready (stdio).");
-  console.error("[schist] Memory writes are authorized by validateOwner against SCHIST_AGENT_ID / SCHIST_ALLOWED_AGENTS.");
-  console.error("[schist] Vault writes (create_note, add_connection, assign_domain) do not yet enforce identity — see issue #63.");
+  console.error("[schist] All writes (memory + vault) are authorized by validateOwner against SCHIST_AGENT_ID / SCHIST_ALLOWED_AGENTS.");
 }
 
 main().catch((e) => {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -166,6 +166,13 @@ async function main() {
   await server.connect(transport);
   console.error("[schist] MCP server ready (stdio).");
   console.error("[schist] All writes (memory + vault) are authorized by validateOwner against SCHIST_AGENT_ID / SCHIST_ALLOWED_AGENTS.");
+  // Loud startup signal when no identity env is set: every write tool will
+  // return CONFIG_ERROR on the first call, but operators upgrading from a
+  // version that didn't gate vault writes would otherwise only discover the
+  // breakage from a downstream tool failure. See PR #131 / #63.
+  if (process.env.SCHIST_AGENT_ID === undefined && process.env.SCHIST_ALLOWED_AGENTS === undefined) {
+    console.error("[schist] WARNING: neither SCHIST_AGENT_ID nor SCHIST_ALLOWED_AGENTS is set — all write tools will return CONFIG_ERROR. Set one of these env vars in your MCP server config.");
+  }
 }
 
 main().catch((e) => {

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -163,6 +163,7 @@ export function makeWriteTools(config: VaultConfig) {
       inputSchema: {
         type: "object" as const,
         properties: {
+          owner: { type: "string", description: "Agent identity. Required; validated against SCHIST_ALLOWED_AGENTS or SCHIST_AGENT_ID. Stamped on the note's source_agent frontmatter and the git commit message." },
           title: { type: "string" },
           body: { type: "string" },
           tags: { type: "array", items: { type: "string" } },
@@ -185,7 +186,7 @@ export function makeWriteTools(config: VaultConfig) {
             enum: config.directories,
           },
         },
-        required: ["title", "body"],
+        required: ["owner", "title", "body"],
       },
     },
     {
@@ -194,12 +195,13 @@ export function makeWriteTools(config: VaultConfig) {
       inputSchema: {
         type: "object" as const,
         properties: {
+          owner: { type: "string", description: "Agent identity. Required; validated against SCHIST_ALLOWED_AGENTS or SCHIST_AGENT_ID. Stamped on the git commit message." },
           source: { type: "string" },
           target: { type: "string" },
           type: { type: "string", enum: config.connectionTypes },
           context: { type: "string" },
         },
-        required: ["source", "target", "type"],
+        required: ["owner", "source", "target", "type"],
       },
     },
     {
@@ -208,10 +210,11 @@ export function makeWriteTools(config: VaultConfig) {
       inputSchema: {
         type: "object" as const,
         properties: {
+          owner: { type: "string", description: "Agent identity. Required; validated against SCHIST_ALLOWED_AGENTS or SCHIST_AGENT_ID. Stamped on the git commit message." },
           id: { type: "string", description: "Note ID (relative path)" },
           domain: { type: "string", description: "Domain slug from vault.yaml domains list" },
         },
-        required: ["id", "domain"],
+        required: ["owner", "id", "domain"],
       },
     },
     {
@@ -253,9 +256,10 @@ export function makeWriteTools(config: VaultConfig) {
  *   - Memory writes (add_memory, set_agent_state, delete_agent_state,
  *     add_concept_alias) call `validateOwner` (see `agent-identity.ts`)
  *     against the configured SCHIST_AGENT_ID / SCHIST_ALLOWED_AGENTS.
- *   - Vault writes (create_note, add_connection, assign_domain) do not
- *     yet enforce identity — every commit attributes to source_agent: "mcp"
- *     regardless of caller. Tracked as issue #63.
+ *   - Vault writes (create_note, add_connection, assign_domain) call the
+ *     same `validateOwner` (closed by #63): each accepts a required
+ *     `owner` arg, stamped onto note frontmatter (`source_agent`) and the
+ *     git commit message.
  */
 export function listAllTools(config: VaultConfig) {
   return [

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -547,7 +547,10 @@ export async function create_note(
   try {
     // Identity gate (#63): validate before any path / config checks so an
     // unauthorized caller can't enumerate vault config via error messages.
-    validateOwner(args.owner);
+    // Reassign to the canonicalized owner so the trimmed form flows to
+    // both source_agent and the commit subject (avoids divergence when
+    // the caller sends e.g. "atwood ").
+    const owner = validateOwner(args.owner);
     const directory = args.directory ?? "notes";
     if (directory.includes("..") || path.isAbsolute(directory)) {
       return {
@@ -604,11 +607,11 @@ export async function create_note(
       tags: args.tags ?? [],
       concepts: args.concepts ?? [],
       status: args.status ?? "draft",
-      source_agent: args.owner,
+      source_agent: owner,
     };
 
     const noteContent = buildNote(metadata, args.body, args.connections);
-    const result = await writeNote(vaultRoot, relPath, noteContent, args.title, args.owner);
+    const result = await writeNote(vaultRoot, relPath, noteContent, args.title, owner);
 
     // Always-fire even on dedup'd writes: triggerSpokePush is the SOLE spoke→hub
     // mechanism (no git hook handles it), so gating it on `committed` would
@@ -642,8 +645,9 @@ export async function add_connection(
   args: { owner: string; source: string; target: string; type: string; context?: string }
 ): Promise<unknown> {
   try {
-    // Identity gate (#63): same ordering as create_note.
-    validateOwner(args.owner);
+    // Identity gate (#63): same ordering as create_note. Reassign to the
+    // canonicalized owner for downstream stamps.
+    const owner = validateOwner(args.owner);
     const filePath = path.join(vaultRoot, args.source);
     const absVaultRoot = path.resolve(vaultRoot);
     const absFilePath = path.resolve(filePath);
@@ -675,7 +679,7 @@ export async function add_connection(
       args.source,
       newContent,
       `connection ${args.type} → ${args.target} on ${args.source}`,
-      args.owner
+      owner
     );
 
     triggerIngestion(vaultRoot);
@@ -701,8 +705,9 @@ export async function assign_domain(
   args: { owner: string; id: string; domain: string }
 ): Promise<unknown> {
   try {
-    // Identity gate (#63): same ordering as create_note.
-    validateOwner(args.owner);
+    // Identity gate (#63): same ordering as create_note. Reassign to the
+    // canonicalized owner for downstream stamps.
+    const owner = validateOwner(args.owner);
     const filePath = path.join(vaultRoot, args.id);
     const absVaultRoot = path.resolve(vaultRoot);
     const absFilePath = path.resolve(filePath);
@@ -744,7 +749,7 @@ export async function assign_domain(
       args.id,
       newContent,
       `assign domain ${args.domain} to ${args.id}`,
-      args.owner
+      owner
     );
 
     triggerIngestion(vaultRoot);
@@ -1322,8 +1327,12 @@ export async function add_memory(
   }
 ): Promise<unknown> {
   try {
-    validateOwner(args.owner);
-    return sqliteReader.addMemory(args);
+    // Canonicalize so `agent_memory.owner` stores the trimmed form — pre-#131
+    // a caller passing "atwood " would have been silently accepted (allowlist
+    // already trimmed at parse time) and stored under a key that diverges
+    // from every "atwood" write by the same agent.
+    const owner = validateOwner(args.owner);
+    return sqliteReader.addMemory({ ...args, owner });
   } catch (e: unknown) {
     return normalizeError(e, "VALIDATION_ERROR");
   }
@@ -1334,8 +1343,8 @@ export async function set_agent_state(
   args: { key: string; value: unknown; owner: string; ttl_hours?: number }
 ): Promise<unknown> {
   try {
-    validateOwner(args.owner);
-    return sqliteReader.setAgentState(args.key, args.value, args.owner, args.ttl_hours);
+    const owner = validateOwner(args.owner);
+    return sqliteReader.setAgentState(args.key, args.value, owner, args.ttl_hours);
   } catch (e: unknown) {
     return normalizeError(e, "VALIDATION_ERROR");
   }
@@ -1346,8 +1355,8 @@ export async function delete_agent_state(
   args: { key: string; owner: string }
 ): Promise<unknown> {
   try {
-    validateOwner(args.owner);
-    return sqliteReader.deleteAgentState(args.key, args.owner);
+    const owner = validateOwner(args.owner);
+    return sqliteReader.deleteAgentState(args.key, owner);
   } catch (e: unknown) {
     return normalizeError(e, "VALIDATION_ERROR");
   }
@@ -1358,8 +1367,8 @@ export async function add_concept_alias(
   args: { duplicate_slug: string; canonical_slug: string; reason?: string; created_by: string }
 ): Promise<unknown> {
   try {
-    validateOwner(args.created_by);
-    return sqliteReader.addConceptAlias(vaultRoot, args.duplicate_slug, args.canonical_slug, args.reason, args.created_by);
+    const createdBy = validateOwner(args.created_by);
+    return sqliteReader.addConceptAlias(vaultRoot, args.duplicate_slug, args.canonical_slug, args.reason, createdBy);
   } catch (e: unknown) {
     return normalizeError(e, "VALIDATION_ERROR");
   }

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -533,6 +533,7 @@ export async function get_note(
 export async function create_note(
   vaultRoot: string,
   args: {
+    owner: string;
     title: string;
     body: string;
     tags?: string[];
@@ -544,6 +545,9 @@ export async function create_note(
   config: VaultConfig
 ): Promise<unknown> {
   try {
+    // Identity gate (#63): validate before any path / config checks so an
+    // unauthorized caller can't enumerate vault config via error messages.
+    validateOwner(args.owner);
     const directory = args.directory ?? "notes";
     if (directory.includes("..") || path.isAbsolute(directory)) {
       return {
@@ -600,11 +604,11 @@ export async function create_note(
       tags: args.tags ?? [],
       concepts: args.concepts ?? [],
       status: args.status ?? "draft",
-      source_agent: "mcp",
+      source_agent: args.owner,
     };
 
     const noteContent = buildNote(metadata, args.body, args.connections);
-    const result = await writeNote(vaultRoot, relPath, noteContent, args.title);
+    const result = await writeNote(vaultRoot, relPath, noteContent, args.title, args.owner);
 
     // Always-fire even on dedup'd writes: triggerSpokePush is the SOLE spoke→hub
     // mechanism (no git hook handles it), so gating it on `committed` would
@@ -635,9 +639,11 @@ export async function create_note(
 
 export async function add_connection(
   vaultRoot: string,
-  args: { source: string; target: string; type: string; context?: string }
+  args: { owner: string; source: string; target: string; type: string; context?: string }
 ): Promise<unknown> {
   try {
+    // Identity gate (#63): same ordering as create_note.
+    validateOwner(args.owner);
     const filePath = path.join(vaultRoot, args.source);
     const absVaultRoot = path.resolve(vaultRoot);
     const absFilePath = path.resolve(filePath);
@@ -668,7 +674,8 @@ export async function add_connection(
       vaultRoot,
       args.source,
       newContent,
-      `connection ${args.type} → ${args.target} on ${args.source}`
+      `connection ${args.type} → ${args.target} on ${args.source}`,
+      args.owner
     );
 
     triggerIngestion(vaultRoot);
@@ -691,9 +698,11 @@ export async function add_connection(
 
 export async function assign_domain(
   vaultRoot: string,
-  args: { id: string; domain: string }
+  args: { owner: string; id: string; domain: string }
 ): Promise<unknown> {
   try {
+    // Identity gate (#63): same ordering as create_note.
+    validateOwner(args.owner);
     const filePath = path.join(vaultRoot, args.id);
     const absVaultRoot = path.resolve(vaultRoot);
     const absFilePath = path.resolve(filePath);
@@ -734,7 +743,8 @@ export async function assign_domain(
       vaultRoot,
       args.id,
       newContent,
-      `assign domain ${args.domain} to ${args.id}`
+      `assign domain ${args.domain} to ${args.id}`,
+      args.owner
     );
 
     triggerIngestion(vaultRoot);

--- a/mcp-server/tests/agent-identity.test.ts
+++ b/mcp-server/tests/agent-identity.test.ts
@@ -119,4 +119,45 @@ describe("validateOwner", () => {
       );
     });
   });
+
+  describe("returns canonical (trimmed) owner — #131 trim symmetry", () => {
+    // Pre-#131 the allowlist parser trimmed entries but the includes-check
+    // ran against the raw owner. So `SCHIST_ALLOWED_AGENTS="atwood,octopus"`
+    // with caller-sent `owner="atwood "` would reject with VALIDATION_ERROR
+    // even though the operator intended atwood==atwood. Both halves are
+    // now canonicalized.
+
+    it("accepts owner with leading/trailing whitespace in allowlist mode", () => {
+      process.env.SCHIST_ALLOWED_AGENTS = "octopus,atwood";
+      expect(() => validateOwner("atwood ")).not.toThrow();
+      expect(() => validateOwner(" atwood")).not.toThrow();
+      expect(() => validateOwner("\tatwood\n")).not.toThrow();
+    });
+
+    it("accepts owner with leading/trailing whitespace in legacy mode", () => {
+      process.env.SCHIST_AGENT_ID = "sansan";
+      expect(() => validateOwner(" sansan")).not.toThrow();
+      expect(() => validateOwner("sansan\n")).not.toThrow();
+    });
+
+    it("returns the canonical trimmed string", () => {
+      process.env.SCHIST_ALLOWED_AGENTS = "octopus,atwood";
+      expect(validateOwner("atwood ")).toBe("atwood");
+      expect(validateOwner(" octopus\t")).toBe("octopus");
+    });
+
+    it("returns the same string when no whitespace is present", () => {
+      process.env.SCHIST_AGENT_ID = "sansan";
+      expect(validateOwner("sansan")).toBe("sansan");
+    });
+
+    it("still rejects whitespace-only owner (canonical form is empty)", () => {
+      process.env.SCHIST_ALLOWED_AGENTS = "octopus,atwood";
+      expectThrow(
+        () => validateOwner("   "),
+        "VALIDATION_ERROR",
+        /not in SCHIST_ALLOWED_AGENTS/
+      );
+    });
+  });
 });

--- a/mcp-server/tests/tool-listing.test.ts
+++ b/mcp-server/tests/tool-listing.test.ts
@@ -62,4 +62,20 @@ describe("listAllTools — unconditional tool exposure", () => {
     const names = listAllTools(testConfig()).map((t) => t.name);
     expect(names).not.toContain("request_capabilities");
   });
+
+  test("vault-write tools mark `owner` as required in inputSchema (#63)", () => {
+    // Regression guard: validateOwner enforces identity at the data layer,
+    // but agents discover required fields from the inputSchema. If `owner`
+    // silently drops out of `required[]` in a future refactor, agents
+    // would stop passing it and every call would fail at runtime with
+    // CONFIG_ERROR / VALIDATION_ERROR — wasting tokens on an avoidable
+    // round-trip. This test catches that drift at build time.
+    const tools = listAllTools(testConfig());
+    for (const name of ["create_note", "add_connection", "assign_domain"]) {
+      const tool = tools.find((t) => t.name === name);
+      expect(tool).toBeDefined();
+      const required = (tool!.inputSchema as { required?: string[] }).required ?? [];
+      expect(required).toContain("owner");
+    }
+  });
 });

--- a/mcp-server/tests/tools.test.ts
+++ b/mcp-server/tests/tools.test.ts
@@ -12,6 +12,18 @@ const __dirname = path.dirname(__filename);
 
 const execFile = promisify(execFileCb);
 
+// Identity gate (#63): vault-write tools now call validateOwner, which
+// CONFIG_ERRORs unless SCHIST_AGENT_ID (or SCHIST_ALLOWED_AGENTS) is set.
+// Tests in this file exercise the happy path with a single fixed identity;
+// dedicated identity-enforcement coverage lives in vault-write-identity.test.ts.
+const TEST_AGENT = "test-agent";
+beforeAll(() => {
+  process.env.SCHIST_AGENT_ID = TEST_AGENT;
+});
+afterAll(() => {
+  delete process.env.SCHIST_AGENT_ID;
+});
+
 async function makeTempVault(extraYaml = ""): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "schist-tools-test-"));
   await execFile("git", ["init"], { cwd: dir });
@@ -88,13 +100,13 @@ describe("create_note filename collision", () => {
 
     const result1 = await create_note(
       vault,
-      { title: "Duplicate Title", body: "first body" },
+      { owner: TEST_AGENT, title: "Duplicate Title", body: "first body" },
       config
     ) as { id: string; path: string; commitSha: string };
 
     const result2 = await create_note(
       vault,
-      { title: "Duplicate Title", body: "second body" },
+      { owner: TEST_AGENT, title: "Duplicate Title", body: "second body" },
       config
     ) as { id: string; path: string; commitSha: string };
 
@@ -142,7 +154,7 @@ describe("create_note directory validation", () => {
 
     const result = await create_note(
       vault,
-      { title: "Nested Path Note", body: "lives under projects/foo", directory: "projects/foo" },
+      { owner: TEST_AGENT, title: "Nested Path Note", body: "lives under projects/foo", directory: "projects/foo" },
       config
     ) as { id: string; path: string; commitSha: string };
 
@@ -161,7 +173,7 @@ describe("create_note directory validation", () => {
 
     const result = await create_note(
       vault,
-      { title: "Should Fail", body: "x", directory: "projects/foo" },
+      { owner: TEST_AGENT, title: "Should Fail", body: "x", directory: "projects/foo" },
       config
     ) as { error: string; message: string };
 
@@ -177,7 +189,7 @@ describe("create_note directory validation", () => {
 
     const result = await create_note(
       vault,
-      { title: "Traversal Attempt", body: "x", directory: "projects/../etc" },
+      { owner: TEST_AGENT, title: "Traversal Attempt", body: "x", directory: "projects/../etc" },
       config
     ) as { error: string; message: string };
 
@@ -648,7 +660,7 @@ describe("write-tool syncWarning surfacing (#120)", () => {
 
     const result = (await create_note(
       vault,
-      { title: "Test sync surfacing", body: "body" },
+      { owner: TEST_AGENT, title: "Test sync surfacing", body: "body" },
       await loadVaultConfig(vault),
     )) as { id: string; path: string; commitSha: string; syncWarning?: string };
 
@@ -666,7 +678,7 @@ describe("write-tool syncWarning surfacing (#120)", () => {
     const vault = await makeTempVault();
     const result = (await create_note(
       vault,
-      { title: "Test no sync warn", body: "body" },
+      { owner: TEST_AGENT, title: "Test no sync warn", body: "body" },
       await loadVaultConfig(vault),
     )) as { id: string; syncWarning?: string };
     expect(result.syncWarning).toBeUndefined();
@@ -677,7 +689,7 @@ describe("write-tool syncWarning surfacing (#120)", () => {
     // Create a source note for add_connection to attach to.
     const noteResult = (await create_note(
       vault,
-      { title: "Source", body: "body" },
+      { owner: TEST_AGENT, title: "Source", body: "body" },
       await loadVaultConfig(vault),
     )) as { path: string };
 
@@ -691,6 +703,7 @@ describe("write-tool syncWarning surfacing (#120)", () => {
     );
 
     const result = (await add_connection(vault, {
+      owner: TEST_AGENT,
       source: noteResult.path,
       target: "some-target",
       type: "related",
@@ -713,7 +726,7 @@ describe("write-tool syncWarning surfacing (#120)", () => {
 
     const result = (await create_note(
       vault,
-      { title: "Test phrasing", body: "body" },
+      { owner: TEST_AGENT, title: "Test phrasing", body: "body" },
       await loadVaultConfig(vault),
     )) as { syncWarning?: string };
 
@@ -739,7 +752,7 @@ describe("write-tool syncWarning surfacing (#120)", () => {
 
     const result = (await create_note(
       vault,
-      { title: "Test sanitize", body: "body" },
+      { owner: TEST_AGENT, title: "Test sanitize", body: "body" },
       await loadVaultConfig(vault),
     )) as { syncWarning?: string };
 
@@ -763,7 +776,7 @@ describe("write-tool syncWarning surfacing (#120)", () => {
 
     const result = (await create_note(
       vault,
-      { title: "Test truncate", body: "body" },
+      { owner: TEST_AGENT, title: "Test truncate", body: "body" },
       await loadVaultConfig(vault),
     )) as { syncWarning?: string };
 
@@ -784,7 +797,7 @@ describe("write-tool syncWarning surfacing (#120)", () => {
 
     const result = (await create_note(
       vault,
-      { title: "Test eisdir", body: "body" },
+      { owner: TEST_AGENT, title: "Test eisdir", body: "body" },
       await loadVaultConfig(vault),
     )) as { syncWarning?: string };
 
@@ -810,7 +823,7 @@ describe("write-tool syncWarning surfacing (#120)", () => {
 
     const noteResult = (await create_note(
       vault,
-      { title: "Domain test", body: "body" },
+      { owner: TEST_AGENT, title: "Domain test", body: "body" },
       await loadVaultConfig(vault),
     )) as { path: string };
 
@@ -822,6 +835,7 @@ describe("write-tool syncWarning surfacing (#120)", () => {
     );
 
     const result = (await assign_domain(vault, {
+      owner: TEST_AGENT,
       id: noteResult.path,
       domain: "ai",
     })) as { id: string; domain: string; commitSha: string; syncWarning?: string };
@@ -879,7 +893,7 @@ describe("normalizeError", () => {
     // create_note catches and normalizes — use a bad vault to force an error
     const result = await create_note(
       "/nonexistent-vault",
-      { title: "Test", body: "body" },
+      { owner: TEST_AGENT, title: "Test", body: "body" },
       {
         name: "t",
         path: "/nonexistent-vault",
@@ -933,12 +947,13 @@ describe("assign_domain", () => {
     // Create a note
     const noteResult = (await create_note(
       vault,
-      { title: "Test Note", body: "Test body" },
+      { owner: TEST_AGENT, title: "Test Note", body: "Test body" },
       await loadVaultConfig(vault)
     )) as { id: string; path: string };
 
     // Assign domain
     const result = (await assign_domain(vault, {
+      owner: TEST_AGENT,
       id: noteResult.path,
       domain: "ml",
     })) as { id: string; domain: string; commitSha: string };
@@ -958,18 +973,20 @@ describe("assign_domain", () => {
     // Create a note
     const noteResult = (await create_note(
       vault,
-      { title: "Test Note", body: "Test body" },
+      { owner: TEST_AGENT, title: "Test Note", body: "Test body" },
       await loadVaultConfig(vault)
     )) as { id: string; path: string };
 
     // Assign first domain
     await assign_domain(vault, {
+      owner: TEST_AGENT,
       id: noteResult.path,
       domain: "ai",
     });
 
     // Assign different domain
     await assign_domain(vault, {
+      owner: TEST_AGENT,
       id: noteResult.path,
       domain: "security",
     });
@@ -987,11 +1004,12 @@ describe("assign_domain", () => {
 
     const noteResult = (await create_note(
       vault,
-      { title: "Test Note", body: "Test body" },
+      { owner: TEST_AGENT, title: "Test Note", body: "Test body" },
       await loadVaultConfig(vault)
     )) as { id: string; path: string };
 
     const result = (await assign_domain(vault, {
+      owner: TEST_AGENT,
       id: noteResult.path,
       domain: "invalid-domain",
     })) as { error: string; message: string };
@@ -1005,6 +1023,7 @@ describe("assign_domain", () => {
     const vault = await makeVaultWithDomains(["ai"]);
 
     const result = (await assign_domain(vault, {
+      owner: TEST_AGENT,
       id: "../../../etc/passwd",
       domain: "ai",
     })) as { error: string; message: string };
@@ -1017,6 +1036,7 @@ describe("assign_domain", () => {
     const vault = await makeVaultWithDomains(["ai"]);
 
     const result = (await assign_domain(vault, {
+      owner: TEST_AGENT,
       id: "notes/nonexistent.md",
       domain: "ai",
     })) as { error: string; message: string };
@@ -1032,12 +1052,13 @@ describe("assign_domain", () => {
 
     const noteResult = (await create_note(
       vault,
-      { title: "Test Note", body: "Test body" },
+      { owner: TEST_AGENT, title: "Test Note", body: "Test body" },
       await loadVaultConfig(vault)
     )) as { id: string; path: string };
 
     // Should accept any domain when list is empty
     const result = (await assign_domain(vault, {
+      owner: TEST_AGENT,
       id: noteResult.path,
       domain: "arbitrary-domain",
     })) as { id: string; domain: string; commitSha: string };
@@ -1057,7 +1078,7 @@ describe("assign_domain", () => {
 
     const noteResult = (await create_note(
       vault,
-      { title: "Test Note", body: "Test body" },
+      { owner: TEST_AGENT, title: "Test Note", body: "Test body" },
       await loadVaultConfig(vault)
     )) as { id: string; path: string };
 
@@ -1065,6 +1086,7 @@ describe("assign_domain", () => {
     // explicit `limit: Number.MAX_SAFE_INTEGER` in assign_domain, this
     // call would return INVALID_DOMAIN.
     const result = (await assign_domain(vault, {
+      owner: TEST_AGENT,
       id: noteResult.path,
       domain: "domain-149",
     })) as { id: string; domain: string; commitSha: string };

--- a/mcp-server/tests/vault-write-identity.test.ts
+++ b/mcp-server/tests/vault-write-identity.test.ts
@@ -1,0 +1,249 @@
+/**
+ * #63 — vault-write tools (create_note, add_connection, assign_domain) must
+ * call validateOwner on each call AND stamp the validated identity onto
+ * frontmatter (source_agent) + the git commit message.
+ *
+ * Tests in tools.test.ts exercise the happy path with a single fixed identity
+ * via a process-level SCHIST_AGENT_ID. Here we cover:
+ *   1. Missing/empty owner → CONFIG/VALIDATION error
+ *   2. Owner not in allowlist → VALIDATION error
+ *   3. Valid owner → propagates to source_agent frontmatter + commit message
+ */
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+import { execFile as execFileCb } from "child_process";
+import { promisify } from "util";
+import Database from "better-sqlite3";
+import {
+  loadVaultConfig,
+  create_note,
+  add_connection,
+  assign_domain,
+} from "../src/tools.js";
+
+const execFile = promisify(execFileCb);
+
+async function makeTempVault(extraYaml = ""): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "schist-vw-identity-"));
+  await execFile("git", ["init"], { cwd: dir });
+  await execFile("git", ["config", "user.email", "test@test.com"], { cwd: dir });
+  await execFile("git", ["config", "user.name", "Test"], { cwd: dir });
+  const yaml = [
+    "name: Test Vault",
+    "write_branch: drafts",
+    "directories:",
+    "  - notes",
+    "statuses:",
+    "  - draft",
+    "connection_types:",
+    "  - related",
+    extraYaml,
+  ]
+    .filter(Boolean)
+    .join("\n") + "\n";
+  await fs.writeFile(path.join(dir, "schist.yaml"), yaml);
+  await execFile("git", ["add", "."], { cwd: dir });
+  await execFile("git", ["commit", "-m", "init"], { cwd: dir });
+  return dir;
+}
+
+async function makeVaultWithDomains(domains: string[]): Promise<string> {
+  const vault = await makeTempVault(
+    `\ndomains:\n${domains.map((d) => `  - ${d}`).join("\n")}`
+  );
+  const dbPath = path.join(vault, ".schist", "schist.db");
+  await fs.mkdir(path.dirname(dbPath), { recursive: true });
+  const db = new Database(dbPath);
+  db.exec(
+    "CREATE TABLE domains (slug TEXT PRIMARY KEY, label TEXT NOT NULL, description TEXT, parent_slug TEXT REFERENCES domains(slug))"
+  );
+  const insert = db.prepare("INSERT INTO domains (slug, label) VALUES (?, ?)");
+  for (const d of domains) insert.run(d, d);
+  db.close();
+  return vault;
+}
+
+describe("#63 vault-write identity enforcement", () => {
+  beforeEach(() => {
+    delete process.env.SCHIST_AGENT_ID;
+    delete process.env.SCHIST_ALLOWED_AGENTS;
+  });
+  afterEach(() => {
+    delete process.env.SCHIST_AGENT_ID;
+    delete process.env.SCHIST_ALLOWED_AGENTS;
+  });
+
+  // -------------------------------------------------------------------------
+  // CONFIG_ERROR when no identity env is set (regardless of args.owner)
+  // -------------------------------------------------------------------------
+
+  describe("CONFIG_ERROR when neither SCHIST_AGENT_ID nor SCHIST_ALLOWED_AGENTS is set", () => {
+    test("create_note returns CONFIG_ERROR", async () => {
+      const vault = await makeTempVault();
+      const config = await loadVaultConfig(vault);
+      const result = (await create_note(
+        vault,
+        { owner: "anything", title: "X", body: "y" },
+        config,
+      )) as { error: string; message: string };
+      expect(result.error).toBe("CONFIG_ERROR");
+      expect(result.message).toMatch(/SCHIST_AGENT_ID or SCHIST_ALLOWED_AGENTS/);
+    });
+
+    test("add_connection returns CONFIG_ERROR", async () => {
+      const vault = await makeTempVault();
+      const result = (await add_connection(vault, {
+        owner: "anything",
+        source: "notes/missing.md",
+        target: "t",
+        type: "related",
+      })) as { error: string; message: string };
+      expect(result.error).toBe("CONFIG_ERROR");
+    });
+
+    test("assign_domain returns CONFIG_ERROR", async () => {
+      const vault = await makeVaultWithDomains(["ai"]);
+      const result = (await assign_domain(vault, {
+        owner: "anything",
+        id: "notes/missing.md",
+        domain: "ai",
+      })) as { error: string; message: string };
+      expect(result.error).toBe("CONFIG_ERROR");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // VALIDATION_ERROR when owner doesn't match env (single-agent mode)
+  // -------------------------------------------------------------------------
+
+  describe("VALIDATION_ERROR when owner does not match SCHIST_AGENT_ID", () => {
+    test("create_note rejects mismatched owner", async () => {
+      process.env.SCHIST_AGENT_ID = "octopus";
+      const vault = await makeTempVault();
+      const config = await loadVaultConfig(vault);
+      const result = (await create_note(
+        vault,
+        { owner: "atwood", title: "X", body: "y" },
+        config,
+      )) as { error: string; message: string };
+      expect(result.error).toBe("VALIDATION_ERROR");
+      expect(result.message).toMatch(/Owner 'atwood' does not match SCHIST_AGENT_ID 'octopus'/);
+    });
+
+    test("add_connection rejects mismatched owner before doing any IO", async () => {
+      // No source note exists; if identity gate runs first we get VALIDATION_ERROR,
+      // not NOT_FOUND. This proves the gate fires before vault reads.
+      process.env.SCHIST_AGENT_ID = "octopus";
+      const vault = await makeTempVault();
+      const result = (await add_connection(vault, {
+        owner: "atwood",
+        source: "notes/never-existed.md",
+        target: "t",
+        type: "related",
+      })) as { error: string; message: string };
+      expect(result.error).toBe("VALIDATION_ERROR");
+    });
+
+    test("assign_domain rejects mismatched owner before listing domains", async () => {
+      process.env.SCHIST_AGENT_ID = "octopus";
+      // No .schist/schist.db at all — listDomains would otherwise throw.
+      const vault = await makeTempVault("\ndomains:\n  - ai\n");
+      const result = (await assign_domain(vault, {
+        owner: "atwood",
+        id: "notes/n.md",
+        domain: "ai",
+      })) as { error: string; message: string };
+      expect(result.error).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Allowlist mode — multi-agent shared MCP deployment
+  // -------------------------------------------------------------------------
+
+  describe("allowlist mode (SCHIST_ALLOWED_AGENTS)", () => {
+    test("create_note accepts an allowlisted owner and stamps source_agent", async () => {
+      process.env.SCHIST_ALLOWED_AGENTS = "octopus,atwood,eleven";
+      const vault = await makeTempVault();
+      const config = await loadVaultConfig(vault);
+      const result = (await create_note(
+        vault,
+        { owner: "atwood", title: "Note by atwood", body: "body" },
+        config,
+      )) as { id: string; path: string; commitSha: string };
+      expect(result.commitSha).toBeDefined();
+
+      const content = await fs.readFile(path.join(vault, result.path), "utf-8");
+      expect(content).toMatch(/^source_agent:\s*atwood$/m);
+
+      // Commit message includes the agent — git log subject of HEAD.
+      const { stdout } = await execFile("git", ["log", "-1", "--format=%s"], { cwd: vault });
+      expect(stdout.trim()).toMatch(/^feat\(schist\): write Note by atwood — by atwood$/);
+    });
+
+    test("create_note rejects an owner outside the allowlist", async () => {
+      process.env.SCHIST_ALLOWED_AGENTS = "octopus,eleven";
+      const vault = await makeTempVault();
+      const config = await loadVaultConfig(vault);
+      const result = (await create_note(
+        vault,
+        { owner: "atwood", title: "X", body: "y" },
+        config,
+      )) as { error: string; message: string };
+      expect(result.error).toBe("VALIDATION_ERROR");
+      expect(result.message).toMatch(/'atwood' not in SCHIST_ALLOWED_AGENTS/);
+    });
+
+    test("add_connection stamps commit message with the validated agent", async () => {
+      process.env.SCHIST_ALLOWED_AGENTS = "octopus,atwood";
+      const vault = await makeTempVault();
+      const config = await loadVaultConfig(vault);
+
+      // Seed a source note as octopus...
+      const seed = (await create_note(
+        vault,
+        { owner: "octopus", title: "Seed", body: "body" },
+        config,
+      )) as { path: string };
+
+      // ...then have atwood add a connection. Both commits should attribute
+      // to the agent that made them — i.e. the connection commit must say
+      // "by atwood", not "by octopus".
+      await add_connection(vault, {
+        owner: "atwood",
+        source: seed.path,
+        target: "some-target",
+        type: "related",
+      });
+
+      const { stdout } = await execFile("git", ["log", "-2", "--format=%s"], { cwd: vault });
+      const subjects = stdout.trim().split("\n");
+      expect(subjects[0]).toMatch(/^feat\(schist\): write .* — by atwood$/);
+      expect(subjects[1]).toMatch(/^feat\(schist\): write Seed — by octopus$/);
+    });
+
+    test("assign_domain stamps commit message with the validated agent", async () => {
+      process.env.SCHIST_ALLOWED_AGENTS = "octopus,atwood";
+      const vault = await makeVaultWithDomains(["ai"]);
+      const config = await loadVaultConfig(vault);
+
+      const seed = (await create_note(
+        vault,
+        { owner: "octopus", title: "Doc", body: "body" },
+        config,
+      )) as { path: string };
+
+      await assign_domain(vault, {
+        owner: "atwood",
+        id: seed.path,
+        domain: "ai",
+      });
+
+      const { stdout } = await execFile("git", ["log", "-1", "--format=%s"], { cwd: vault });
+      // writeNote always prefixes "write" — the commitTitle here is the
+      // tool-supplied "assign domain ai to <path>".
+      expect(stdout.trim()).toMatch(/^feat\(schist\): write assign domain ai to .* — by atwood$/);
+    });
+  });
+});

--- a/mcp-server/tests/vault-write-identity.test.ts
+++ b/mcp-server/tests/vault-write-identity.test.ts
@@ -156,6 +156,61 @@ describe("#63 vault-write identity enforcement", () => {
       })) as { error: string; message: string };
       expect(result.error).toBe("VALIDATION_ERROR");
     });
+
+    test("empty-string owner is rejected (single-agent mode)", async () => {
+      process.env.SCHIST_AGENT_ID = "octopus";
+      const vault = await makeTempVault();
+      const config = await loadVaultConfig(vault);
+      const result = (await create_note(
+        vault,
+        { owner: "", title: "X", body: "y" },
+        config,
+      )) as { error: string };
+      expect(result.error).toBe("VALIDATION_ERROR");
+    });
+
+    test("whitespace-only owner is rejected (allowlist mode)", async () => {
+      // allowedAgents.split(",").map(trim).filter(Boolean) drops empty entries,
+      // so a whitespace-only owner is never in the allowlist.
+      process.env.SCHIST_ALLOWED_AGENTS = "octopus,atwood";
+      const vault = await makeTempVault();
+      const config = await loadVaultConfig(vault);
+      const result = (await create_note(
+        vault,
+        { owner: "   ", title: "X", body: "y" },
+        config,
+      )) as { error: string };
+      expect(result.error).toBe("VALIDATION_ERROR");
+    });
+
+    test("padded owner is accepted; canonical form stamped on both frontmatter and commit", async () => {
+      // End-to-end of the #131 review-time trim-symmetry fix: caller sends
+      // "atwood " (trailing space), validateOwner canonicalizes to "atwood",
+      // and both source_agent and the commit subject store "atwood" (NOT
+      // "atwood "). Without canonicalization the agent's writes would
+      // silently split across two distinct owner keys in the side tables.
+      process.env.SCHIST_ALLOWED_AGENTS = "octopus,atwood";
+      const vault = await makeTempVault();
+      const config = await loadVaultConfig(vault);
+      const result = (await create_note(
+        vault,
+        { owner: "atwood ", title: "Padded owner", body: "body" },
+        config,
+      )) as { path: string; commitSha: string };
+      expect(result.commitSha).toBeDefined();
+
+      const content = await fs.readFile(path.join(vault, result.path), "utf-8");
+      // The YAML line must be exactly `source_agent: atwood` with no inner
+      // whitespace bracketed by the trailing space the caller sent. The
+      // `$` in multiline mode matches end-of-line, so trailing-space-then-
+      // newline would fail the assertion.
+      expect(content).toMatch(/^source_agent: atwood$/m);
+
+      const { stdout } = await execFile("git", ["log", "-1", "--format=%s"], { cwd: vault });
+      // git's `--format=%s` strips trailing newline but not interior ones;
+      // an end-anchored `— by atwood` proves no padding leaked through.
+      expect(stdout.trim()).toMatch(/— by atwood$/);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -180,6 +235,35 @@ describe("#63 vault-write identity enforcement", () => {
       // Commit message includes the agent — git log subject of HEAD.
       const { stdout } = await execFile("git", ["log", "-1", "--format=%s"], { cwd: vault });
       expect(stdout.trim()).toMatch(/^feat\(schist\): write Note by atwood — by atwood$/);
+    });
+
+    test("source_agent frontmatter matches the agent in the commit subject", async () => {
+      // Defense-in-depth: validateOwner currently demands exact env match,
+      // so the value stamped on `source_agent: <owner>` and the value
+      // following "— by " in the commit subject MUST be identical. If a
+      // future refactor weakens validateOwner (e.g. case-insensitive match,
+      // trim-on-accept), this test fires before silent attribution drift
+      // makes it into a release.
+      process.env.SCHIST_ALLOWED_AGENTS = "octopus,atwood";
+      const vault = await makeTempVault();
+      const config = await loadVaultConfig(vault);
+      const result = (await create_note(
+        vault,
+        { owner: "atwood", title: "Sync check", body: "body" },
+        config,
+      )) as { path: string };
+
+      const content = await fs.readFile(path.join(vault, result.path), "utf-8");
+      const sourceAgentMatch = content.match(/^source_agent:\s*(.+)$/m);
+      expect(sourceAgentMatch).not.toBeNull();
+      const sourceAgent = sourceAgentMatch![1].trim();
+
+      const { stdout } = await execFile("git", ["log", "-1", "--format=%s"], { cwd: vault });
+      const commitMatch = stdout.trim().match(/— by (.+)$/);
+      expect(commitMatch).not.toBeNull();
+      const commitOwner = commitMatch![1].trim();
+
+      expect(sourceAgent).toBe(commitOwner);
     });
 
     test("create_note rejects an owner outside the allowlist", async () => {


### PR DESCRIPTION
## Summary

- Closes #63 — vault-write tools (`create_note`, `add_connection`, `assign_domain`) now require an `owner` arg, validated via the existing `validateOwner` policy against `SCHIST_AGENT_ID` / `SCHIST_ALLOWED_AGENTS`. Mirrors the memory-write strictness introduced in PR #61.
- Stamps the validated owner on `source_agent:` frontmatter (replaces hardcoded `"mcp"`) and on the git commit subject (`— by {owner}` instead of `— via MCP`). Per-agent attribution now works end-to-end for shared multi-agent MCP deployments.
- Identity gate fires before any path/config IO, so an unauthorized caller can't enumerate vault config via error messages.

## Breaking change

Every caller of `create_note` / `add_connection` / `assign_domain` must now pass `owner`. The MCP server's environment must set `SCHIST_AGENT_ID` (single-agent) or `SCHIST_ALLOWED_AGENTS` (multi-agent allowlist), or these tools return `CONFIG_ERROR`. CHANGELOG documents under Unreleased.

## Files

- `mcp-server/src/git-writer.ts` — `writeNote`/`appendToNote` accept optional `owner`; commit message format degrades gracefully when not provided (preserves the existing `git-writer.test.ts` surface and the unused `appendToNote` callers).
- `mcp-server/src/tools.ts` — `validateOwner(args.owner)` first thing in each handler; `source_agent: args.owner`; threads `args.owner` into `writeNote`.
- `mcp-server/src/tool-registry.ts` — `owner` added to inputSchema + `required` for all 3 tools; stale "Tracked as issue #63" comment updated.
- `mcp-server/src/index.ts` — startup banner updated; "do not yet enforce" warning removed.
- `mcp-server/tests/tools.test.ts` — 29 call sites updated with `owner: TEST_AGENT`; top-of-file `beforeAll/afterAll` sets `SCHIST_AGENT_ID`.
- `mcp-server/tests/vault-write-identity.test.ts` — new, 10 tests covering CONFIG_ERROR / VALIDATION_ERROR / allowlist-accept / allowlist-reject / single-agent-mismatch / frontmatter stamping / commit-message stamping for each of the 3 tools.

## Test plan
- [x] `cd mcp-server && npm run build` — clean tsc
- [x] `npm test` — 387 passed across 22 suites (new `vault-write-identity.test.ts` adds 10 tests)
- [x] `npm test -- --testPathPatterns=vault-write-identity` — 10/10 pass
- [x] `uv run --with pytest --with ./cli python -m pytest cli/tests/` — 347 passed, 1 skipped (no CLI churn — ingestion just reads whatever `source_agent:` value is in frontmatter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)