### PR TITLE
[codex] Make Claude confirmation comment best effort

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -83,20 +83,29 @@ jobs:
             gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
               --jq ".[] | select(.body | contains(\"${marker}\")) | .id" \
               | head -n 1
-          )"
+          )" || {
+            echo "GitHub token could not read existing PR comments; recording confirmation in the job summary." >> "$GITHUB_STEP_SUMMARY"
+            cat "$body_file" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          }
 
+          body="$(cat "$body_file")"
           if [ -n "$comment_id" ]; then
-            body="$(cat "$body_file")"
-            gh api \
+            if ! gh api \
               --method PATCH \
               "repos/${REPOSITORY}/issues/comments/${comment_id}" \
-              --field body="$body" >/dev/null
+              --field body="$body" >/dev/null; then
+              echo "GitHub token could not update the Claude confirmation PR comment; recording confirmation in the job summary." >> "$GITHUB_STEP_SUMMARY"
+              cat "$body_file" >> "$GITHUB_STEP_SUMMARY"
+            fi
           else
-            body="$(cat "$body_file")"
-            gh api \
+            if ! gh api \
               --method POST \
               "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
-              --field body="$body" >/dev/null
+              --field body="$body" >/dev/null; then
+              echo "GitHub token could not create the Claude confirmation PR comment; recording confirmation in the job summary." >> "$GITHUB_STEP_SUMMARY"
+              cat "$body_file" >> "$GITHUB_STEP_SUMMARY"
+            fi
           fi
 
       - name: Record Claude review skipped for workflow self-change


### PR DESCRIPTION
## Summary
- keep the Claude review completion comment idempotent when the token can read/write comments
- fall back to the workflow job summary when GitHub denies comment access
- prevent comment permission failures from turning a successful Claude review into a failed required check

## Test plan
- inspected failing run for PR #188: confirmation step failed with HTTP 403 after Claude review completed
- workflow-only change