### PR TITLE
[codex] Fix CLI query and search reliability

### DIFF
--- a/cli/schist/sqlite_query.py
+++ b/cli/schist/sqlite_query.py
@@ -7,6 +7,8 @@ import sys
 
 
 ALLOWED_TABLES = {'docs', 'concepts', 'edges', 'docs_fts', 'paper_metadata'}
+# Keep in sync with mcp-server/src/sqlite-reader.ts REQUIRED_TABLES.
+REQUIRED_TABLES = {'docs', 'paper_metadata'}
 
 
 def get_db(vault_path: str, db_path: str | None = None) -> sqlite3.Connection:
@@ -20,8 +22,13 @@ def get_db(vault_path: str, db_path: str | None = None) -> sqlite3.Connection:
     if not needs_ingest:
         conn = sqlite3.connect(db_path)
         try:
-            count = conn.execute("SELECT count(*) FROM sqlite_master WHERE type='table' AND name='docs'").fetchone()[0]
-            if count == 0:
+            table_names = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            if not REQUIRED_TABLES.issubset(table_names):
                 needs_ingest = True
                 conn.close()
         except sqlite3.DatabaseError:
@@ -60,6 +67,10 @@ def _run_ingest(vault_path: str, db_path: str):
 def fts_search(db: sqlite3.Connection, query: str, limit: int = 20,
                status: str | None = None, tags: list[str] | None = None) -> list[dict]:
     """FTS5 search on docs_fts joined to docs."""
+    sanitized_query = _sanitize_fts_query(query)
+    if not sanitized_query:
+        return []
+
     sql = """
         SELECT d.id, d.title, d.date, d.status,
                snippet(docs_fts, 1, '[', ']', '...', 32) AS snippet
@@ -67,7 +78,7 @@ def fts_search(db: sqlite3.Connection, query: str, limit: int = 20,
         JOIN docs d ON d.rowid = fts.rowid
         WHERE docs_fts MATCH ?
     """
-    params: list = [query]
+    params: list = [sanitized_query]
 
     if status:
         sql += ' AND d.status = ?'
@@ -85,6 +96,12 @@ def fts_search(db: sqlite3.Connection, query: str, limit: int = 20,
     return [dict(r) for r in rows]
 
 
+def _sanitize_fts_query(query: str) -> str:
+    """Quote each token so FTS5 treats user input as literal search text."""
+    tokens = query.split()
+    return " ".join(f'"{token.replace(chr(34), chr(34) * 2)}"' for token in tokens)
+
+
 def raw_query(db: sqlite3.Connection, sql: str, params: tuple = ()) -> dict:
     """Execute a validated SELECT query. Returns {columns, rows}."""
     _validate_sql(sql)
@@ -94,20 +111,76 @@ def raw_query(db: sqlite3.Connection, sql: str, params: tuple = ()) -> dict:
     return {'columns': columns, 'rows': rows}
 
 
+def _mask_sql_literals_and_comments(sql: str) -> str:
+    """Replace SQL string/comment contents with spaces before regex checks."""
+    chars = list(sql)
+    i = 0
+    state = "normal"
+
+    while i < len(chars):
+        ch = chars[i]
+        nxt = chars[i + 1] if i + 1 < len(chars) else ""
+
+        if state == "normal":
+            if ch == "'":
+                state = "single"
+            elif ch == '"':
+                state = "double"
+            elif ch == "-" and nxt == "-":
+                chars[i] = chars[i + 1] = " "
+                i += 1
+                state = "line_comment"
+            elif ch == "/" and nxt == "*":
+                chars[i] = chars[i + 1] = " "
+                i += 1
+                state = "block_comment"
+        elif state == "single":
+            if ch == "'" and nxt == "'":
+                chars[i] = chars[i + 1] = " "
+                i += 1
+            elif ch == "'":
+                state = "normal"
+            else:
+                chars[i] = " "
+        elif state == "double":
+            if ch == '"' and nxt == '"':
+                chars[i] = chars[i + 1] = " "
+                i += 1
+            elif ch == '"':
+                state = "normal"
+            else:
+                chars[i] = " "
+        elif state == "line_comment":
+            if ch == "\n":
+                state = "normal"
+            else:
+                chars[i] = " "
+        elif state == "block_comment":
+            if ch == "*" and nxt == "/":
+                chars[i] = chars[i + 1] = " "
+                i += 1
+                state = "normal"
+            else:
+                chars[i] = " "
+
+        i += 1
+
+    return "".join(chars)
+
+
 def _validate_sql(sql: str):
     """Ensure SQL is SELECT-only and uses only allowed tables."""
-    # Strip SQL comments
-    cleaned = re.sub(r'--.*$', '', sql, flags=re.MULTILINE)
-    cleaned = re.sub(r'/\*.*?\*/', '', cleaned, flags=re.DOTALL)
+    cleaned = _mask_sql_literals_and_comments(sql)
     cleaned = cleaned.strip()
 
-    if not cleaned.upper().startswith('SELECT'):
+    if not re.match(r'SELECT\b', cleaned, re.IGNORECASE):
         print('Error: only SELECT queries are allowed', file=sys.stderr)
         sys.exit(1)
 
-    # Check for disallowed statements
+    # sqlite3.execute() rejects multiple statements, but catch obvious stacked
+    # write attempts here so the CLI reports the same friendly validation style.
     for keyword in ('INSERT', 'UPDATE', 'DELETE', 'DROP', 'ALTER', 'CREATE', 'ATTACH'):
-        if re.search(rf'\b{keyword}\b', cleaned, re.IGNORECASE):
+        if re.search(rf';\s*{keyword}\b', cleaned, re.IGNORECASE):
             print(f'Error: {keyword} statements are not allowed', file=sys.stderr)
             sys.exit(1)
 

--- a/cli/tests/test_sqlite_query.py
+++ b/cli/tests/test_sqlite_query.py
@@ -1,0 +1,146 @@
+"""Tests for SQLite query/search helper behavior."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from schist.sqlite_query import fts_search, get_db, raw_query
+
+
+def _connect(path: Path | str = ":memory:") -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_get_db_reingests_when_required_side_table_missing(tmp_path: Path) -> None:
+    """Pre-paper_metadata DBs should self-heal instead of failing at query time."""
+    vault = tmp_path / "vault"
+    db_path = vault / ".schist" / "schist.db"
+    db_path.parent.mkdir(parents=True)
+
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE docs (id TEXT PRIMARY KEY)")
+    conn.commit()
+    conn.close()
+
+    with patch("schist.sqlite_query._run_ingest") as run_ingest:
+        db = get_db(str(vault), str(db_path))
+        db.close()
+
+    run_ingest.assert_called_once_with(str(vault), str(db_path))
+
+
+def test_get_db_keeps_current_db_when_required_tables_exist(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    db_path = vault / ".schist" / "schist.db"
+    db_path.parent.mkdir(parents=True)
+
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE docs (id TEXT PRIMARY KEY)")
+    conn.execute("CREATE TABLE paper_metadata (doc_id TEXT PRIMARY KEY)")
+    conn.commit()
+    conn.close()
+
+    with patch("schist.sqlite_query._run_ingest") as run_ingest:
+        db = get_db(str(vault), str(db_path))
+        db.close()
+
+    run_ingest.assert_not_called()
+
+
+def test_validate_sql_allows_blocked_keywords_inside_string_literals() -> None:
+    conn = _connect()
+    conn.execute("CREATE TABLE docs (id TEXT PRIMARY KEY, title TEXT)")
+    conn.execute("INSERT INTO docs (id, title) VALUES ('a', 'create-note workflow')")
+
+    result = raw_query(
+        conn,
+        "SELECT id FROM docs WHERE title LIKE '%create-note%'",
+    )
+
+    assert result == {"columns": ["id"], "rows": [["a"]]}
+
+
+def test_validate_sql_does_not_strip_comment_markers_inside_strings() -> None:
+    conn = _connect()
+    conn.execute("CREATE TABLE docs (id TEXT PRIMARY KEY, title TEXT)")
+    conn.execute("INSERT INTO docs (id, title) VALUES ('a', 'foo--bar')")
+
+    result = raw_query(conn, "SELECT id FROM docs WHERE title = 'foo--bar'")
+
+    assert result == {"columns": ["id"], "rows": [["a"]]}
+
+
+def test_validate_sql_still_rejects_stacked_write_statements(capsys) -> None:
+    conn = _connect()
+    conn.execute("CREATE TABLE docs (id TEXT PRIMARY KEY)")
+
+    with pytest.raises(SystemExit):
+        raw_query(conn, "SELECT id FROM docs; DELETE FROM docs")
+
+    assert "DELETE statements are not allowed" in capsys.readouterr().err
+
+
+def test_fts_search_sanitizes_special_syntax_without_traceback() -> None:
+    conn = _connect()
+    conn.execute("""
+        CREATE TABLE docs (
+            id TEXT PRIMARY KEY,
+            title TEXT,
+            date TEXT,
+            status TEXT,
+            tags TEXT,
+            body TEXT
+        )
+    """)
+    conn.execute("CREATE VIRTUAL TABLE docs_fts USING fts5(title, body, tags, scope UNINDEXED)")
+    conn.execute(
+        "INSERT INTO docs (rowid, id, title, date, status, tags, body) "
+        "VALUES (1, 'notes/a.md', 'Syntax', '2026-06-09', 'draft', '[]', 'literal (unclosed text')"
+    )
+    conn.execute(
+        "INSERT INTO docs_fts (rowid, title, body, tags, scope) "
+        "VALUES (1, 'Syntax', 'literal (unclosed text', '[]', 'global')"
+    )
+
+    rows = fts_search(conn, "(unclosed")
+
+    assert [row["id"] for row in rows] == ["notes/a.md"]
+
+
+def test_fts_search_matches_mcp_literal_operator_behavior() -> None:
+    conn = _connect()
+    conn.execute("""
+        CREATE TABLE docs (
+            id TEXT PRIMARY KEY,
+            title TEXT,
+            date TEXT,
+            status TEXT,
+            tags TEXT,
+            body TEXT
+        )
+    """)
+    conn.execute("CREATE VIRTUAL TABLE docs_fts USING fts5(title, body, tags, scope UNINDEXED)")
+    conn.execute(
+        "INSERT INTO docs (rowid, id, title, date, status, tags, body) "
+        "VALUES (1, 'notes/a.md', 'Foo', '2026-06-09', 'draft', '[]', 'foo only')"
+    )
+    conn.execute(
+        "INSERT INTO docs (rowid, id, title, date, status, tags, body) "
+        "VALUES (2, 'notes/b.md', 'Bar', '2026-06-09', 'draft', '[]', 'bar only')"
+    )
+    conn.execute(
+        "INSERT INTO docs_fts (rowid, title, body, tags, scope) "
+        "VALUES (1, 'Foo', 'foo only', '[]', 'global')"
+    )
+    conn.execute(
+        "INSERT INTO docs_fts (rowid, title, body, tags, scope) "
+        "VALUES (2, 'Bar', 'bar only', '[]', 'global')"
+    )
+
+    assert fts_search(conn, "foo OR bar") == []


### PR DESCRIPTION
## Summary
- rebuild stale CLI SQLite DBs when required side tables like `paper_metadata` are missing
- sanitize CLI FTS search input the same way as the MCP reader so special syntax is treated as literal text
- make SELECT validation ignore SQL keywords and comment markers inside string literals while still rejecting obvious stacked write statements
- add focused sqlite query/search regression tests

## Root cause
The Python CLI query path had drifted from the TypeScript reader. It only checked for the `docs` table before trusting an existing DB, sent raw user text into FTS5 MATCH, and scanned SQL keywords with regexes that matched inside string literals.

## Validation
- `cd cli && uv run --with pytest --with . python -m pytest tests/test_sqlite_query.py -v`
- `cd cli && uv run --with pytest --with . python -m pytest tests/ -v`

Closes #185
Closes #186
Closes #187