### PR TITLE
[codex] Fix concept edge counts for path targets

### DIFF
--- a/mcp-server/src/sqlite-reader.ts
+++ b/mcp-server/src/sqlite-reader.ts
@@ -302,6 +302,15 @@ export function getNote(vaultRoot: string, id: string): Note | null {
   }
 }
 
+function conceptEdgeJoinCondition(edgeAlias: string, conceptAlias: string): string {
+  return `(
+    ${edgeAlias}.source = ${conceptAlias}.slug OR
+    ${edgeAlias}.target = ${conceptAlias}.slug OR
+    ${edgeAlias}.source = 'concepts/' || ${conceptAlias}.slug || '.md' OR
+    ${edgeAlias}.target = 'concepts/' || ${conceptAlias}.slug || '.md'
+  )`;
+}
+
 export function listConcepts(
   vaultRoot: string,
   opts?: { tags?: string[]; search?: string; limit?: number; offset?: number }
@@ -314,7 +323,7 @@ export function listConcepts(
       SELECT c.slug, c.title, c.description, c.tags,
              COUNT(e.id) as edgeCount
       FROM concepts c
-      LEFT JOIN edges e ON e.source = c.slug OR e.target = c.slug
+      LEFT JOIN edges e ON ${conceptEdgeJoinCondition("e", "c")}
     `;
     const params: unknown[] = [];
     const where: string[] = [];
@@ -438,7 +447,7 @@ export function getContext(
       .prepare(`
         SELECT c.slug, c.title, COUNT(e.id) as edgeCount
         FROM concepts c
-        LEFT JOIN edges e ON e.source = c.slug OR e.target = c.slug
+        LEFT JOIN edges e ON ${conceptEdgeJoinCondition("e", "c")}
         GROUP BY c.slug
         ORDER BY edgeCount DESC
         LIMIT 10

--- a/mcp-server/tests/list-concepts-sql.test.ts
+++ b/mcp-server/tests/list-concepts-sql.test.ts
@@ -1,4 +1,4 @@
-import { listConcepts } from "../src/sqlite-reader.js";
+import { getContext, listConcepts } from "../src/sqlite-reader.js";
 import * as fs from "fs/promises";
 import * as path from "path";
 import * as os from "os";
@@ -17,6 +17,21 @@ async function makeConceptVault(
 
   const db = new Database(dbPath);
   db.exec(`
+    CREATE TABLE docs (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      date TEXT,
+      status TEXT DEFAULT 'draft',
+      tags TEXT,
+      concepts TEXT,
+      body TEXT NOT NULL,
+      scope TEXT DEFAULT 'global',
+      source TEXT,
+      confidence TEXT,
+      file_ref TEXT,
+      created_at TEXT DEFAULT (datetime('now')),
+      updated_at TEXT DEFAULT (datetime('now'))
+    );
     CREATE TABLE concepts (
       slug TEXT PRIMARY KEY,
       title TEXT NOT NULL,
@@ -34,6 +49,9 @@ async function makeConceptVault(
       UNIQUE(source, target, type)
     );
   `);
+  db.prepare(
+    `INSERT INTO docs (id, title, body, tags) VALUES (?, ?, ?, ?)`,
+  ).run("notes/seed.md", "Seed", "body", "[]");
 
   const insertConcept = db.prepare(
     `INSERT INTO concepts (slug, title) VALUES (?, ?)`
@@ -145,5 +163,45 @@ describe("listConcepts — cursor pagination", () => {
 
     const results = listConcepts(vault, { limit: 2 });
     expect(results.length).toBe(2);
+  });
+
+  it("counts both slug and concepts/<slug>.md edge endpoints", async () => {
+    const vault = await makeConceptVault([
+      { slug: "backpropagation", title: "Backpropagation" },
+    ]);
+    const db = new Database(path.join(vault, ".schist", "schist.db"));
+    db.prepare(`INSERT INTO edges (source, target, type) VALUES (?, ?, ?)`).run(
+      "notes/seed.md", "backpropagation", "references",
+    );
+    db.prepare(`INSERT INTO edges (source, target, type) VALUES (?, ?, ?)`).run(
+      "notes/seed.md", "concepts/backpropagation.md", "extends",
+    );
+    db.close();
+
+    const [concept] = listConcepts(vault);
+
+    expect(concept.slug).toBe("backpropagation");
+    expect(concept.edgeCount).toBe(2);
+  });
+
+  it("uses the same path-aware edge count for getContext hotConcepts", async () => {
+    const vault = await makeConceptVault([
+      { slug: "backpropagation", title: "Backpropagation" },
+    ]);
+    const db = new Database(path.join(vault, ".schist", "schist.db"));
+    db.prepare(`INSERT INTO edges (source, target, type) VALUES (?, ?, ?)`).run(
+      "notes/seed.md", "backpropagation", "references",
+    );
+    db.prepare(`INSERT INTO edges (source, target, type) VALUES (?, ?, ?)`).run(
+      "notes/seed.md", "concepts/backpropagation.md", "extends",
+    );
+    db.close();
+
+    const context = getContext(vault) as { hotConcepts: Array<{ slug: string; edgeCount: number }> };
+
+    expect(context.hotConcepts[0]).toMatchObject({
+      slug: "backpropagation",
+      edgeCount: 2,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- count concept edges whose endpoints use either the concept slug or `concepts/<slug>.md`
- share the path-aware join condition between `listConcepts` and `getContext` hot concepts
- add SQL-level regression coverage for mixed slug/path concept edges

## Root cause
Explicit `## Connections` edges can store concept endpoints as relative paths, while implicit `concepts:` references store slugs. The MCP concept-count queries only joined on slugs, so explicit path-form concept connections were missing from `edgeCount` and hot-concept ranking.

## Validation
- `cd mcp-server && npm test -- --runTestsByPath tests/list-concepts-sql.test.ts`
- `cd mcp-server && npm run build`
- `cd mcp-server && npm test`

Closes #184