### PR TITLE
fix(mcp-server): attach spoke-push handlers before unref

### DIFF
--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -361,23 +361,15 @@ export function triggerSpokePush(vaultRoot: string): void {
       ["--vault", vaultRoot, "sync", "push"],
       { cwd: vaultRoot, stdio: "ignore", env: process.env, detached: true }
     );
-    child.unref();
 
     // Clean up the in-flight marker on terminal events. Wrap in helper so
-    // both error and exit can call it idempotently — handlers can fire in
-    // either order depending on the failure mode.
+    // error, exit, and close handlers stay idempotent — handlers can fire in
+    // different orders depending on the failure mode.
     const cleanup = (): void => { inFlightSpokePushes.delete(vaultRoot); };
-
-    child.on("error", (err) => {
-      cleanup();
-      // spawn error = schist binary not on PATH, or permission denied.
-      // Silent by default is a footgun — write a sentinel so the next
-      // get_context (or write-tool response — see readSyncWarning) can
-      // surface it. Also log for operators watching stderr.
-      console.error("[schist] spoke push failed:", err);
-      writeSyncError(vaultRoot, `push spawn failed: ${err.message}`);
-    });
-    child.on("exit", (code, signal) => {
+    let terminalHandled = false;
+    const handleTerminal = (code: number | null, signal: NodeJS.Signals | null): void => {
+      if (terminalHandled) return;
+      terminalHandled = true;
       cleanup();
       if (code !== null && code !== 0) {
         writeSyncError(vaultRoot, `push exited with code ${code}`);
@@ -387,7 +379,21 @@ export function triggerSpokePush(vaultRoot: string): void {
         // push died silently and the next get_context would report "healthy."
         writeSyncError(vaultRoot, `push killed by signal ${signal}`);
       }
+    };
+
+    child.on("error", (err) => {
+      terminalHandled = true;
+      cleanup();
+      // spawn error = schist binary not on PATH, or permission denied.
+      // Silent by default is a footgun — write a sentinel so the next
+      // get_context (or write-tool response — see readSyncWarning) can
+      // surface it. Also log for operators watching stderr.
+      console.error("[schist] spoke push failed:", err);
+      writeSyncError(vaultRoot, `push spawn failed: ${err.message}`);
     });
+    child.on("exit", handleTerminal);
+    child.on("close", handleTerminal);
+    child.unref();
   }).catch(() => {
     // Not a spoke vault — silent no-op
   });

--- a/mcp-server/tests/tools.test.ts
+++ b/mcp-server/tests/tools.test.ts
@@ -789,12 +789,13 @@ describe("sync error sentinel", () => {
       "hub: file:///nonexistent\nidentity: test\nscope: notes\n"
     );
 
-    // Stub that runs long enough for the test to send SIGKILL.
+    // Stub that kills itself, so the spawned child exits via signal without
+    // relying on platform-specific `pkill -f <script path>` matching.
     const stubDir = await fs.mkdtemp(path.join(os.tmpdir(), "stub-schist-"));
     const stub = path.join(stubDir, "schist");
     await fs.writeFile(
       stub,
-      "#!/bin/sh\nsleep 10\n",
+      "#!/bin/sh\nkill -KILL $$\n",
       { mode: 0o755 },
     );
 
@@ -802,18 +803,6 @@ describe("sync error sentinel", () => {
     process.env.PATH = `${stubDir}:${origPath}`;
     try {
       triggerSpokePush(vault);
-      // Give the spawn a moment to launch, then SIGKILL it via pgrep.
-      await new Promise((r) => setTimeout(r, 200));
-      const { execFile } = await import("child_process");
-      const exec = promisify(execFile);
-      try {
-        // pkill on the temp stub's full path — bounded to our process group.
-        await exec("pkill", ["-9", "-f", stub]);
-      } catch {
-        // pkill returns 1 if no processes matched — that means the spawn
-        // hadn't started yet, which is fine; the test below will then
-        // skip-equivalent (no sentinel) and we'll just retry the check.
-      }
       // Poll for the sentinel.
       const sentinelPath = path.join(vault, ".schist", "last-sync-error");
       let found = false;
@@ -1340,4 +1329,3 @@ access:
     }
   }, 30000);
 });
-


### PR DESCRIPTION
## What

Fixes a fast-exit race in triggerSpokePush: the code called child.unref() before installing terminal handlers. A very fast child could exit before the exit listener was attached, leaving inFlightSpokePushes uncleared and causing later pushes to coalesce forever.

Also makes the signal-killed fixture deterministic by having the stub kill itself instead of relying on platform-specific pkill matching.

## Verification

- cd mcp-server && npm run build
- cd mcp-server && npm test -- --testPathPatterns=tools.test.ts --runInBand -t "triggerSpokePush|sync error sentinel"
- cd mcp-server && npm test -- 433/433 pass locally on macOS/Node 25

Note: full local Jest run still prints the existing worker-exit warning, but all suites pass.