### PR TITLE
[codex] Allow CLI queries of concept aliases

### DIFF
--- a/cli/schist/sqlite_query.py
+++ b/cli/schist/sqlite_query.py
@@ -6,7 +6,8 @@ import sqlite3
 import sys
 
 
-ALLOWED_TABLES = {'docs', 'concepts', 'edges', 'docs_fts', 'paper_metadata'}
+# Keep in sync with the read/queryable tables defined in schema.sql.
+ALLOWED_TABLES = {'docs', 'concepts', 'edges', 'docs_fts', 'paper_metadata', 'concept_aliases'}
 # Keep in sync with mcp-server/src/sqlite-reader.ts REQUIRED_TABLES.
 REQUIRED_TABLES = {'docs', 'paper_metadata'}
 

--- a/cli/tests/test_sqlite_query.py
+++ b/cli/tests/test_sqlite_query.py
@@ -86,6 +86,35 @@ def test_validate_sql_still_rejects_stacked_write_statements(capsys) -> None:
     assert "DELETE statements are not allowed" in capsys.readouterr().err
 
 
+def test_raw_query_allows_concept_aliases_table() -> None:
+    conn = _connect()
+    conn.execute("""
+        CREATE TABLE concept_aliases (
+            duplicate_slug TEXT NOT NULL,
+            canonical_slug TEXT NOT NULL,
+            reason TEXT,
+            created_by TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (duplicate_slug, canonical_slug)
+        )
+    """)
+    conn.execute(
+        "INSERT INTO concept_aliases "
+        "(duplicate_slug, canonical_slug, reason, created_by) "
+        "VALUES ('ml', 'machine-learning', 'abbreviation', 'agent-a')"
+    )
+
+    result = raw_query(
+        conn,
+        "SELECT duplicate_slug, canonical_slug FROM concept_aliases",
+    )
+
+    assert result == {
+        "columns": ["duplicate_slug", "canonical_slug"],
+        "rows": [["ml", "machine-learning"]],
+    }
+
+
 def test_fts_search_sanitizes_special_syntax_without_traceback() -> None:
     conn = _connect()
     conn.execute("""


### PR DESCRIPTION
## Summary
- add concept_aliases to the CLI raw-query table allowlist
- document that the allowlist should stay aligned with schema.sql queryable tables
- add a regression test that selects alias rows through raw_query

## Root cause
The MCP layer can write concept_aliases, but the CLI raw query validator only allowed docs, concepts, edges, docs_fts, and paper_metadata. Legitimate diagnostic queries against concept_aliases were rejected before reaching SQLite.

## Validation
- cd cli && uv run --with pytest --with . python -m pytest tests/test_sqlite_query.py
- cd cli && uv run --with pytest --with . python -m pytest tests/

Closes #201