### PR TITLE
[codex] Fix pre-receive intermediate commit ACL checks

### DIFF
--- a/cli/schist/pre_receive.py
+++ b/cli/schist/pre_receive.py
@@ -68,21 +68,27 @@ def derive_scope(filepath: str) -> str:
 
 
 def get_changed_files(oldrev: str, newrev: str) -> list[str]:
-    """Get list of files changed between two revisions.
+    """Get list of files touched by commits introduced between two revisions.
 
     Handles special cases:
-    - New branch (oldrev is zero): diff against empty tree
+    - New branch (oldrev is zero): inspect commits not already reachable
     - Deleted branch (newrev is zero): no files to check
+
+    This intentionally enumerates per-commit file touches instead of using a
+    net diff. A multi-commit push can add an out-of-scope file in an
+    intermediate commit and remove it before the tip; the hook must still see
+    that file because it entered git history.
     """
     if newrev == ZERO_SHA:
         # Branch deletion — nothing to check
         return []
 
     if oldrev == ZERO_SHA:
-        # New branch — diff all files in the new ref against empty tree
-        # Use git diff-tree against the empty tree hash
+        # New branch — inspect commits introduced by this ref. Exclude commits
+        # already reachable from existing refs so creating a branch at an
+        # existing commit does not re-count old history.
         result = subprocess.run(
-            ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", "-z", newrev],
+            ["git", "log", "--name-only", "--format=", "-z", newrev, "--not", "--all"],
             capture_output=True,
             text=True,
             check=True,
@@ -90,14 +96,15 @@ def get_changed_files(oldrev: str, newrev: str) -> list[str]:
         )
     else:
         result = subprocess.run(
-            ["git", "diff", "--name-only", "-z", oldrev, newrev],
+            ["git", "log", "--name-only", "--format=", "-z", f"{oldrev}..{newrev}"],
             capture_output=True,
             text=True,
             check=True,
             timeout=30,
         )
 
-    return [f for f in result.stdout.strip("\0").split("\0") if f]
+    changed_files = [f for f in result.stdout.strip("\0").split("\0") if f]
+    return list(dict.fromkeys(changed_files))
 
 
 def check_push(

--- a/cli/tests/test_pre_receive.py
+++ b/cli/tests/test_pre_receive.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -428,24 +429,28 @@ class TestGetChangedFiles:
         result = get_changed_files("abc123", ZERO_SHA)
         assert result == []
 
-    def test_normal_diff(self):
+    def test_existing_branch_uses_commit_history_not_net_diff(self):
         from schist.pre_receive import get_changed_files
 
-        mock_result = type("Result", (), {"stdout": "a.md\0b.md\0", "returncode": 0})()
-        with patch("subprocess.run", return_value=mock_result):
+        mock_result = type("Result", (), {"stdout": "a.md\0b.md\0a.md\0", "returncode": 0})()
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
             result = get_changed_files("aaa", "bbb")
         assert result == ["a.md", "b.md"]
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["git", "log", "--name-only", "--format=", "-z", "aaa..bbb"]
 
-    def test_new_branch_uses_diff_tree(self):
+    def test_new_branch_uses_commit_history_not_tip_diff(self):
         from schist.pre_receive import ZERO_SHA, get_changed_files
 
         mock_result = type("Result", (), {"stdout": "new-file.md\0", "returncode": 0})()
         with patch("subprocess.run", return_value=mock_result) as mock_run:
             result = get_changed_files(ZERO_SHA, "abc123")
         assert result == ["new-file.md"]
-        # Should use diff-tree for new branches
         cmd = mock_run.call_args[0][0]
-        assert "diff-tree" in cmd
+        assert cmd == [
+            "git", "log", "--name-only", "--format=", "-z",
+            "abc123", "--not", "--all",
+        ]
 
     def test_empty_diff_returns_empty(self):
         from schist.pre_receive import get_changed_files
@@ -454,6 +459,64 @@ class TestGetChangedFiles:
         with patch("subprocess.run", return_value=mock_result):
             result = get_changed_files("aaa", "bbb")
         assert result == []
+
+    @pytest.mark.integration
+    def test_intermediate_reverted_file_is_rejected(self, acl, tmp_path, monkeypatch, capsys):
+        """ACL checks must inspect every pushed commit, not only the net diff.
+
+        The simulated push starts at ``oldrev``. The first new commit writes an
+        out-of-scope file; the second removes it, so ``git diff oldrev newrev``
+        would not show that path. The pre-receive hook must still reject the
+        push because the unauthorized content entered git history.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        def git(*args: str) -> str:
+            result = subprocess.run(
+                ["git", *args],
+                cwd=repo,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return result.stdout.strip()
+
+        git("init")
+        git("config", "user.email", "test@example.com")
+        git("config", "user.name", "Test User")
+
+        allowed = repo / "research" / "mario" / "ok.md"
+        allowed.parent.mkdir(parents=True)
+        allowed.write_text("ok\n")
+        git("add", "research/mario/ok.md")
+        git("commit", "-m", "base")
+        oldrev = git("rev-parse", "HEAD")
+
+        bad = repo / "security" / "bad.md"
+        bad.parent.mkdir(parents=True)
+        bad.write_text("bad\n")
+        git("add", "security/bad.md")
+        git("commit", "-m", "bad intermediate")
+
+        bad.unlink()
+        git("add", "security/bad.md")
+        git("commit", "-m", "revert bad")
+        newrev = git("rev-parse", "HEAD")
+
+        monkeypatch.chdir(repo)
+        rc = main(
+            stdin=[f"{oldrev} {newrev} refs/heads/main"],
+            acl=acl,
+            identity="cluster-mario",
+            log_path=tmp_path / "rejected-pushes.log",
+            db_path=tmp_path / "rate-limits.sqlite",
+        )
+
+        assert rc == 1
+        stderr = capsys.readouterr().err
+        assert "out-of-scope writes" in stderr
+        assert "security/bad.md" in stderr
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- change pre-receive changed-file detection from net diffs to per-commit history enumeration
- cover existing branch updates and new branch pushes while preserving deletion handling
- add a real git regression test where an out-of-scope intermediate commit is reverted before the push tip

## Root cause
The pre-receive hook used `git diff --name-only oldrev newrev` for existing branch updates. That only reports the net tree diff, so a multi-commit push could add an unauthorized file in an intermediate commit, remove it before the tip, and bypass ACL and rate-limit checks even though the content entered git history.

## Validation
- `cd cli && uv run --with pytest --with . python -m pytest tests/test_pre_receive.py -v`
- `cd cli && uv run --with pytest --with . python -m pytest tests/ -v`

Closes #182