### PR TITLE
Preserve all paper verification sources

### DIFF
--- a/cli/schist/ingest.py
+++ b/cli/schist/ingest.py
@@ -92,16 +92,18 @@ def _authors_json(value) -> str | None:
     return None
 
 
-def _first_verification_source(value) -> str | None:
+def _verification_sources_json(value) -> str | None:
+    sources: list[str] = []
     if isinstance(value, list):
         for item in value:
             if isinstance(item, str) and item:
-                return item
+                sources.append(item)
             if isinstance(item, dict) and item:
-                key, val = next(iter(item.items()))
-                return f'{key}:{val}' if val is not None else str(key)
+                for key, val in item.items():
+                    sources.append(f'{key}:{val}' if val is not None else str(key))
+        return json.dumps(sources) if sources else None
     if isinstance(value, str) and value:
-        return value
+        return json.dumps([value])
     return None
 
 
@@ -117,7 +119,7 @@ def paper_metadata_from_frontmatter(meta: dict, rel: Path) -> tuple | None:
         verification = {}
     verified_date = _string_or_none(verification.get('verified_on'))
     verified_by = _string_or_none(verification.get('verified_by'))
-    verification_source = _first_verification_source(verification.get('verified_against'))
+    verification_sources = _verification_sources_json(verification.get('verified_against'))
     verified = 1 if verified_date else 0
 
     return (
@@ -132,7 +134,7 @@ def paper_metadata_from_frontmatter(meta: dict, rel: Path) -> tuple | None:
         verified,
         verified_by,
         verified_date,
-        verification_source,
+        verification_sources,
         _string_or_none(meta.get('url')),
     )
 
@@ -258,7 +260,7 @@ def _ingest_into(conn: sqlite3.Connection, vault: Path, schema_path: Path) -> No
                 INSERT INTO paper_metadata (
                     doc_id, authors, year, venue, paper_type, doi, arxiv_id,
                     pubmed_pmid, bibtex_key, verified, verified_by,
-                    verified_date, verification_source, url
+                    verified_date, verification_sources, url
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (doc_id, *paper_row),

--- a/cli/schist/schema.sql
+++ b/cli/schist/schema.sql
@@ -58,7 +58,7 @@ CREATE TABLE paper_metadata (
     verified            INTEGER DEFAULT 0,
     verified_by         TEXT,
     verified_date       TEXT,
-    verification_source TEXT,
+    verification_sources TEXT,              -- JSON array of verification sources
     url                 TEXT
 );
 

--- a/cli/tests/test_ingest.py
+++ b/cli/tests/test_ingest.py
@@ -181,6 +181,7 @@ def test_ingest_indexes_paper_metadata(tmp_path: Path) -> None:
         "  verified_by: codex\n"
         "  verified_against:\n"
         "    - crossref:10.1234/example\n"
+        "    - pubmed:12345678\n"
         "---\n"
         "\n"
         "Body.\n",
@@ -220,7 +221,10 @@ def test_ingest_indexes_paper_metadata(tmp_path: Path) -> None:
     assert row["verified"] == 1
     assert row["verified_by"] == "codex"
     assert row["verified_date"] == "2026-06-08"
-    assert row["verification_source"] == "crossref:10.1234/example"
+    assert json.loads(row["verification_sources"]) == [
+        "crossref:10.1234/example",
+        "pubmed:12345678",
+    ]
     assert row["url"] == "https://doi.org/10.1234/example"
     assert query == {"columns": ["title", "year"], "rows": [["Example Paper", 2024]]}
 

--- a/schema/SCHEMA.md
+++ b/schema/SCHEMA.md
@@ -128,7 +128,9 @@ See `CONVENTIONS.md` for the full authoring guide and example template.
 
 Ingest copies citation-grade paper fields into the `paper_metadata` SQLite side
 table keyed by `docs.id`. This keeps generic document rows compact while making
-paper integrity queries straightforward:
+paper integrity queries straightforward. The `verification_sources` column
+stores `verification.verified_against` as a JSON array so multi-source
+verification records remain queryable after ingest.
 
 ```sql
 -- Unverified papers
@@ -148,6 +150,13 @@ SELECT d.title
 FROM docs d
 JOIN paper_metadata pm ON pm.doc_id = d.id
 WHERE pm.doi IS NULL;
+
+-- Papers verified against PubMed
+SELECT d.title
+FROM docs d
+JOIN paper_metadata pm ON pm.doc_id = d.id
+JOIN json_each(pm.verification_sources) src
+WHERE src.value LIKE 'pubmed:%';
 ```
 
 ## Connection Types


### PR DESCRIPTION
## Summary
- store paper verification sources as a JSON array in paper_metadata.verification_sources
- preserve all verification.verified_against entries during ingest instead of only the first
- document JSON-array querying and cover multi-source verification in ingest tests

Fixes #183.

## Tests
- cd cli && uv run --with pytest --with . python -m pytest tests/test_ingest.py
- cd cli && uv run --with pytest --with . python -m pytest tests/