### PR TITLE
test(mcp): make ingest wrapper portable in CI

### DIFF
--- a/mcp-server/tests/confidence-field.test.ts
+++ b/mcp-server/tests/confidence-field.test.ts
@@ -33,11 +33,15 @@ async function useLocalSchistIngestBin(): Promise<void> {
   createdDirs.add(dir);
   const bin = path.join(dir, "schist-ingest-local");
   const python = path.join(repoRoot, "cli", ".venv", "bin", "python");
+  const cliDir = path.join(repoRoot, "cli");
   await fs.writeFile(
     bin,
     [
       "#!/bin/sh",
-      `PYTHONPATH=${JSON.stringify(path.join(repoRoot, "cli"))} exec ${JSON.stringify(python)} -m schist.ingest "$@"`,
+      `if [ -x ${JSON.stringify(python)} ]; then`,
+      `  PYTHONPATH=${JSON.stringify(cliDir)} exec ${JSON.stringify(python)} -m schist.ingest "$@"`,
+      "fi",
+      `cd ${JSON.stringify(cliDir)} && exec uv run --with . python -m schist.ingest "$@"`,
       "",
     ].join("\n"),
     { mode: 0o755 },

--- a/mcp-server/tests/file-ref-field.test.ts
+++ b/mcp-server/tests/file-ref-field.test.ts
@@ -28,11 +28,15 @@ async function useLocalSchistIngestBin(): Promise<void> {
   createdDirs.add(dir);
   const bin = path.join(dir, "schist-ingest-local");
   const python = path.join(repoRoot, "cli", ".venv", "bin", "python");
+  const cliDir = path.join(repoRoot, "cli");
   await fs.writeFile(
     bin,
     [
       "#!/bin/sh",
-      `PYTHONPATH=${JSON.stringify(path.join(repoRoot, "cli"))} exec ${JSON.stringify(python)} -m schist.ingest "$@"`,
+      `if [ -x ${JSON.stringify(python)} ]; then`,
+      `  PYTHONPATH=${JSON.stringify(cliDir)} exec ${JSON.stringify(python)} -m schist.ingest "$@"`,
+      "fi",
+      `cd ${JSON.stringify(cliDir)} && exec uv run --with . python -m schist.ingest "$@"`,
       "",
     ].join("\n"),
     { mode: 0o755 },


### PR DESCRIPTION
## Summary
- Fix schema-drift tests that assumed cli/.venv/bin/python exists
- Keep the local venv fast path, but fall back to uv run --with . in CI

## Verification
- npm test -- --runTestsByPath tests/file-ref-field.test.ts tests/confidence-field.test.ts
- npm run build
- git diff --check

This addresses the MCP CI failure seen on PR #179 and on the current main-based checks.