### PR TITLE
[codex] Clean staging on init install race

### DIFF
--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -132,6 +132,26 @@ def _install_local_hooks(vault_path) -> None:
     _atomic_write_hook(hooks_dir / "pre-commit", PRE_COMMIT_HOOK)
 
 
+def _install_staging_tree(staging: Path, target: Path, display_path: str) -> None:
+    """Atomically install a completed staging tree, cleaning staging on failure."""
+    try:
+        if target.exists():
+            target.rmdir()
+        os.rename(staging, target)
+    except OSError as e:
+        print(f"Error: failed to install vault at '{display_path}': {e}", file=sys.stderr)
+        try:
+            if staging.exists():
+                shutil.rmtree(staging)
+        except OSError as cleanup_err:
+            print(
+                f"Warning: could not clean up staging dir {staging}: {cleanup_err}\n"
+                f"  Manual fix: rm -rf {staging}",
+                file=sys.stderr,
+            )
+        sys.exit(1)
+
+
 _HOOK_VERSION_LINE = re.compile(r"^# schist-hook-version:\s*(\S+)", re.MULTILINE)
 
 
@@ -234,9 +254,7 @@ def init_spoke(args, vault_path: str, db_path: str) -> None:
         sys.exit(1)
 
     # Atomic rename: either target points at a complete spoke, or nothing.
-    if target.exists():
-        target.rmdir()
-    os.rename(staging, target)
+    _install_staging_tree(staging, target, vault_path)
 
     # Rebuild SQLite index against the final path (best-effort post-rename).
     # If this step fails the spoke is still usable; user can re-run rebuild.
@@ -611,11 +629,7 @@ def init_hub(args, hub_path: str) -> None:
 
     # Atomic rename: either hub_path points at a complete bare repo, or it
     # doesn't exist at all. No half-initialized intermediate state.
-    if hub.exists():
-        # The pre-check above guarded against existing non-empty; an empty
-        # dir is OK to remove before rename.
-        hub.rmdir()
-    os.rename(staging, hub)
+    _install_staging_tree(staging, hub, hub_path)
 
     print(f"Hub initialized at {hub_path}")
     print(f"  participants: {', '.join(participants)}")
@@ -811,9 +825,7 @@ def init_standalone(args) -> None:
 
     # Atomic rename: either target points at a complete vault, or it doesn't
     # exist at all.
-    if target.exists():
-        target.rmdir()
-    os.rename(staging, target)
+    _install_staging_tree(staging, target, path_arg)
 
     print(f"Vault initialized at {target}")
     print()

--- a/cli/tests/test_hub.py
+++ b/cli/tests/test_hub.py
@@ -146,6 +146,30 @@ class TestInitHub:
         leftover = list(tmp_path.glob(".hub.git.init-*"))
         assert not leftover, f"staging dir not cleaned up: {leftover}"
 
+    def test_final_install_race_cleans_staging(self, tmp_path, monkeypatch, capsys):
+        """If hub_path becomes non-empty after the pre-check, init_hub should
+        clean staging and report a user-facing install error."""
+        from schist import sync as sync_mod
+
+        hub = tmp_path / "hub.git"
+
+        def fake_build(staging, hub_path, vault_data, participants, name):
+            staging.mkdir(parents=True)
+            (staging / "HEAD").write_text("ref: refs/heads/main\n")
+            hub.mkdir()
+            (hub / "intruder").write_text("raced\n")
+
+        monkeypatch.setattr(sync_mod, "_build_hub_in_staging", fake_build)
+
+        args = SimpleNamespace(name="vault", participant=["alpha"])
+        with pytest.raises(SystemExit):
+            sync_mod.init_hub(args, str(hub))
+
+        err = capsys.readouterr().err
+        assert "failed to install vault" in err
+        assert not list(tmp_path.glob(".hub.git.init-*"))
+        assert (hub / "intruder").read_text() == "raced\n"
+
     def test_hub_push_then_rejects_out_of_scope(self, tmp_path):
         """After init_hub, a spoke push to a dir outside the content-axis write list is rejected.
 

--- a/cli/tests/test_init_standalone.py
+++ b/cli/tests/test_init_standalone.py
@@ -310,6 +310,29 @@ class TestInitStandalone:
         init_standalone(_args(path=str(target)))
         assert (target / "vault.yaml").is_file()
 
+    def test_final_install_race_cleans_staging(self, tmp_path, monkeypatch, capsys):
+        """If target becomes non-empty after the pre-check, report cleanly and
+        remove the completed staging tree instead of leaving retry debris."""
+        from schist import sync as sync_mod
+
+        target = tmp_path / "v"
+
+        def fake_build(staging, vault_data, name):
+            staging.mkdir(parents=True)
+            (staging / "vault.yaml").write_text("name: staged\n")
+            target.mkdir()
+            (target / "intruder").write_text("raced\n")
+
+        monkeypatch.setattr(sync_mod, "_build_standalone_in_staging", fake_build)
+
+        with pytest.raises(SystemExit):
+            sync_mod.init_standalone(_args(path=str(target)))
+
+        err = capsys.readouterr().err
+        assert "failed to install vault" in err
+        assert not list(tmp_path.glob(".v.init-*"))
+        assert (target / "intruder").read_text() == "raced\n"
+
     def test_post_commit_constant_matches_disk(self):
         """Drift guard — in-memory POST_COMMIT_HOOK must equal the on-disk copy."""
         from schist.sync import POST_COMMIT_HOOK

--- a/cli/tests/test_sync.py
+++ b/cli/tests/test_sync.py
@@ -213,6 +213,30 @@ class TestInitSpoke:
         assert "disk full" in err  # original error preserved
         assert "Manual fix: rm -rf" in err  # cleanup-failure hint
 
+    def test_final_install_race_cleans_staging(self, tmp_path, monkeypatch, capsys):
+        """If the target becomes non-empty after the pre-check, init_spoke
+        should clean staging and report a user-facing install error."""
+        from schist import sync as sync_mod
+
+        dest = tmp_path / "spoke"
+
+        def fake_build(staging, hub, scope, identity):
+            staging.mkdir(parents=True)
+            (staging / ".git" / "info").mkdir(parents=True)
+            dest.mkdir()
+            (dest / "intruder").write_text("raced\n")
+
+        monkeypatch.setattr(sync_mod, "_build_spoke_in_staging", fake_build)
+
+        args = MagicMock(hub="git@pi:vault.git", scope="research/x", identity="cluster")
+        with pytest.raises(SystemExit):
+            sync_mod.init_spoke(args, str(dest), str(tmp_path / "db.sqlite"))
+
+        err = capsys.readouterr().err
+        assert "failed to install vault" in err
+        assert not list(tmp_path.glob(".spoke.init-*"))
+        assert (dest / "intruder").read_text() == "raced\n"
+
     @patch("schist.sync.git_ops.clone_shallow", return_value=(True, ""))
     @patch("schist.sync.git_ops.setup_sparse_checkout", return_value=(True, ""))
     @patch("schist.sync._rebuild_index")


### PR DESCRIPTION
## Summary
- add a shared final install helper for completed init staging trees
- clean up staging if the final target rmdir/rename fails
- apply the helper to standalone, spoke, and hub init flows
- add regression coverage for target-populated-after-precheck races in all three flows

## Root cause
The init flows cleaned staging during build failures, but the final rmdir/rename install step was outside that error handling. If the target became non-empty after the early empty-directory guard, target.rmdir() raised and left the completed staging directory behind.

## Validation
- cd cli && uv run --with pytest --with . python -m pytest tests/test_init_standalone.py tests/test_sync.py tests/test_hub.py
- cd cli && uv run --with pytest --with . python -m pytest tests/

Closes #52