### PR TITLE
[codex] Handle spaces in pre-commit secret scan

### DIFF
--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -46,7 +46,7 @@ sys.exit(main())
 
 POST_COMMIT_HOOK = r"""#!/bin/sh
 # schist post-commit hook — re-ingest vault into SQLite after every commit
-# schist-hook-version: 2
+# schist-hook-version: 3
 
 VAULT_ROOT=$(git rev-parse --show-toplevel)
 DB_PATH="$VAULT_ROOT/.schist/schist.db"
@@ -74,11 +74,11 @@ python3 "$INGEST" --vault "$VAULT_ROOT" --db "$DB_PATH"
 # `# schist-hook-version: N` line lives inside each hook script body. A user
 # who has intentionally customized their hook can replace the version line
 # with `# schist-hook-version: pinned` to silence the staleness warning.
-HOOK_VERSION = 2
+HOOK_VERSION = 3
 
 PRE_COMMIT_HOOK = r"""#!/bin/sh
 # schist pre-commit hook — reject staged files containing secrets
-# schist-hook-version: 2
+# schist-hook-version: 3
 
 # Patterns intentionally require a left boundary on token prefixes so substrings
 # like "task-..." inside a filename don't trigger on "sk-...", and require a
@@ -86,12 +86,15 @@ PRE_COMMIT_HOOK = r"""#!/bin/sh
 # doesn't trip the guard. See issue #103 for the false-positive cases.
 PATTERNS="(^|[^A-Za-z0-9])sk-[A-Za-z0-9_-]{20,}|(^|[^A-Za-z0-9])ghp_[A-Za-z0-9]{20,}|(^|[^A-Za-z0-9])ghs_[A-Za-z0-9]{20,}|(^|[^A-Za-z0-9])AKIA[A-Z0-9]{16}|-----BEGIN [A-Z ]+PRIVATE KEY-----|password\s*=\s*[\"'][^\"' ]+[\"']|api_key\s*=\s*[\"'][^\"' ]+[\"']"
 
-STAGED_FILES=$(git diff --cached --name-only)
-if [ -z "$STAGED_FILES" ]; then
+STAGED_FILES=$(mktemp "${TMPDIR:-/tmp}/schist-pre-commit.XXXXXX") || exit 1
+trap 'rm -f "$STAGED_FILES"' EXIT HUP INT TERM
+
+git diff --cached --name-only -z > "$STAGED_FILES"
+if [ ! -s "$STAGED_FILES" ]; then
     exit 0
 fi
 
-MATCH=$(echo "$STAGED_FILES" | xargs grep -lE "$PATTERNS" 2>/dev/null)
+MATCH=$(xargs -0 grep -lE "$PATTERNS" < "$STAGED_FILES" 2>/dev/null)
 if [ -n "$MATCH" ]; then
     echo "ERROR: Potential secret detected in staged files:"
     echo "$MATCH" | sed 's/^/  /'

--- a/cli/tests/test_pre_commit_hook.py
+++ b/cli/tests/test_pre_commit_hook.py
@@ -87,6 +87,21 @@ def test_real_secrets_blocked(vault: Path, content: str) -> None:
     assert "Potential secret detected" in result.stdout + result.stderr
 
 
+def test_secret_in_filename_with_spaces_is_blocked(vault: Path) -> None:
+    """Whitespace in staged paths must not let files bypass secret scanning."""
+    result = _try_commit(
+        vault,
+        "research note with spaces.md",
+        "api_key = 'sk-redacted-but-quoted-value-here'\n",
+    )
+    assert result.returncode != 0, (
+        "Hook silently accepted a secret in a staged filename containing spaces"
+    )
+    output = result.stdout + result.stderr
+    assert "Potential secret detected" in output
+    assert "research note with spaces.md" in output
+
+
 def test_pre_commit_hook_carries_version_marker() -> None:
     """Doctor's freshness check parses this marker — it must be present."""
     assert f"# schist-hook-version: {HOOK_VERSION}" in PRE_COMMIT_HOOK
@@ -104,7 +119,7 @@ def test_hook_version_is_an_int() -> None:
     """`schist doctor` compares HOOK_VERSION as a token string but the constant
     should be an int so bumps are unambiguous."""
     assert isinstance(HOOK_VERSION, int)
-    assert HOOK_VERSION >= 2  # was 1 (unversioned) before issue #103
+    assert HOOK_VERSION >= 3  # was 2 before issue #202 fixed path splitting
 
 
 class TestHooksReinstall:

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 # schist post-commit hook — re-ingest vault into SQLite after every commit
-# schist-hook-version: 2
+# schist-hook-version: 3
 
 VAULT_ROOT=$(git rev-parse --show-toplevel)
 DB_PATH="$VAULT_ROOT/.schist/schist.db"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 # schist pre-commit hook — reject staged files containing secrets
-# schist-hook-version: 2
+# schist-hook-version: 3
 
 # Patterns intentionally require a left boundary on token prefixes so substrings
 # like "task-..." inside a filename don't trigger on "sk-...", and require a
@@ -8,12 +8,15 @@
 # doesn't trip the guard. See issue #103 for the false-positive cases.
 PATTERNS="(^|[^A-Za-z0-9])sk-[A-Za-z0-9_-]{20,}|(^|[^A-Za-z0-9])ghp_[A-Za-z0-9]{20,}|(^|[^A-Za-z0-9])ghs_[A-Za-z0-9]{20,}|(^|[^A-Za-z0-9])AKIA[A-Z0-9]{16}|-----BEGIN [A-Z ]+PRIVATE KEY-----|password\s*=\s*[\"'][^\"' ]+[\"']|api_key\s*=\s*[\"'][^\"' ]+[\"']"
 
-STAGED_FILES=$(git diff --cached --name-only)
-if [ -z "$STAGED_FILES" ]; then
+STAGED_FILES=$(mktemp "${TMPDIR:-/tmp}/schist-pre-commit.XXXXXX") || exit 1
+trap 'rm -f "$STAGED_FILES"' EXIT HUP INT TERM
+
+git diff --cached --name-only -z > "$STAGED_FILES"
+if [ ! -s "$STAGED_FILES" ]; then
     exit 0
 fi
 
-MATCH=$(echo "$STAGED_FILES" | xargs grep -lE "$PATTERNS" 2>/dev/null)
+MATCH=$(xargs -0 grep -lE "$PATTERNS" < "$STAGED_FILES" 2>/dev/null)
 if [ -n "$MATCH" ]; then
     echo "ERROR: Potential secret detected in staged files:"
     echo "$MATCH" | sed 's/^/  /'


### PR DESCRIPTION
## Summary
- scan staged filenames with NUL-delimited git output and xargs -0
- keep canonical hook templates in hooks/ and cli/schist/sync.py in sync
- bump hook template version to v3 so doctor can flag stale installed hooks
- add regression coverage for a staged secret in a filename containing spaces

## Root cause
The pre-commit hook piped newline-delimited staged paths through xargs without -0. xargs split filenames on whitespace, grep skipped the resulting nonexistent path fragments with stderr suppressed, and staged files with spaces could bypass secret scanning silently.

## Validation
- cd cli && uv run --with pytest --with . python -m pytest tests/test_pre_commit_hook.py
- cd cli && uv run --with pytest --with . python -m pytest tests/

Closes #202