### PR TITLE
[codex] Enforce concept alias foreign keys

### DIFF
--- a/mcp-server/src/sqlite-reader.ts
+++ b/mcp-server/src/sqlite-reader.ts
@@ -194,7 +194,12 @@ function runIngestSync(vaultRoot: string): void {
 function openDb(vaultRoot: string, opts?: { readonly?: boolean }): Database.Database {
   ensureSchemaCurrent(vaultRoot);
   const dbPath = path.join(vaultRoot, ".schist", "schist.db");
-  return new Database(dbPath, { readonly: opts?.readonly ?? true });
+  const readonly = opts?.readonly ?? true;
+  const db = new Database(dbPath, { readonly });
+  if (!readonly) {
+    db.pragma("foreign_keys = ON");
+  }
+  return db;
 }
 
 export function searchNotes(

--- a/mcp-server/tests/memory.test.ts
+++ b/mcp-server/tests/memory.test.ts
@@ -370,12 +370,21 @@ describe("addConceptAlias", () => {
     vaultDir = await fs.mkdtemp(path.join(os.tmpdir(), "schist-alias-test-"));
     const schistDir = path.join(vaultDir, ".schist");
     await fs.mkdir(schistDir, { recursive: true });
-    // Create a minimal schist.db with concept_aliases table
+    // Create a minimal schist.db with concept_aliases table.
     const db = new Database(path.join(schistDir, "schist.db"));
     db.exec(`
+      CREATE TABLE concepts (
+        slug TEXT PRIMARY KEY,
+        name TEXT NOT NULL
+      );
+
+      INSERT INTO concepts (slug, name) VALUES
+        ('ml', 'ML'),
+        ('machine-learning', 'Machine Learning');
+
       CREATE TABLE IF NOT EXISTS concept_aliases (
-        duplicate_slug  TEXT NOT NULL,
-        canonical_slug  TEXT NOT NULL,
+        duplicate_slug  TEXT NOT NULL REFERENCES concepts(slug),
+        canonical_slug  TEXT NOT NULL REFERENCES concepts(slug),
         reason          TEXT,
         created_by      TEXT NOT NULL,
         created_at      TEXT NOT NULL DEFAULT (datetime('now')),
@@ -411,5 +420,15 @@ describe("addConceptAlias", () => {
     expect(() =>
       addConceptAlias(vaultDir, "ml", "machine-learning", "test", "sansan")
     ).toThrow();
+  });
+
+  it("throws when either concept slug does not exist", () => {
+    process.env.SCHIST_AGENT_ID = "sansan";
+    expect(() =>
+      addConceptAlias(vaultDir, "dl", "machine-learning", "test", "sansan")
+    ).toThrow(/FOREIGN KEY constraint failed/);
+    expect(() =>
+      addConceptAlias(vaultDir, "ml", "deep-learning", "test", "sansan")
+    ).toThrow(/FOREIGN KEY constraint failed/);
   });
 });


### PR DESCRIPTION
## Summary
- enable SQLite foreign-key enforcement for writable vault DB connections
- make the concept alias test fixture use FK-backed concept slugs
- add regression coverage for nonexistent duplicate and canonical slugs

## Root cause
SQLite does not enforce foreign-key constraints unless each writing connection enables `PRAGMA foreign_keys = ON`. `addConceptAlias` opened a writable `schist.db` connection without that pragma, so orphaned `concept_aliases` rows could be inserted silently.

## Validation
- `npm test -- --testPathPatterns=memory.test.ts`
- `npm test`

Closes #196