### PR TITLE
test(cli): cover schema command

### DIFF
--- a/cli/tests/test_schema_command.py
+++ b/cli/tests/test_schema_command.py
@@ -1,0 +1,71 @@
+from argparse import Namespace
+
+import pytest
+import yaml
+
+from schist import commands
+
+
+def _schema_args(validate: bool = False) -> Namespace:
+    return Namespace(validate=validate)
+
+
+class TestSchemaCommand:
+    def test_prints_vault_schema_when_present(self, tmp_path, capsys):
+        (tmp_path / "schist.yaml").write_text(
+            "\n".join([
+                "name: Custom Vault",
+                "directories:",
+                "  - notes",
+                "  - lab",
+                "statuses:",
+                "  - draft",
+                "connection_types:",
+                "  - related",
+                "write_branch: drafts",
+                "",
+            ]),
+            encoding="utf-8",
+        )
+
+        commands.schema(_schema_args(), str(tmp_path), str(tmp_path / ".schist" / "schist.db"))
+
+        cfg = yaml.safe_load(capsys.readouterr().out)
+        assert cfg["name"] == "Custom Vault"
+        assert cfg["directories"] == ["notes", "lab"]
+
+    def test_prints_packaged_default_when_vault_schema_missing(self, tmp_path, capsys):
+        commands.schema(_schema_args(), str(tmp_path), str(tmp_path / ".schist" / "schist.db"))
+
+        cfg = yaml.safe_load(capsys.readouterr().out)
+        assert cfg["directories"]["notes"] == "notes/"
+        assert cfg["directories"]["projects"] == "projects/"
+        assert cfg["write_branch"] == "drafts"
+
+    def test_validate_happy_path(self, tmp_path, capsys):
+        notes_dir = tmp_path / "notes"
+        notes_dir.mkdir()
+        (notes_dir / "good.md").write_text(
+            "---\ntitle: Valid Note\nstatus: draft\n---\n\nBody\n",
+            encoding="utf-8",
+        )
+
+        commands.schema(_schema_args(validate=True), str(tmp_path), str(tmp_path / ".schist" / "schist.db"))
+
+        assert capsys.readouterr().out.strip() == "All documents valid."
+
+    def test_validate_reports_missing_title_topic_or_concept(self, tmp_path, capsys):
+        notes_dir = tmp_path / "notes"
+        notes_dir.mkdir()
+        (notes_dir / "bad.md").write_text(
+            "---\nstatus: draft\n---\n\nBody\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            commands.schema(_schema_args(validate=True), str(tmp_path), str(tmp_path / ".schist" / "schist.db"))
+
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "1 violation(s):" in out
+        assert "notes/bad.md: missing title/topic/concept in frontmatter" in out


### PR DESCRIPTION
## Summary
- add direct coverage for `commands.schema()` using vault-local `schist.yaml`
- cover packaged `cli/schist/default.yaml` fallback when no vault schema exists
- cover `--validate` happy path and missing title/topic/concept violation

Closes #152.

## Verification
- `cd cli && uv run --with pytest --with . python -m pytest tests/test_schema_command.py -q`
- `cd cli && uv run --with pytest --with . python -m pytest tests/ -q`