### PR TITLE
[codex] Fix stale sync state recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP gained `sync_status` and `sync_retry` tools (#135). `sync_status` is read-only and reports spoke/hub heads, ahead/behind counts, working-tree cleanliness, and the last background sync sentinel with bounded git calls. `sync_retry` is identity-gated, supports explicit `push-only` and `pull-rebase-push` modes, awaits any in-flight background push, never force-pushes, aborts conflicted rebases, treats ACL/pre-receive rejection as non-retriable, and clears `.schist/last-sync-error` only after a successful push when the sentinel has not changed.
 
 ### Fixed
+- `schist sync` gained stale git-operation recovery for spoke pushes (#143). `sync pull` still self-heals leftover rebase state, and `sync push --force` / `sync --force` now clears stale rebase, merge, and `.git/index.lock` state before retrying. MCP background `triggerSpokePush` detects stale git state after a failed push, retries once with `sync push --force`, clears an unchanged `last-sync-error` sentinel after successful pushes, and write-tool `syncWarning` messages now include the sentinel age.
 - `schist sync push` now stages existing canonical content directories for logical `scope: global` instead of trying `git add global/`, and now fails explicitly if staging the configured scope fails. Fixes the misleading "Nothing to push" path when global-scope spokes had dirty tracked files under directories like `concepts/` (#79).
 
 ### Added

--- a/cli/schist/__main__.py
+++ b/cli/schist/__main__.py
@@ -88,9 +88,25 @@ def main():
 
     # sync
     p_sync = sub.add_parser('sync', help='Sync spoke vault with hub')
+    p_sync.add_argument(
+        '--force', action='store_true',
+        help='Clear stale git rebase/merge/index-lock state before syncing',
+    )
+    p_sync.add_argument(
+        '--pull', action='store_true',
+        help='With --force and no subcommand, pull before pushing',
+    )
     sync_sub = p_sync.add_subparsers(dest='sync_action')
-    sync_sub.add_parser('pull', help='Pull updates from hub')
-    sync_sub.add_parser('push', help='Push local changes to hub')
+    p_sync_pull = sync_sub.add_parser('pull', help='Pull updates from hub')
+    p_sync_pull.add_argument(
+        '--force', action='store_true', default=argparse.SUPPRESS,
+        help='Clear stale git rebase/merge/index-lock state before pulling',
+    )
+    p_sync_push = sync_sub.add_parser('push', help='Push local changes to hub')
+    p_sync_push.add_argument(
+        '--force', action='store_true', default=argparse.SUPPRESS,
+        help='Clear stale git rebase/merge/index-lock state before pushing',
+    )
 
     # hooks
     p_hooks = sub.add_parser('hooks', help='Manage installed git hooks')
@@ -199,8 +215,12 @@ def main():
             sync.sync_pull(args, vault_path, db_path)
         elif args.sync_action == 'push':
             sync.sync_push(args, vault_path, db_path)
+        elif args.force:
+            if args.pull:
+                sync.sync_pull(args, vault_path, db_path)
+            sync.sync_push(args, vault_path, db_path)
         else:
-            print('Usage: schist sync {pull|push}', file=sys.stderr)
+            print('Usage: schist sync [--force [--pull]] {pull|push}', file=sys.stderr)
             sys.exit(1)
         sys.exit(0)
 

--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -285,6 +285,113 @@ def _build_spoke_in_staging(
     _install_local_hooks(str(staging))
 
 
+def _run_git_cleanup(vault_path: str, args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=vault_path,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _cleanup_rebase_state(vault_path: str) -> None:
+    print("Aborting leftover rebase state...", file=sys.stderr)
+    abort = _run_git_cleanup(vault_path, ["rebase", "--abort"])
+    if abort.returncode == 0:
+        return
+
+    # --abort can fail if the rebase is in a weird state (e.g. git is
+    # still running, or an orphan rebase-merge without a HEAD ref). Try
+    # --quit, which drops rebase state without restoring HEAD.
+    quit_result = _run_git_cleanup(vault_path, ["rebase", "--quit"])
+    if quit_result.returncode == 0:
+        return
+
+    print(
+        "Error: could not clear rebase state automatically.\n"
+        f"  rebase --abort: {abort.stderr.strip()}\n"
+        f"  rebase --quit:  {quit_result.stderr.strip()}\n"
+        "  Manual fix: rm -rf .git/rebase-merge .git/rebase-apply",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def _cleanup_merge_state(vault_path: str) -> None:
+    print("Aborting leftover merge state...", file=sys.stderr)
+    abort = _run_git_cleanup(vault_path, ["merge", "--abort"])
+    if abort.returncode == 0:
+        return
+
+    print(
+        "Error: could not clear merge state automatically.\n"
+        f"  merge --abort: {abort.stderr.strip()}\n"
+        "  Manual fix: inspect git status, resolve or abort the merge manually, then rerun sync.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def _cleanup_stale_index_lock(vault_path: str) -> None:
+    lock_path = Path(vault_path) / ".git" / "index.lock"
+    if not lock_path.exists():
+        return
+    print("Removing stale git index.lock...", file=sys.stderr)
+    try:
+        lock_path.unlink()
+    except OSError as e:
+        print(
+            "Error: could not remove stale .git/index.lock automatically.\n"
+            f"  {e}\n"
+            "  Manual fix: ensure no git process is running, then remove .git/index.lock.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def cleanup_stale_git_state(vault_path: str, *, force: bool) -> None:
+    """Clear stale git operation sentinels before sync.
+
+    Rebase state is always cleaned because a killed `sync pull` leaves the
+    spoke permanently unusable until it is removed. Merge and index-lock cleanup
+    are gated behind --force: merge abort can touch the worktree, and lock files
+    should only be removed as an explicit recovery action. Under --force, remove
+    index.lock before aborting a merge so Git gets a fair chance to restore the
+    worktree. Never drop MERGE_* sentinels after abort failure; that can hide
+    unresolved merge content from later status/staging checks.
+    """
+    git_dir = Path(vault_path) / ".git"
+    rebase_present = any((git_dir / d).exists() for d in ("rebase-merge", "rebase-apply"))
+    if rebase_present:
+        _cleanup_rebase_state(vault_path)
+
+    merge_present = (git_dir / "MERGE_HEAD").exists()
+    index_lock_present = (git_dir / "index.lock").exists()
+    if index_lock_present:
+        if not force:
+            print(
+                "Error: git index.lock present. Run `schist sync --force` after "
+                "confirming no git process is active.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        _cleanup_stale_index_lock(vault_path)
+
+    if merge_present:
+        if not force:
+            print(
+                "Error: merge in progress. Run `schist sync --force` after "
+                "confirming no manual merge is active.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        _cleanup_merge_state(vault_path)
+
+
+def _force_enabled(args) -> bool:
+    return getattr(args, "force", False) is True
+
+
 def sync_pull(args, vault_path: str, db_path: str) -> None:
     """Pull updates from hub and rebuild SQLite index."""
     if not is_spoke(vault_path):
@@ -292,38 +399,7 @@ def sync_pull(args, vault_path: str, db_path: str) -> None:
         sys.exit(1)
 
     config = load_spoke_config(vault_path)
-
-    # Self-heal: a prior pull may have been SIGKILL'd mid-rebase (e.g. by the
-    # MCP server's 5s maybeSpokePull timeout). Detect leftover rebase state
-    # and abort before starting a fresh pull. Without this, every subsequent
-    # sync fails with "rebase in progress" until manual cleanup.
-    rebase_present = any(
-        (Path(vault_path) / d).exists()
-        for d in (".git/rebase-merge", ".git/rebase-apply")
-    )
-    if rebase_present:
-        print("Aborting leftover rebase state...", file=sys.stderr)
-        abort = subprocess.run(
-            ["git", "rebase", "--abort"],
-            cwd=vault_path, capture_output=True, text=True,
-        )
-        if abort.returncode != 0:
-            # --abort can fail if the rebase is in a weird state (e.g. git is
-            # still running, or an orphan rebase-merge without a HEAD ref).
-            # Try --quit, which drops rebase state without restoring HEAD.
-            quit_result = subprocess.run(
-                ["git", "rebase", "--quit"],
-                cwd=vault_path, capture_output=True, text=True,
-            )
-            if quit_result.returncode != 0:
-                print(
-                    "Error: could not clear rebase state automatically.\n"
-                    f"  rebase --abort: {abort.stderr.strip()}\n"
-                    f"  rebase --quit:  {quit_result.stderr.strip()}\n"
-                    "  Manual fix: rm -rf .git/rebase-merge .git/rebase-apply",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
+    cleanup_stale_git_state(vault_path, force=_force_enabled(args))
 
     print(f"Pulling from hub as {config.identity}...")
 
@@ -425,6 +501,7 @@ def sync_push(args, vault_path: str, db_path: str) -> None:
         sys.exit(1)
 
     config = load_spoke_config(vault_path)
+    cleanup_stale_git_state(vault_path, force=_force_enabled(args))
 
     # Auto-commit if there are uncommitted changes
     if git_ops.has_uncommitted_changes(vault_path):

--- a/cli/tests/test_sync.py
+++ b/cli/tests/test_sync.py
@@ -533,6 +533,102 @@ class TestSyncPush:
         err = capsys.readouterr().err
         assert "unreachable" in err.lower() or "saved locally" in err.lower()
 
+    @patch("schist.sync.git_ops.has_uncommitted_changes", return_value=False)
+    def test_push_blocks_index_lock_without_force(self, mock_changes, tmp_path, capsys):
+        from schist.sync import sync_push
+
+        vault = _make_spoke(tmp_path)
+        (Path(vault) / ".git" / "index.lock").write_text("")
+        args = MagicMock(force=False)
+
+        with pytest.raises(SystemExit):
+            sync_push(args, vault, "db.sqlite")
+
+        assert "index.lock" in capsys.readouterr().err
+
+    @patch("schist.sync.git_ops.has_unpushed_commits", return_value=False)
+    @patch("schist.sync.git_ops.has_uncommitted_changes", return_value=False)
+    def test_push_force_removes_index_lock(self, mock_changes, mock_unpushed, tmp_path, capsys):
+        from schist.sync import sync_push
+
+        vault = _make_spoke(tmp_path)
+        lock = Path(vault) / ".git" / "index.lock"
+        lock.write_text("")
+        args = MagicMock(force=True)
+
+        sync_push(args, vault, "db.sqlite")
+
+        assert not lock.exists()
+        assert "Removing stale git index.lock" in capsys.readouterr().err
+
+    @patch("schist.sync.git_ops.has_unpushed_commits", return_value=False)
+    @patch("schist.sync.git_ops.has_uncommitted_changes", return_value=False)
+    @patch("subprocess.run")
+    def test_push_force_aborts_merge_state(
+        self, mock_run, mock_changes, mock_unpushed, tmp_path, capsys
+    ):
+        from schist.sync import sync_push
+
+        vault = _make_spoke(tmp_path)
+        (Path(vault) / ".git" / "MERGE_HEAD").write_text("deadbeef\n")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        args = MagicMock(force=True)
+
+        sync_push(args, vault, "db.sqlite")
+
+        calls = [call.args[0] for call in mock_run.call_args_list if call.args]
+        assert ["git", "merge", "--abort"] in calls
+        assert "Aborting leftover merge state" in capsys.readouterr().err
+
+    @patch("schist.sync.git_ops.has_unpushed_commits", return_value=False)
+    @patch("schist.sync.git_ops.has_uncommitted_changes", return_value=False)
+    @patch("subprocess.run")
+    def test_push_force_removes_lock_before_merge_abort(
+        self, mock_run, mock_changes, mock_unpushed, tmp_path, capsys
+    ):
+        from schist.sync import sync_push
+
+        vault = _make_spoke(tmp_path)
+        git_dir = Path(vault) / ".git"
+        lock = git_dir / "index.lock"
+        lock.write_text("")
+        (git_dir / "MERGE_HEAD").write_text("deadbeef\n")
+
+        def merge_abort(args, **kwargs):
+            assert args == ["git", "merge", "--abort"]
+            assert not lock.exists()
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = merge_abort
+        args = MagicMock(force=True)
+
+        sync_push(args, vault, "db.sqlite")
+
+        err = capsys.readouterr().err
+        assert "Removing stale git index.lock" in err
+        assert "Aborting leftover merge state" in err
+
+    @patch("schist.sync.git_ops.has_uncommitted_changes", return_value=False)
+    @patch("subprocess.run")
+    def test_push_force_keeps_merge_head_when_abort_fails(
+        self, mock_run, mock_changes, tmp_path, capsys
+    ):
+        from schist.sync import sync_push
+
+        vault = _make_spoke(tmp_path)
+        merge_head = Path(vault) / ".git" / "MERGE_HEAD"
+        merge_head.write_text("deadbeef\n")
+        mock_run.return_value = MagicMock(returncode=128, stdout="", stderr="fatal: unresolved merge")
+        args = MagicMock(force=True)
+
+        with pytest.raises(SystemExit):
+            sync_push(args, vault, "db.sqlite")
+
+        assert merge_head.exists()
+        err = capsys.readouterr().err
+        assert "could not clear merge state" in err
+        assert "resolve or abort the merge manually" in err
+
 
 class TestStageScopeFiles:
     def test_global_scope_stages_existing_canonical_dirs(self, tmp_path):

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -250,6 +250,27 @@ function sanitizeSentinelContent(raw: string): string {
   return cleaned.length > 500 ? cleaned.slice(0, 500) + "…" : cleaned;
 }
 
+function parseSyncErrorText(sanitized: string): { timestamp?: string; contents: string } {
+  const match = sanitized.match(/^(\S+)\s+([\s\S]*)$/);
+  const timestamp = match?.[1]?.match(/^\d{4}-\d{2}-\d{2}T/) ? match[1] : undefined;
+  return { timestamp, contents: timestamp ? (match?.[2] ?? "") : sanitized };
+}
+
+function formatSyncErrorAge(timestamp?: string): string | undefined {
+  if (!timestamp) return undefined;
+  const then = Date.parse(timestamp);
+  if (!Number.isFinite(then)) return undefined;
+  const ageMs = Date.now() - then;
+  if (ageMs < 0) return "less than 1 minute ago";
+  const minutes = Math.floor(ageMs / 60_000);
+  if (minutes < 1) return "less than 1 minute ago";
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"} ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours} hour${hours === 1 ? "" : "s"} ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+}
+
 async function readSyncWarning(vaultRoot: string): Promise<string | undefined> {
   const sentinelPath = path.join(vaultRoot, SYNC_ERROR_SENTINEL);
   let rawText: string;
@@ -267,10 +288,13 @@ async function readSyncWarning(vaultRoot: string): Promise<string | undefined> {
   }
   const errText = sanitizeSentinelContent(rawText);
   if (!errText) return undefined;
+  const parsed = parseSyncErrorText(errText);
+  const age = formatSyncErrorAge(parsed.timestamp);
+  const ageClause = age ? ` Sync failed ${age}.` : "";
   // Descriptive phrasing (not imperative). Agents reading this on every
   // write should NOT abandon their current task to "acknowledge" — the
   // sentinel will be cleared the next time get_context runs anyway.
-  return `Recent background sync failure: ${errText}. Writes may not have reached the hub. \`sync_status\` reports divergence and \`sync_retry\` can retry the push; \`get_context\` clears this on its next call.`;
+  return `Recent background sync failure:${ageClause} ${parsed.contents}. Writes may not have reached the hub. \`sync_status\` reports divergence and \`sync_retry\` can retry the push; \`get_context\` clears this on its next call.`;
 }
 
 async function readSyncErrorState(vaultRoot: string): Promise<SyncStatusResponse["last_sync_error"] & { mtimeMs: number } | null> {
@@ -282,9 +306,7 @@ async function readSyncErrorState(vaultRoot: string): Promise<SyncStatusResponse
     ]);
     const sanitized = sanitizeSentinelContent(rawText);
     if (!sanitized) return null;
-    const match = sanitized.match(/^(\S+)\s+([\s\S]*)$/);
-    const timestamp = match?.[1]?.match(/^\d{4}-\d{2}-\d{2}T/) ? match[1] : undefined;
-    const contents = timestamp ? (match?.[2] ?? "") : sanitized;
+    const { timestamp, contents } = parseSyncErrorText(sanitized);
     return { timestamp, contents, mtimeMs: stat.mtimeMs };
   } catch {
     return null;
@@ -440,15 +462,55 @@ async function runCommand(
   });
 }
 
-function runSchistSync(vaultRoot: string, action: "pull" | "push", timeoutMs = SYNC_RETRY_TIMEOUT_MS): Promise<SyncCommandOutcome> {
+function runSchistSync(
+  vaultRoot: string,
+  action: "pull" | "push",
+  timeoutMs = SYNC_RETRY_TIMEOUT_MS,
+  force = false,
+): Promise<SyncCommandOutcome> {
+  const args = ["--vault", vaultRoot, "sync", action];
+  if (force) args.push("--force");
   return runCommand(
     schistCliBin("schist"),
-    ["--vault", vaultRoot, "sync", action],
+    args,
     { cwd: vaultRoot, timeoutMs, env: process.env, capture: true },
   );
 }
 
 const inFlightSpokePushes = new Map<string, Promise<SyncCommandOutcome>>();
+
+async function hasStaleGitOperation(vaultRoot: string): Promise<boolean> {
+  const gitDir = path.join(vaultRoot, ".git");
+  const sentinels = [
+    path.join(gitDir, "rebase-merge"),
+    path.join(gitDir, "rebase-apply"),
+    path.join(gitDir, "MERGE_HEAD"),
+    path.join(gitDir, "index.lock"),
+  ];
+  for (const sentinel of sentinels) {
+    try {
+      await fs.access(sentinel);
+      return true;
+    } catch {
+      // absent is healthy for this sentinel
+    }
+  }
+  return false;
+}
+
+function pushFailureMessage(outcome: SyncCommandOutcome): string | null {
+  if (outcome.error && outcome.code === undefined && outcome.signal === undefined && !outcome.timedOut) {
+    return `push spawn failed: ${outcome.error}`;
+  }
+  if (outcome.timedOut) return "push timed out after 30000ms";
+  if (outcome.code !== null && outcome.code !== undefined && outcome.code !== 0) {
+    return `push exited with code ${outcome.code}`;
+  }
+  if (outcome.code === null && outcome.signal) {
+    return `push killed by signal ${outcome.signal}`;
+  }
+  return null;
+}
 
 /** Fire-and-forget spoke push after a write. No-op for non-spoke vaults. */
 export function triggerSpokePush(vaultRoot: string): void {
@@ -462,26 +524,34 @@ export function triggerSpokePush(vaultRoot: string): void {
     // the synchronous check above and we beat them to fs.access. Cheap.
     if (inFlightSpokePushes.has(vaultRoot)) return;
 
-    const pushPromise = runCommand(
-      schistCliBin("schist"),
-      ["--vault", vaultRoot, "sync", "push"],
-      { cwd: vaultRoot, timeoutMs: SYNC_RETRY_TIMEOUT_MS, env: process.env, capture: false },
-    ).then(async (outcome) => {
-      if (outcome.error && outcome.code === undefined && outcome.signal === undefined && !outcome.timedOut) {
-        console.error("[schist] spoke push failed:", outcome.error);
-        await writeSyncError(vaultRoot, `push spawn failed: ${outcome.error}`);
-      } else if (outcome.timedOut) {
-        await writeSyncError(vaultRoot, "push timed out after 30000ms");
-      } else if (outcome.code !== null && outcome.code !== undefined && outcome.code !== 0) {
-        await writeSyncError(vaultRoot, `push exited with code ${outcome.code}`);
-      } else if (outcome.code === null && outcome.signal) {
-        // Signal-killed: SIGTERM / SIGKILL from OOM killer, parent shutdown
-        // sending TERM down the process group, etc. Without this branch the
-        // push died silently and the next get_context would report "healthy."
-        await writeSyncError(vaultRoot, `push killed by signal ${outcome.signal}`);
+    const pushPromise = (async () => {
+      const sentinelBeforePush = await readSyncErrorState(vaultRoot);
+      let outcome = await runCommand(
+        schistCliBin("schist"),
+        ["--vault", vaultRoot, "sync", "push"],
+        { cwd: vaultRoot, timeoutMs: SYNC_RETRY_TIMEOUT_MS, env: process.env, capture: false },
+      );
+
+      let failure = pushFailureMessage(outcome);
+      if (failure !== null && await hasStaleGitOperation(vaultRoot)) {
+        console.error("[schist] spoke push failed with stale git state; retrying with sync push --force");
+        const retry = await runSchistSync(vaultRoot, "push", SYNC_RETRY_TIMEOUT_MS, true);
+        if (retry.ok) {
+          outcome = retry;
+          failure = null;
+        } else {
+          outcome = retry;
+          failure = `push failed after stale-state cleanup retry: ${outcomeMessage(retry)}`;
+        }
+      }
+
+      if (failure === null) {
+        await clearSyncErrorIfUnchanged(vaultRoot, sentinelBeforePush?.mtimeMs ?? null);
+      } else {
+        await writeSyncError(vaultRoot, failure);
       }
       return outcome;
-    }).finally(() => {
+    })().finally(() => {
       inFlightSpokePushes.delete(vaultRoot);
     });
     inFlightSpokePushes.set(vaultRoot, pushPromise);

--- a/mcp-server/tests/tools.test.ts
+++ b/mcp-server/tests/tools.test.ts
@@ -624,6 +624,56 @@ describe("triggerSpokePush", () => {
       await fs.rm(stubDir, { recursive: true, force: true });
     }
   }, 10000);
+
+  test("stale git state triggers one forced background push retry (#143)", async () => {
+    const vault = await makeTempVault();
+    await fs.mkdir(path.join(vault, ".schist"), { recursive: true });
+    await fs.writeFile(
+      path.join(vault, ".schist", "spoke.yaml"),
+      "hub: file:///nonexistent\nidentity: test\nscope: notes\n"
+    );
+
+    const logPath = path.join(vault, ".schist", "push-log");
+    const sentinelPath = path.join(vault, ".schist", "last-sync-error");
+    const stubDir = await fs.mkdtemp(path.join(os.tmpdir(), "stub-schist-"));
+    const stub = path.join(stubDir, "schist");
+    await fs.writeFile(
+      stub,
+      `#!/bin/sh
+echo "$@" >> "${logPath}"
+case "$*" in
+  *"--force"*) exit 0 ;;
+  *) mkdir -p "${path.join(vault, ".git", "rebase-merge")}"; exit 1 ;;
+esac
+`,
+      { mode: 0o755 },
+    );
+
+    const origPath = process.env.PATH;
+    process.env.PATH = `${stubDir}:${origPath}`;
+    try {
+      triggerSpokePush(vault);
+      let lines: string[] = [];
+      for (let i = 0; i < 80; i++) {
+        try {
+          lines = (await fs.readFile(logPath, "utf-8")).trim().split("\n").filter(Boolean);
+          if (lines.length >= 2) break;
+        } catch {
+          // not spawned yet
+        }
+        await new Promise((r) => setTimeout(r, 50));
+      }
+
+      expect(lines).toEqual([
+        `--vault ${vault} sync push`,
+        `--vault ${vault} sync push --force`,
+      ]);
+      await expect(fs.access(sentinelPath)).rejects.toBeDefined();
+    } finally {
+      process.env.PATH = origPath;
+      await fs.rm(stubDir, { recursive: true, force: true });
+    }
+  }, 10000);
 });
 
 describe("triggerIngestion — SCHIST_INGEST_BIN env override (#123)", () => {
@@ -1041,6 +1091,7 @@ describe("write-tool syncWarning surfacing (#120)", () => {
     expect(result.syncWarning).toBeDefined();
     expect(result.syncWarning).toContain("push exited with code 1");
     expect(result.syncWarning).toContain("Recent background sync failure");
+    expect(result.syncWarning).toMatch(/Sync failed .* ago/);
 
     // Sentinel is NOT cleared by write tools — get_context still owns that.
     const sentinelPath = path.join(vault, ".schist", "last-sync-error");


### PR DESCRIPTION
## Summary

Fixes stale spoke sync recovery for issue #143.

- adds `schist sync --force` / `schist sync --force --pull` shortcuts and `sync pull|push --force`
- centralizes stale git cleanup for leftover rebase state, merge state, and `.git/index.lock`
- makes MCP background `triggerSpokePush` retry once with `sync push --force` when a failed push leaves stale git state
- clears unchanged sync-error sentinels after successful background pushes
- includes sync-error age in write-tool `syncWarning` messages

## Validation

- `uv run --with pytest pytest tests/test_sync.py` — 42 passed
- `npm test -- --runTestsByPath tests/tools.test.ts` — 57 passed
- `npm run build` — passed

Closes #143.
