### PR TITLE
fix(mcp-server): key vault.yaml ACL intersection on machine identity, not agent owner

### DIFF
--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -9,7 +9,7 @@ import { writeNote } from "./git-writer.js";
 import { buildNote, buildConnectionLine } from "./markdown-parser.js";
 import { validateOwner, resolveActiveOwner } from "./agent-identity.js";
 import type { VaultConfig, ToolError, SearchMemoryResponse, SearchNotesResponse, QueryGraphResponse, ListConceptsResponse, GetContextResponse } from "./types.js";
-import { loadVaultAcl, canWrite, deriveScope } from "./vault-acl.js";
+import { loadVaultAcl, canWrite, deriveScope, resolveAclIdentity } from "./vault-acl.js";
 import {
   canonicalizeQueryHash,
   decodeCursor,
@@ -719,11 +719,12 @@ export async function create_note(
     const acl = loadVaultAcl(vaultRoot);
     if (acl !== null) {
       const scope = deriveScope(relPath);
-      if (!canWrite(acl, owner, scope)) {
+      const aclIdentity = resolveAclIdentity(owner);
+      if (!canWrite(acl, aclIdentity, scope)) {
         return {
           error: "ACL_DENIED",
           message:
-            `Identity '${owner}' is not granted write access to scope ` +
+            `Identity '${aclIdentity}' is not granted write access to scope ` +
             `'${scope}' by vault.yaml. Hub push would reject this write. ` +
             `Ask the hub admin to extend your write grant.`,
         } satisfies ToolError;
@@ -800,11 +801,12 @@ export async function add_connection(
     const acl = loadVaultAcl(vaultRoot);
     if (acl !== null) {
       const scope = deriveScope(args.source);
-      if (!canWrite(acl, owner, scope)) {
+      const aclIdentity = resolveAclIdentity(owner);
+      if (!canWrite(acl, aclIdentity, scope)) {
         return {
           error: "ACL_DENIED",
           message:
-            `Identity '${owner}' is not granted write access to scope ` +
+            `Identity '${aclIdentity}' is not granted write access to scope ` +
             `'${scope}' by vault.yaml. Hub push would reject this write. ` +
             `Ask the hub admin to extend your write grant.`,
         } satisfies ToolError;

--- a/mcp-server/src/vault-acl.ts
+++ b/mcp-server/src/vault-acl.ts
@@ -55,6 +55,13 @@ export function canWrite(acl: VaultAcl, identity: string, scope: string): boolea
  * Falls back to `fallback` (the calling agent's owner id) only when no machine
  * identity is configured — preserving single-axis deployments where the
  * vault.yaml participant is named after the agent.
+ *
+ * Known gap (pre-existing): on a SPOKE with neither env var set, this falls
+ * back to owner and may locally ALLOW a write the hub then rejects ("cannot
+ * determine push identity", pre_receive.py:286). That surfaces as a delayed
+ * push failure / syncWarning rather than an upfront ACL_DENIED — git stays
+ * canonical, so it's a sync hiccup, not corruption. A misconfigured spoke is
+ * the real fault; `schist doctor` is the place to fail-fast on it.
  */
 export function resolveAclIdentity(fallback: string): string {
   return process.env.SCHIST_IDENTITY || process.env.GL_USER || fallback;

--- a/mcp-server/src/vault-acl.ts
+++ b/mcp-server/src/vault-acl.ts
@@ -42,6 +42,25 @@ export function canWrite(acl: VaultAcl, identity: string, scope: string): boolea
 }
 
 /**
+ * Resolve the identity used for the vault.yaml ACL lookup — the SAME identity
+ * the hub's pre-receive resolves (cli/schist/pre_receive.py:resolve_identity):
+ * SCHIST_IDENTITY, then GL_USER. This is the per-MACHINE/spoke identity that
+ * `schist sync push` forwards to the hub — NOT the per-AGENT SCHIST_AGENT_ID.
+ *
+ * vault.yaml's `access` map is keyed by machine identity (e.g. `dragonfly`),
+ * so the local intersection (#155) must look up the machine identity too;
+ * keying it on the agent owner (e.g. `claude-desktop`) produces a FALSE
+ * ACL_DENIED on writes the hub would actually accept.
+ *
+ * Falls back to `fallback` (the calling agent's owner id) only when no machine
+ * identity is configured — preserving single-axis deployments where the
+ * vault.yaml participant is named after the agent.
+ */
+export function resolveAclIdentity(fallback: string): string {
+  return process.env.SCHIST_IDENTITY || process.env.GL_USER || fallback;
+}
+
+/**
  * Derive the ACL scope from a file path. Mirrors
  * cli/schist/pre_receive.py:derive_scope verbatim.
  *

--- a/mcp-server/tests/tools.test.ts
+++ b/mcp-server/tests/tools.test.ts
@@ -1095,6 +1095,25 @@ describe("default.yaml drift detection", () => {
 // ---------------------------------------------------------------------------
 
 describe("create_note ACL enforcement (#155)", () => {
+  // Hermeticity: the ACL identity now resolves from SCHIST_IDENTITY / GL_USER
+  // (mirroring the hub), falling back to owner only when neither is set. These
+  // tests pin owner == participant, so clear any ambient machine identity (a
+  // dev box may export SCHIST_IDENTITY) to exercise the owner-fallback path.
+  let savedIdentity: string | undefined;
+  let savedGlUser: string | undefined;
+  beforeAll(() => {
+    savedIdentity = process.env.SCHIST_IDENTITY;
+    savedGlUser = process.env.GL_USER;
+    delete process.env.SCHIST_IDENTITY;
+    delete process.env.GL_USER;
+  });
+  afterAll(() => {
+    if (savedIdentity === undefined) delete process.env.SCHIST_IDENTITY;
+    else process.env.SCHIST_IDENTITY = savedIdentity;
+    if (savedGlUser === undefined) delete process.env.GL_USER;
+    else process.env.GL_USER = savedGlUser;
+  });
+
   test("write to a granted directory succeeds", async () => {
     const vault = await makeTempVaultWithAcl(TEST_AGENT, ["notes"]);
     const config = await loadVaultConfig(vault);
@@ -1155,6 +1174,51 @@ describe("create_note ACL enforcement (#155)", () => {
     ) as { id: string; path: string };
     expect(result.path).toBeDefined();
   }, 30000);
+
+  test("ACL keys on SCHIST_IDENTITY, not the agent owner", async () => {
+    // The hub's pre-receive keys access on the machine identity, and so must
+    // the local intersection. vault.yaml grants the machine identity
+    // 'dragonfly'; the agent owner 'claude-desktop' is NOT in the access map.
+    // Pre-fix this falsely returned ACL_DENIED ("claude-desktop lacks grant")
+    // even though the hub would accept the push as dragonfly.
+    const vault = await makeTempVaultWithAcl("dragonfly", ["notes"]);
+    const config = await loadVaultConfig(vault);
+    process.env.SCHIST_IDENTITY = "dragonfly";
+    process.env.SCHIST_AGENT_ID = "claude-desktop";  // agent ≠ machine identity
+    try {
+      const result = await create_note(
+        vault,
+        { owner: "claude-desktop", title: "Decision", body: "x", directory: "notes" },
+        config,
+      ) as { id: string; path: string };
+      expect(result.path?.startsWith("notes/")).toBe(true);
+    } finally {
+      delete process.env.SCHIST_IDENTITY;
+      process.env.SCHIST_AGENT_ID = TEST_AGENT;
+    }
+  }, 30000);
+
+  test("ungranted SCHIST_IDENTITY is denied and message names the identity", async () => {
+    // vault.yaml grants 'dragonfly'; the machine identity is 'orcd' (no grant).
+    // The owner happens to match a participant name, but owner must NOT rescue
+    // an ungranted machine identity — the hub would reject this push.
+    const vault = await makeTempVaultWithAcl("dragonfly", ["notes"]);
+    const config = await loadVaultConfig(vault);
+    process.env.SCHIST_IDENTITY = "orcd";
+    process.env.SCHIST_AGENT_ID = "dragonfly";  // owner happens to name a participant
+    try {
+      const result = await create_note(
+        vault,
+        { owner: "dragonfly", title: "Decision", body: "x", directory: "notes" },
+        config,
+      ) as { error: string; message: string };
+      expect(result.error).toBe("ACL_DENIED");
+      expect(result.message).toMatch(/orcd/);
+    } finally {
+      delete process.env.SCHIST_IDENTITY;
+      process.env.SCHIST_AGENT_ID = TEST_AGENT;
+    }
+  }, 30000);
 });
 
 // ---------------------------------------------------------------------------
@@ -1162,6 +1226,23 @@ describe("create_note ACL enforcement (#155)", () => {
 // ---------------------------------------------------------------------------
 
 describe("add_connection ACL enforcement (#155)", () => {
+  // Same hermeticity guard as create_note: clear ambient machine identity so
+  // the owner-fallback path is exercised deterministically.
+  let savedIdentity: string | undefined;
+  let savedGlUser: string | undefined;
+  beforeAll(() => {
+    savedIdentity = process.env.SCHIST_IDENTITY;
+    savedGlUser = process.env.GL_USER;
+    delete process.env.SCHIST_IDENTITY;
+    delete process.env.GL_USER;
+  });
+  afterAll(() => {
+    if (savedIdentity === undefined) delete process.env.SCHIST_IDENTITY;
+    else process.env.SCHIST_IDENTITY = savedIdentity;
+    if (savedGlUser === undefined) delete process.env.GL_USER;
+    else process.env.GL_USER = savedGlUser;
+  });
+
   test("appending to a note in an ungranted directory returns ACL_DENIED", async () => {
     // Step 1: write a note with 'notes' AND 'papers' granted
     const vault = await makeTempVaultWithAcl(TEST_AGENT, ["notes", "papers"]);

--- a/mcp-server/tests/tools.test.ts
+++ b/mcp-server/tests/tools.test.ts
@@ -1280,5 +1280,64 @@ access:
     expect(result.error).toBe("ACL_DENIED");
     expect(result.message).toMatch(/papers/);
   }, 30000);
+
+  test("ACL keys on SCHIST_IDENTITY, not the agent owner", async () => {
+    // Mirror of the create_note regression: vault.yaml grants the machine
+    // identity 'dragonfly'; the agent owner 'claude-desktop' is absent from
+    // the access map. add_connection must resolve via SCHIST_IDENTITY so the
+    // append is allowed (the hub would accept it as dragonfly).
+    const vault = await makeTempVaultWithAcl("dragonfly", ["notes"]);
+    const config = await loadVaultConfig(vault);
+    process.env.SCHIST_IDENTITY = "dragonfly";
+    process.env.SCHIST_AGENT_ID = "claude-desktop";
+    try {
+      const created = await create_note(
+        vault,
+        { owner: "claude-desktop", title: "Target", body: "x", directory: "notes" },
+        config,
+      ) as { id: string; path: string };
+      expect(created.path).toBeDefined();
+
+      const result = await add_connection(
+        vault,
+        { owner: "claude-desktop", source: created.path, target: "[[Some Concept]]", type: "related" },
+      ) as { commitSha?: string; error?: string };
+      expect(result.error).toBeUndefined();
+    } finally {
+      delete process.env.SCHIST_IDENTITY;
+      process.env.SCHIST_AGENT_ID = TEST_AGENT;
+    }
+  }, 30000);
+
+  test("ungranted SCHIST_IDENTITY denies the append and names the identity", async () => {
+    // Note authored while 'dragonfly' holds the grant, then the machine
+    // identity flips to ungranted 'orcd'. The append must be denied even
+    // though the owner names a granted participant — owner must not rescue
+    // an ungranted machine identity.
+    const vault = await makeTempVaultWithAcl("dragonfly", ["notes"]);
+    const config = await loadVaultConfig(vault);
+    process.env.SCHIST_IDENTITY = "dragonfly";
+    process.env.SCHIST_AGENT_ID = "dragonfly";
+    let created: { path: string };
+    try {
+      created = await create_note(
+        vault,
+        { owner: "dragonfly", title: "Target", body: "x", directory: "notes" },
+        config,
+      ) as { id: string; path: string };
+      expect(created.path).toBeDefined();
+
+      process.env.SCHIST_IDENTITY = "orcd";
+      const result = await add_connection(
+        vault,
+        { owner: "dragonfly", source: created.path, target: "[[Some Concept]]", type: "related" },
+      ) as { error: string; message: string };
+      expect(result.error).toBe("ACL_DENIED");
+      expect(result.message).toMatch(/orcd/);
+    } finally {
+      delete process.env.SCHIST_IDENTITY;
+      process.env.SCHIST_AGENT_ID = TEST_AGENT;
+    }
+  }, 30000);
 });
 

--- a/mcp-server/tests/vault-acl.test.ts
+++ b/mcp-server/tests/vault-acl.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, test, afterAll, jest } from "@jest/globals";
+import { describe, expect, test, beforeEach, afterEach, afterAll, jest } from "@jest/globals";
 import * as fs from "fs/promises";
 import * as os from "os";
 import { readdirSync, readFileSync as readFileSyncForFixtures } from "fs";
 import { join as pathJoin, dirname as pathDirname } from "path";
 import { fileURLToPath } from "url";
-import { scopeMatches, canWrite, type VaultAcl, loadVaultAcl, deriveScope } from "../src/vault-acl.js";
+import { scopeMatches, canWrite, resolveAclIdentity, type VaultAcl, loadVaultAcl, deriveScope } from "../src/vault-acl.js";
 
 describe("scopeMatches", () => {
   test("exact match returns true", () => {
@@ -50,6 +50,43 @@ describe("canWrite", () => {
   test("wildcard write grants every scope", () => {
     expect(canWrite(acl, "admin", "anything")).toBe(true);
     expect(canWrite(acl, "admin", "")).toBe(true);
+  });
+});
+
+describe("resolveAclIdentity", () => {
+  // Mirrors cli/schist/pre_receive.py:resolve_identity precedence:
+  // SCHIST_IDENTITY -> GL_USER -> fallback. Save/restore env so cases are
+  // hermetic regardless of the ambient identity on a dev box.
+  let savedIdentity: string | undefined;
+  let savedGlUser: string | undefined;
+  beforeEach(() => {
+    savedIdentity = process.env.SCHIST_IDENTITY;
+    savedGlUser = process.env.GL_USER;
+    delete process.env.SCHIST_IDENTITY;
+    delete process.env.GL_USER;
+  });
+  afterEach(() => {
+    if (savedIdentity === undefined) delete process.env.SCHIST_IDENTITY;
+    else process.env.SCHIST_IDENTITY = savedIdentity;
+    if (savedGlUser === undefined) delete process.env.GL_USER;
+    else process.env.GL_USER = savedGlUser;
+  });
+
+  test("prefers SCHIST_IDENTITY over GL_USER and fallback", () => {
+    process.env.SCHIST_IDENTITY = "dragonfly";
+    process.env.GL_USER = "gl-user";
+    expect(resolveAclIdentity("claude-desktop")).toBe("dragonfly");
+  });
+  test("falls back to GL_USER when SCHIST_IDENTITY is unset", () => {
+    process.env.GL_USER = "gl-user";
+    expect(resolveAclIdentity("claude-desktop")).toBe("gl-user");
+  });
+  test("falls back to owner when neither env var is set", () => {
+    expect(resolveAclIdentity("claude-desktop")).toBe("claude-desktop");
+  });
+  test("empty-string SCHIST_IDENTITY falls through (matches Python `or`)", () => {
+    process.env.SCHIST_IDENTITY = "";
+    expect(resolveAclIdentity("claude-desktop")).toBe("claude-desktop");
   });
 });
 


### PR DESCRIPTION
## Problem

A `claude-desktop` MCP session got `ACL_DENIED` writing to the `decisions` scope — *"claude-desktop lacks write grant"* — even though the spoke's `SCHIST_IDENTITY` is `dragonfly` and `dragonfly` **does** have `decisions` write access in `vault.yaml`. The push would have succeeded; only the local pre-check rejected it.

## Root cause

The #155 local ACL intersection in `create_note`/`add_connection` calls `canWrite(acl, owner, scope)` where `owner` is the per-**agent** `SCHIST_AGENT_ID` (`claude-desktop`). But `vault.yaml`'s `access` map — and the hub's `pre-receive` (`pre_receive.py:resolve_identity`) — key on the per-**machine** `SCHIST_IDENTITY` (`dragonfly`). The access map has no `claude-desktop` entry, so `canWrite` returned `false`.

The guard whose stated purpose is *"never produce a local commit the hub's pre-receive will reject"* was doing the opposite: rejecting commits the hub would accept, with an error naming the wrong identity.

## Fix

- `vault-acl.ts`: add `resolveAclIdentity(fallback)` mirroring `pre_receive.resolve_identity` — `SCHIST_IDENTITY → GL_USER → fallback`. The `owner` fallback preserves single-axis deployments where the `vault.yaml` participant is named after the agent (no `SCHIST_IDENTITY` set).
- `tools.ts`: `create_note` and `add_connection` now intersect against `resolveAclIdentity(owner)`; `ACL_DENIED` messages name the resolved identity.

No `vault.yaml` change or grant extension is needed — `claude-desktop` writes now correctly evaluate (locally and on the hub) as `dragonfly`.

## Tests

- Hermeticity guards on both ACL describe blocks: clear ambient `SCHIST_IDENTITY`/`GL_USER` so the owner-fallback cases stay deterministic on dev boxes that export an identity (this Mac exports `dragonfly`).
- Regressions: identity-granted / owner-absent → **succeeds**; ungranted identity → **denied** and the message names the identity.
- Full suite: 418 passed, including with `SCHIST_IDENTITY=dragonfly` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)