### PR TITLE
Harden query_graph resource usage

### DIFF
--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -151,6 +151,20 @@ under "BREAKING: `query_graph`" for migration guidance.
 Only `SELECT` and `WITH` are allowed; mutation keywords are rejected with
 `INVALID_SQL`.
 
+`query_graph` is a trusted-agent tool, not a SQL sandbox. Callers can read any
+table in the vault SQLite database, including schema tables and side tables.
+Access control belongs at the MCP process boundary (`SCHIST_ALLOWED_AGENTS`,
+stdio process isolation, or an external auth proxy for any non-stdio
+transport). Do not expose the MCP server directly to a network.
+
+Two resource caps protect the MCP process from accidental or adversarial
+resource burn:
+
+- `SCHIST_QUERY_GRAPH_TIMEOUT_MS` — wall-clock timeout for the SQLite worker;
+  default `5000`.
+- `SCHIST_QUERY_GRAPH_BYTE_BUDGET` — maximum JSON response size before
+  `QUERY_RESPONSE_TOO_LARGE`; default `10485760` (10 MiB).
+
 ### Reason-string verbose
 
 `search_memory` and `get_context` accept an optional `verbose: "<reason>"`

--- a/docs/superpowers/specs/2026-05-04-mcp-context-efficiency.md
+++ b/docs/superpowers/specs/2026-05-04-mcp-context-efficiency.md
@@ -325,10 +325,20 @@ SELECT * FROM (<caller_sql>) AS user_query LIMIT :limit OFFSET :offset
   `5 < limit`). A caller passing `SELECT * FROM docs ORDER BY date DESC`
   gets server-paginated results in date-descending order.
 - The existing `query_graph` guards (SELECT/WITH-only, no
-  INSERT/UPDATE/etc., enforced via `sqlite-reader.ts:208-211`) still
-  reject mutating statements before wrapping.
+  INSERT/UPDATE/etc.) still reject mutating statements before wrapping.
 - Caller's SQL with a trailing `;` or multi-statement input is
   rejected by `better-sqlite3.prepare()` as it is today — no change.
+- Execution runs in a worker with a wall-clock timeout
+  (`SCHIST_QUERY_GRAPH_TIMEOUT_MS`, default 5000 ms). If the worker does
+  not finish in time, the parent terminates it and returns `QUERY_TIMEOUT`.
+- Result assembly enforces a JSON byte budget
+  (`SCHIST_QUERY_GRAPH_BYTE_BUDGET`, default 10 MiB). If the page would
+  exceed the budget, the tool returns `QUERY_RESPONSE_TOO_LARGE` instead
+  of serializing an oversized response.
+- Trust model: `query_graph` is SELECT-only, but it is not a SQL sandbox.
+  Trusted callers can read any table in the vault SQLite database; access
+  control belongs at the MCP process boundary, not inside caller SQL.
+  Do not expose the MCP server to a network without an auth proxy.
 
 This approach removes the spec's prior "detect caller LIMIT and cap"
 requirement entirely. The subquery wrap is a single deterministic

--- a/mcp-server/src/sqlite-reader.ts
+++ b/mcp-server/src/sqlite-reader.ts
@@ -2,7 +2,8 @@ import Database from "better-sqlite3";
 import * as path from "path";
 import * as os from "os";
 import * as fs from "fs";
-import { spawnSync } from "child_process";
+import { spawn, spawnSync } from "child_process";
+import { createRequire } from "module";
 import { load as yamlLoad } from "js-yaml";
 import type { SearchResult, Note, Concept, Connection, MemoryEntry, AgentStateEntry, ConceptAlias } from "./types.js";
 import { CONNECTION_RE, parseConnections as parseConnectionsSync } from "./markdown-parser.js";
@@ -82,6 +83,18 @@ const REQUIRED_DOCS_COLUMNS: ReadonlySet<string> = new Set([
 const REQUIRED_TABLES: ReadonlySet<string> = new Set(["paper_metadata"]);
 
 const verifiedVaults = new Set<string>();
+const requireForWorker = createRequire(import.meta.url);
+const betterSqlite3Path = requireForWorker.resolve("better-sqlite3");
+
+const QUERY_GRAPH_DEFAULT_TIMEOUT_MS = 5_000;
+const QUERY_GRAPH_DEFAULT_BYTE_BUDGET = 10 * 1024 * 1024;
+
+function positiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 /** Test-only — clears the per-process verified-vaults cache so drift detection re-fires. */
 export function resetSchemaCacheForTesting(): void {
@@ -358,12 +371,145 @@ export function listConcepts(
   }
 }
 
-export function queryGraph(
+type QueryGraphResult = { columns: string[]; rows: unknown[][]; rowCount: number };
+
+function runQueryGraphChild(
+  dbPath: string,
+  sql: string,
+  params: unknown[],
+  opts: { timeoutMs: number; byteBudget: number }
+): Promise<QueryGraphResult> {
+  const childSource = `
+    const Database = require(${JSON.stringify(betterSqlite3Path)});
+
+    function jsonBytes(value) {
+      return Buffer.byteLength(JSON.stringify(value), "utf8");
+    }
+
+    function respond(payload) {
+      process.stdout.write(JSON.stringify(payload));
+    }
+
+    let input = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => { input += chunk; });
+    process.stdin.on("end", () => {
+      try {
+        const request = JSON.parse(input);
+        const db = new Database(request.dbPath, { readonly: true });
+        try {
+          const stmt = db.prepare(request.sql);
+          const columns = stmt.columns().map((c) => c.name);
+          const rows = [];
+          let totalBytes = jsonBytes({ columns, rows: [], rowCount: 0 });
+
+          for (const row of stmt.iterate(...request.params)) {
+            const rowValues = columns.map((c) => row[c]);
+            totalBytes += jsonBytes(rowValues) + 1;
+            if (totalBytes > request.byteBudget) {
+              const err = new Error(
+                "query_graph response exceeds byte budget (" +
+                totalBytes + " > " + request.byteBudget + " bytes)"
+              );
+              err.error = "QUERY_RESPONSE_TOO_LARGE";
+              throw err;
+            }
+            rows.push(rowValues);
+          }
+
+          respond({
+            ok: true,
+            result: { columns, rows, rowCount: rows.length },
+          });
+        } finally {
+          db.close();
+        }
+      } catch (e) {
+        respond({
+          ok: false,
+          error: {
+            error: e && (e.error || e.code) || "INVALID_SQL",
+            message: e && e.message || String(e),
+            stack: e && e.stack,
+          },
+        });
+      }
+    });
+  `;
+
+  return new Promise<QueryGraphResult>((resolve, reject) => {
+    const child = spawn(process.execPath, ["-e", childSource], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let settled = false;
+    let stdout = "";
+    let stderr = "";
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn();
+    };
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 500).unref?.();
+      finish(() => {
+        reject(Object.assign(
+          new Error(`query_graph exceeded timeout (${opts.timeoutMs}ms)`),
+          { error: "QUERY_TIMEOUT" },
+        ));
+      });
+    }, opts.timeoutMs);
+    timer.unref?.();
+
+    child.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf8"); });
+    child.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString("utf8"); });
+    child.on("error", (err) => finish(() => reject(err)));
+    child.on("close", (code, signal) => {
+      finish(() => {
+        if (code !== 0) {
+          reject(Object.assign(
+            new Error(`query_graph child exited with code ${code ?? "null"}${signal ? ` signal ${signal}` : ""}: ${stderr.trim()}`),
+            { error: "QUERY_GRAPH_EXECUTOR_ERROR" },
+          ));
+          return;
+        }
+        let message: {
+          ok: boolean;
+          result?: QueryGraphResult;
+          error?: { error?: string; message?: string; stack?: string };
+        };
+        try {
+          message = JSON.parse(stdout);
+        } catch {
+          reject(Object.assign(
+            new Error(`query_graph child returned invalid JSON: ${stdout.slice(0, 200)}`),
+            { error: "QUERY_GRAPH_EXECUTOR_ERROR" },
+          ));
+          return;
+        }
+        if (message.ok && message.result) {
+          resolve(message.result);
+          return;
+        }
+        const err = Object.assign(
+          new Error(message.error?.message ?? "query_graph failed"),
+          { error: message.error?.error ?? "INVALID_SQL" },
+        );
+        if (message.error?.stack) err.stack = message.error.stack;
+        reject(err);
+      });
+    });
+    child.stdin.end(JSON.stringify({ dbPath, sql, params, byteBudget: opts.byteBudget }));
+  });
+}
+
+export async function queryGraph(
   vaultRoot: string,
   sql: string,
   params?: unknown[],
   opts?: { limit?: number; offset?: number }
-): { columns: string[]; rows: unknown[][]; rowCount: number } {
+): Promise<QueryGraphResult> {
   // Strip trailing semicolon(s) + whitespace before either guard or wrap.
   // The subquery wrap below produces invalid SQL if the caller_sql ends in a
   // semicolon (`SELECT * FROM (SELECT 1;) ...`); accept the trailing `;` as a
@@ -405,24 +551,12 @@ export function queryGraph(
   const offset = opts?.offset ?? 0;
   const wrappedSql = `SELECT * FROM (${trimmed}) AS user_query LIMIT ? OFFSET ?`;
   const allParams = [...(params ?? []), limit, offset];
+  const timeoutMs = positiveIntEnv("SCHIST_QUERY_GRAPH_TIMEOUT_MS", QUERY_GRAPH_DEFAULT_TIMEOUT_MS);
+  const byteBudget = positiveIntEnv("SCHIST_QUERY_GRAPH_BYTE_BUDGET", QUERY_GRAPH_DEFAULT_BYTE_BUDGET);
 
-  const db = openDb(vaultRoot);
-  try {
-    const stmt = db.prepare(wrappedSql);
-    const rows = stmt.all(...allParams) as Record<string, unknown>[];
-    if (rows.length === 0) {
-      const columns = stmt.columns().map((c) => c.name);
-      return { columns, rows: [], rowCount: 0 };
-    }
-    const columns = Object.keys(rows[0]);
-    return {
-      columns,
-      rows: rows.map((r) => columns.map((c) => r[c])),
-      rowCount: rows.length,
-    };
-  } finally {
-    db.close();
-  }
+  ensureSchemaCurrent(vaultRoot);
+  const dbPath = path.join(vaultRoot, ".schist", "schist.db");
+  return runQueryGraphChild(dbPath, wrappedSql, allParams, { timeoutMs, byteBudget });
 }
 
 export function getContext(

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -1358,7 +1358,7 @@ export async function query_graph(
 
   let result: { columns: string[]; rows: unknown[][]; rowCount: number };
   try {
-    result = sqliteReader.queryGraph(vaultRoot, args.sql, args.params, {
+    result = await sqliteReader.queryGraph(vaultRoot, args.sql, args.params, {
       limit: effectiveLimit + 1,
       offset,
     });

--- a/mcp-server/tests/file-ref-field.test.ts
+++ b/mcp-server/tests/file-ref-field.test.ts
@@ -190,7 +190,7 @@ describe("schema-drift auto-rebuild for file_ref", () => {
     preDb.close();
     expect(preCols).not.toContain("file_ref");
 
-    const result = sqliteReader.queryGraph(vault, "SELECT id, file_ref FROM docs WHERE id LIKE 'notes/%'");
+    const result = await sqliteReader.queryGraph(vault, "SELECT id, file_ref FROM docs WHERE id LIKE 'notes/%'");
     expect(result.columns).toEqual(["id", "file_ref"]);
     expect(result.rows).toContainEqual(["notes/2026-06-08-file-ref.md", "/mnt/data/drift.pdf"]);
 

--- a/mcp-server/tests/query-graph-tool.test.ts
+++ b/mcp-server/tests/query-graph-tool.test.ts
@@ -41,7 +41,11 @@ async function makeVault(n: number = 0): Promise<string> {
 
 let vaultRoot: string;
 const envSnapshot: Record<string, string | undefined> = {};
-const envKeys = ["SCHIST_AGENT_ID"] as const;
+const envKeys = [
+  "SCHIST_AGENT_ID",
+  "SCHIST_QUERY_GRAPH_BYTE_BUDGET",
+  "SCHIST_QUERY_GRAPH_TIMEOUT_MS",
+] as const;
 
 beforeEach(async () => {
   for (const k of envKeys) {
@@ -355,4 +359,43 @@ describe("query_graph tool — caller params bound under the wrap", () => {
     expect(r.rows[0][0]).toBe("notes/0002.md");
     expect(r.rows[0][1]).toBe("Note 0002");
   });
+});
+
+// ── resource hardening ─────────────────────────────────────────────────────
+
+describe("query_graph tool — resource hardening", () => {
+  it("rejects responses that exceed the configured byte budget", async () => {
+    vaultRoot = await makeVault(1);
+    process.env.SCHIST_QUERY_GRAPH_BYTE_BUDGET = "1024";
+
+    const r = await query_graph(vaultRoot, {
+      sql: "SELECT randomblob(2048) AS payload FROM docs LIMIT 1",
+    });
+
+    expect(r).toMatchObject({
+      error: "QUERY_RESPONSE_TOO_LARGE",
+      message: expect.stringContaining("byte budget"),
+    });
+  });
+
+  it("interrupts CPU-heavy queries at the configured timeout", async () => {
+    vaultRoot = await makeVault(1);
+    process.env.SCHIST_QUERY_GRAPH_TIMEOUT_MS = "200";
+
+    const r = await query_graph(vaultRoot, {
+      sql: `
+        WITH RECURSIVE n(x) AS (
+          SELECT 1
+          UNION ALL
+          SELECT x + 1 FROM n
+        )
+        SELECT x FROM n LIMIT 1 OFFSET 100000000
+      `,
+    });
+
+    expect(r).toMatchObject({
+      error: "QUERY_TIMEOUT",
+      message: expect.stringContaining("timeout"),
+    });
+  }, 10_000);
 });

--- a/mcp-server/tests/sqlite-reader.test.ts
+++ b/mcp-server/tests/sqlite-reader.test.ts
@@ -59,21 +59,21 @@ describe("sqlite-reader", () => {
 
   test("queryGraph: DROP TABLE is rejected with INVALID_SQL", async () => {
     const vaultRoot = await makeTempDb();
-    expect(() => queryGraph(vaultRoot, "DROP TABLE docs")).toThrow(
+    await expect(queryGraph(vaultRoot, "DROP TABLE docs")).rejects.toMatchObject(
       expect.objectContaining({ error: "INVALID_SQL" })
     );
   });
 
   test("queryGraph: CTE with DELETE is rejected with INVALID_SQL", async () => {
     const vaultRoot = await makeTempDb();
-    expect(() =>
+    await expect(
       queryGraph(vaultRoot, "WITH x AS (DELETE FROM docs RETURNING *) SELECT * FROM x")
-    ).toThrow(expect.objectContaining({ error: "INVALID_SQL" }));
+    ).rejects.toMatchObject(expect.objectContaining({ error: "INVALID_SQL" }));
   });
 
   test("queryGraph: valid SELECT returns results", async () => {
     const vaultRoot = await makeTempDb();
-    const result = queryGraph(vaultRoot, "SELECT id, title FROM docs LIMIT 10");
+    const result = await queryGraph(vaultRoot, "SELECT id, title FROM docs LIMIT 10");
     expect(result.columns).toEqual(["id", "title"]);
     expect(result.rows.length).toBeGreaterThan(0);
     expect(result.rows[0][1]).toBe("Test Note");


### PR DESCRIPTION
## Summary
- run query_graph SQL execution in a worker so CPU-heavy SELECTs can be terminated by wall-clock timeout
- enforce a configurable JSON byte budget while assembling query_graph responses
- document the query_graph trust model plus SCHIST_QUERY_GRAPH_TIMEOUT_MS and SCHIST_QUERY_GRAPH_BYTE_BUDGET

Fixes #101.

## Tests
- cd mcp-server && npm test -- --runTestsByPath tests/query-graph-tool.test.ts
- cd mcp-server && npm test -- --runTestsByPath tests/sqlite-reader.test.ts tests/query-graph-tool.test.ts --detectOpenHandles
- cd mcp-server && npm run build
- cd mcp-server && npm test
- cd mcp-server && npm test -- --detectOpenHandles