### PR TITLE
[codex] Mask SQL literals in query_graph guard

### DIFF
--- a/mcp-server/src/sqlite-reader.ts
+++ b/mcp-server/src/sqlite-reader.ts
@@ -96,6 +96,74 @@ function positiveIntEnv(name: string, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function maskSqlLiteralsAndComments(sql: string): string {
+  const chars = [...sql];
+  let i = 0;
+  let state: "normal" | "single" | "double" | "line_comment" | "block_comment" = "normal";
+
+  while (i < chars.length) {
+    const ch = chars[i];
+    const next = chars[i + 1] ?? "";
+
+    if (state === "normal") {
+      if (ch === "'") {
+        state = "single";
+      } else if (ch === "\"") {
+        state = "double";
+      } else if (ch === "-" && next === "-") {
+        chars[i] = " ";
+        chars[i + 1] = " ";
+        i += 1;
+        state = "line_comment";
+      } else if (ch === "/" && next === "*") {
+        chars[i] = " ";
+        chars[i + 1] = " ";
+        i += 1;
+        state = "block_comment";
+      }
+    } else if (state === "single") {
+      if (ch === "'" && next === "'") {
+        chars[i] = " ";
+        chars[i + 1] = " ";
+        i += 1;
+      } else if (ch === "'") {
+        state = "normal";
+      } else {
+        chars[i] = " ";
+      }
+    } else if (state === "double") {
+      if (ch === "\"" && next === "\"") {
+        chars[i] = " ";
+        chars[i + 1] = " ";
+        i += 1;
+      } else if (ch === "\"") {
+        state = "normal";
+      } else {
+        chars[i] = " ";
+      }
+    } else if (state === "line_comment") {
+      if (ch === "\n") {
+        state = "normal";
+      } else {
+        chars[i] = " ";
+      }
+    } else if (state === "block_comment") {
+      if (ch === "*" && next === "/") {
+        chars[i] = " ";
+        chars[i + 1] = " ";
+        i += 1;
+        state = "normal";
+      } else {
+        chars[i] = " ";
+      }
+    }
+
+    i += 1;
+  }
+
+  return chars.join("");
+}
+
 /** Test-only — clears the per-process verified-vaults cache so drift detection re-fires. */
 export function resetSchemaCacheForTesting(): void {
   verifiedVaults.clear();
@@ -516,9 +584,10 @@ export async function queryGraph(
   // common ergonomic affordance and remove it. Multi-statement input is still
   // rejected by `better-sqlite3.prepare()`.
   const trimmed = sql.trim().replace(/;+\s*$/, "");
+  const guardSql = maskSqlLiteralsAndComments(trimmed);
   if (
-    !trimmed.match(/^(SELECT|WITH)\b/i) ||
-    trimmed.match(/\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|REPLACE)\b/i)
+    !guardSql.match(/^(SELECT|WITH)\b/i) ||
+    guardSql.match(/\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE)\b/i)
   ) {
     // Return a ToolError result rather than throwing a plain object.
     // Throwing non-Error objects loses stack traces and breaks instanceof checks

--- a/mcp-server/tests/query-graph-tool.test.ts
+++ b/mcp-server/tests/query-graph-tool.test.ts
@@ -100,6 +100,34 @@ describe("query_graph tool — SQL guards still in force", () => {
     expect(r).toMatchObject({ error: expect.any(String) });
     expect("error" in r ? r.error : "").not.toBe("");
   });
+
+  it("allows SQLite REPLACE() string function in SELECT queries", async () => {
+    vaultRoot = await makeVault(1);
+    const r = await query_graph(vaultRoot, {
+      sql: "SELECT REPLACE(title, 'Note', 'Doc') AS renamed FROM docs",
+    });
+    if (!("rows" in r)) throw new Error(`expected rows: ${JSON.stringify(r)}`);
+    expect(r.columns).toEqual(["renamed"]);
+    expect(r.rows[0][0]).toBe("Doc 0000");
+  });
+
+  it("allows blocked keywords inside string literals", async () => {
+    vaultRoot = await makeVault(1);
+    const r = await query_graph(vaultRoot, {
+      sql: "SELECT id FROM docs WHERE title <> 'DROP TABLE test' AND 'CREATE' = 'CREATE'",
+    });
+    if (!("rows" in r)) throw new Error(`expected rows: ${JSON.stringify(r)}`);
+    expect(r.rows.length).toBe(1);
+  });
+
+  it("allows blocked keywords inside SQL comments", async () => {
+    vaultRoot = await makeVault(1);
+    const r = await query_graph(vaultRoot, {
+      sql: "SELECT id FROM docs /* DROP */ WHERE title <> 'missing' -- CREATE\nORDER BY id",
+    });
+    if (!("rows" in r)) throw new Error(`expected rows: ${JSON.stringify(r)}`);
+    expect(r.rows.length).toBe(1);
+  });
 });
 
 // ── cursor decoding ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- port SQL literal/comment masking to the TypeScript query_graph guard
- allow valid SELECT usage of SQLite REPLACE()
- keep write-keyword rejection for executable SQL text outside literals/comments
- add regression coverage for REPLACE(), string literals, and comments

## Root cause
queryGraph scanned the raw SQL text for write keywords before execution. That rejected safe SELECT queries when a blocked word appeared as a SQLite function name, in a string literal, or in a comment. The Python CLI already masks literals/comments before keyword checks; the MCP path did not.

## Validation
- npm test -- --testPathPatterns=query-graph-tool.test.ts
- npm test

Closes #200