### PR TITLE
fix(sync): stage global scope content dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `schist doctor` gained a `Spoke identity` fail-fast check (#164): spoke vaults now FAIL when neither `SCHIST_IDENTITY` nor `GL_USER` is set, because the hub pre-receive hook will reject background pushes even if MCP's local ACL UX check can fall back to the agent owner. A shared `identity-resolution.cases.json` fixture now pins the hub (`resolve_identity`) and MCP (`resolveAclIdentity`) precedence chain across Python and TypeScript, including the intentional MCP-only owner fallback.
 - MCP gained `sync_status` and `sync_retry` tools (#135). `sync_status` is read-only and reports spoke/hub heads, ahead/behind counts, working-tree cleanliness, and the last background sync sentinel with bounded git calls. `sync_retry` is identity-gated, supports explicit `push-only` and `pull-rebase-push` modes, awaits any in-flight background push, never force-pushes, aborts conflicted rebases, treats ACL/pre-receive rejection as non-retriable, and clears `.schist/last-sync-error` only after a successful push when the sentinel has not changed.
 
+### Fixed
+- `schist sync push` now stages existing canonical content directories for logical `scope: global` instead of trying `git add global/`, and now fails explicitly if staging the configured scope fails. Fixes the misleading "Nothing to push" path when global-scope spokes had dirty tracked files under directories like `concepts/` (#79).
+
 ### Added
 - `confidence` field on docs schema and `create_note` MCP tool. Optional enum (`low | medium | high`); omitted from frontmatter when not declared. Ingestion populates `docs.confidence` (NULL when undeclared — deliberately distinct from "agent said medium"). `search_notes` accepts an optional `confidence` filter that selects matching docs and excludes NULL-confidence rows. `get_note` returns the field when set, omits it when NULL. Closes #69.
 

--- a/cli/schist/git_ops.py
+++ b/cli/schist/git_ops.py
@@ -1,6 +1,15 @@
 """Git operations for vault commits."""
 
+from pathlib import Path
 import subprocess
+
+import yaml
+
+
+GLOBAL_SCOPE_FALLBACK_DIRS = [
+    "notes", "papers", "concepts",
+    "research", "decisions", "ops", "projects", "logs",
+]
 
 
 def commit(vault_path: str, message: str, files: list[str] | None = None) -> tuple[bool, str]:
@@ -151,11 +160,50 @@ def stage_scope_files(vault_path: str, scope: str) -> tuple[bool, str]:
     schist.yaml) are NOT staged — spokes should not modify those.
     """
     try:
+        if scope == "global":
+            targets = _global_scope_targets(vault_path)
+            if not targets:
+                return True, ""
+            add_args = ['git', 'add', '--'] + targets
+        else:
+            add_args = ['git', 'add', '--', scope.rstrip('/') + '/']
+
         result = subprocess.run(
-            ['git', 'add', scope + '/'],
+            add_args,
             cwd=vault_path, capture_output=True, text=True,
         )
         output = result.stdout + result.stderr
         return result.returncode == 0, output.strip()
     except subprocess.CalledProcessError as e:
         return False, (e.stdout or '') + (e.stderr or '')
+
+
+def _global_scope_dirs() -> list[str]:
+    """Return canonical content directories for logical `global` scope."""
+    default_yaml = Path(__file__).resolve().parent / "default.yaml"
+    try:
+        raw = yaml.safe_load(default_yaml.read_text(encoding="utf-8"))
+        dirs = raw.get("directories") if isinstance(raw, dict) else None
+        if isinstance(dirs, dict):
+            return [str(v).rstrip("/") for v in dirs.values()]
+        if isinstance(dirs, list):
+            return [str(v).rstrip("/") for v in dirs]
+    except Exception:
+        pass
+    return GLOBAL_SCOPE_FALLBACK_DIRS
+
+
+def _global_scope_targets(vault_path: str) -> list[str]:
+    targets: list[str] = []
+    for d in _global_scope_dirs():
+        target = f"{d}/"
+        if (Path(vault_path) / d).exists():
+            targets.append(target)
+            continue
+        tracked = subprocess.run(
+            ['git', 'ls-files', '--', target],
+            cwd=vault_path, capture_output=True, text=True,
+        )
+        if tracked.returncode == 0 and tracked.stdout.strip():
+            targets.append(target)
+    return targets

--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -428,7 +428,10 @@ def sync_push(args, vault_path: str, db_path: str) -> None:
 
     # Auto-commit if there are uncommitted changes
     if git_ops.has_uncommitted_changes(vault_path):
-        git_ops.stage_scope_files(vault_path, config.scope)
+        ok, output = git_ops.stage_scope_files(vault_path, config.scope)
+        if not ok:
+            print(f"Error: failed to stage scope '{config.scope}': {output}", file=sys.stderr)
+            sys.exit(1)
 
         # Count staged files
         import subprocess

--- a/cli/tests/test_sync.py
+++ b/cli/tests/test_sync.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -491,6 +492,22 @@ class TestSyncPush:
         mock_push.assert_called_once()
         assert "Pushed to hub" in capsys.readouterr().out
 
+    @patch("schist.sync.git_ops.has_uncommitted_changes", return_value=True)
+    @patch("schist.sync.git_ops.stage_scope_files", return_value=(False, "fatal: pathspec 'global/' did not match"))
+    def test_stage_failure_is_reported(self, mock_stage, mock_changes, tmp_path, capsys):
+        from schist.sync import sync_push
+
+        vault = _make_spoke(tmp_path)
+        args = MagicMock()
+
+        with pytest.raises(SystemExit) as exc:
+            sync_push(args, vault, "db.sqlite")
+
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "failed to stage scope" in err
+        assert "pathspec" in err
+
     @patch("schist.sync.git_ops.push", return_value=(False, "REJECTED: push contains out-of-scope writes"))
     @patch("schist.sync.git_ops.has_unpushed_commits", return_value=True)
     @patch("schist.sync.git_ops.has_uncommitted_changes", return_value=False)
@@ -515,6 +532,70 @@ class TestSyncPush:
             sync_push(args, vault, "db.sqlite")
         err = capsys.readouterr().err
         assert "unreachable" in err.lower() or "saved locally" in err.lower()
+
+
+class TestStageScopeFiles:
+    def test_global_scope_stages_existing_canonical_dirs(self, tmp_path):
+        from schist import git_ops
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        subprocess.run(["git", "init"], cwd=vault, check=True, capture_output=True, text=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=vault, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=vault, check=True)
+        (vault / "concepts").mkdir()
+        (vault / "notes").mkdir()
+        (vault / "concepts" / "existing.md").write_text("before\n", encoding="utf-8")
+        subprocess.run(["git", "add", "concepts/existing.md"], cwd=vault, check=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=vault, check=True, capture_output=True, text=True)
+
+        (vault / "concepts" / "existing.md").write_text("after\n", encoding="utf-8")
+
+        ok, output = git_ops.stage_scope_files(str(vault), "global")
+
+        assert ok, output
+        staged = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            cwd=vault, check=True, capture_output=True, text=True,
+        ).stdout.splitlines()
+        assert staged == ["concepts/existing.md"]
+
+    def test_global_scope_with_no_content_dirs_is_noop_success(self, tmp_path):
+        from schist import git_ops
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        subprocess.run(["git", "init"], cwd=vault, check=True, capture_output=True, text=True)
+
+        ok, output = git_ops.stage_scope_files(str(vault), "global")
+
+        assert ok is True
+        assert output == ""
+
+    def test_global_scope_stages_deleted_tracked_file(self, tmp_path):
+        from schist import git_ops
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        subprocess.run(["git", "init"], cwd=vault, check=True, capture_output=True, text=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=vault, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=vault, check=True)
+        (vault / "concepts").mkdir()
+        tracked = vault / "concepts" / "gone.md"
+        tracked.write_text("before\n", encoding="utf-8")
+        subprocess.run(["git", "add", "concepts/gone.md"], cwd=vault, check=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=vault, check=True, capture_output=True, text=True)
+        tracked.unlink()
+        (vault / "concepts").rmdir()
+
+        ok, output = git_ops.stage_scope_files(str(vault), "global")
+
+        assert ok, output
+        staged = subprocess.run(
+            ["git", "diff", "--cached", "--name-status"],
+            cwd=vault, check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        assert staged == "D\tconcepts/gone.md"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make `stage_scope_files(..., "global")` stage existing canonical content directories instead of `global/`
- include tracked-but-deleted canonical dirs so deletions under global scope are staged too
- make `sync_push` fail explicitly when scope staging fails instead of falling through to `Nothing to push`
- add regression coverage for global scope modified files, deleted files, no-op empty global scope, and stage failure reporting

Closes #79.

## Verification
- `cd cli && uv run --with pytest --with . python -m pytest tests/test_sync.py -q`
- `cd cli && uv run --with pytest --with . python -m pytest tests/ -q`