### PR TITLE
fix: scan staged blobs in pre-commit secret guard

### DIFF
--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -46,7 +46,7 @@ sys.exit(main())
 
 POST_COMMIT_HOOK = r"""#!/bin/sh
 # schist post-commit hook — re-ingest vault into SQLite after every commit
-# schist-hook-version: 3
+# schist-hook-version: 4
 
 VAULT_ROOT=$(git rev-parse --show-toplevel)
 DB_PATH="$VAULT_ROOT/.schist/schist.db"
@@ -74,11 +74,11 @@ python3 "$INGEST" --vault "$VAULT_ROOT" --db "$DB_PATH"
 # `# schist-hook-version: N` line lives inside each hook script body. A user
 # who has intentionally customized their hook can replace the version line
 # with `# schist-hook-version: pinned` to silence the staleness warning.
-HOOK_VERSION = 3
+HOOK_VERSION = 4
 
 PRE_COMMIT_HOOK = r"""#!/bin/sh
 # schist pre-commit hook — reject staged files containing secrets
-# schist-hook-version: 3
+# schist-hook-version: 4
 
 # Patterns intentionally require a left boundary on token prefixes so substrings
 # like "task-..." inside a filename don't trigger on "sk-...", and require a
@@ -89,12 +89,12 @@ PATTERNS="(^|[^A-Za-z0-9])sk-[A-Za-z0-9_-]{20,}|(^|[^A-Za-z0-9])ghp_[A-Za-z0-9]{
 STAGED_FILES=$(mktemp "${TMPDIR:-/tmp}/schist-pre-commit.XXXXXX") || exit 1
 trap 'rm -f "$STAGED_FILES"' EXIT HUP INT TERM
 
-git diff --cached --name-only -z > "$STAGED_FILES"
+git diff --cached --name-only -z --diff-filter=ACMR > "$STAGED_FILES"
 if [ ! -s "$STAGED_FILES" ]; then
     exit 0
 fi
 
-MATCH=$(xargs -0 grep -lE "$PATTERNS" < "$STAGED_FILES" 2>/dev/null)
+MATCH=$(xargs -0 -I {} sh -c 'git show ":$1" 2>/dev/null | grep -qE "$2" && printf "%s\n" "$1"' sh {} "$PATTERNS" < "$STAGED_FILES")
 if [ -n "$MATCH" ]; then
     echo "ERROR: Potential secret detected in staged files:"
     echo "$MATCH" | sed 's/^/  /'

--- a/cli/tests/test_pre_commit_hook.py
+++ b/cli/tests/test_pre_commit_hook.py
@@ -102,6 +102,26 @@ def test_secret_in_filename_with_spaces_is_blocked(vault: Path) -> None:
     assert "research note with spaces.md" in output
 
 
+def test_staged_secret_blocked_after_worktree_cleanup(vault: Path) -> None:
+    """The hook must inspect the staged blob, not the working-tree file."""
+    note = vault / "secret.md"
+    note.write_text("api_key = 'sk-redacted-but-quoted-value-here'\n")
+    subprocess.run(["git", "add", "secret.md"], cwd=vault, check=True)
+
+    note.write_text("clean working-tree copy\n")
+    result = subprocess.run(
+        ["git", "commit", "-m", "test"],
+        cwd=vault, capture_output=True, text=True,
+    )
+
+    assert result.returncode != 0, (
+        "Hook silently accepted a secret that remained in the staged blob"
+    )
+    output = result.stdout + result.stderr
+    assert "Potential secret detected" in output
+    assert "secret.md" in output
+
+
 def test_pre_commit_hook_carries_version_marker() -> None:
     """Doctor's freshness check parses this marker — it must be present."""
     assert f"# schist-hook-version: {HOOK_VERSION}" in PRE_COMMIT_HOOK

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 # schist post-commit hook — re-ingest vault into SQLite after every commit
-# schist-hook-version: 3
+# schist-hook-version: 4
 
 VAULT_ROOT=$(git rev-parse --show-toplevel)
 DB_PATH="$VAULT_ROOT/.schist/schist.db"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 # schist pre-commit hook — reject staged files containing secrets
-# schist-hook-version: 3
+# schist-hook-version: 4
 
 # Patterns intentionally require a left boundary on token prefixes so substrings
 # like "task-..." inside a filename don't trigger on "sk-...", and require a
@@ -11,12 +11,12 @@ PATTERNS="(^|[^A-Za-z0-9])sk-[A-Za-z0-9_-]{20,}|(^|[^A-Za-z0-9])ghp_[A-Za-z0-9]{
 STAGED_FILES=$(mktemp "${TMPDIR:-/tmp}/schist-pre-commit.XXXXXX") || exit 1
 trap 'rm -f "$STAGED_FILES"' EXIT HUP INT TERM
 
-git diff --cached --name-only -z > "$STAGED_FILES"
+git diff --cached --name-only -z --diff-filter=ACMR > "$STAGED_FILES"
 if [ ! -s "$STAGED_FILES" ]; then
     exit 0
 fi
 
-MATCH=$(xargs -0 grep -lE "$PATTERNS" < "$STAGED_FILES" 2>/dev/null)
+MATCH=$(xargs -0 -I {} sh -c 'git show ":$1" 2>/dev/null | grep -qE "$2" && printf "%s\n" "$1"' sh {} "$PATTERNS" < "$STAGED_FILES")
 if [ -n "$MATCH" ]; then
     echo "ERROR: Potential secret detected in staged files:"
     echo "$MATCH" | sed 's/^/  /'


### PR DESCRIPTION
## Summary
- scan staged blob content in the pre-commit secret guard instead of working-tree files
- skip deleted paths when scanning staged entries
- bump hook template version to v4 and add a regression for staged/working-tree divergence

Closes #211.

## Tests
- uv run --with pytest --with ./cli python -m pytest cli/tests/test_pre_commit_hook.py -q
- uv run --with pytest --with ./cli python -m pytest cli/tests/test_init_standalone.py::TestInitStandalone::test_pre_commit_constant_matches_disk cli/tests/test_init_standalone.py::TestInitStandalone::test_post_commit_constant_matches_disk cli/tests/test_init_standalone.py::TestInitStandalone::test_pre_commit_blocks_real_looking_keys cli/tests/test_init_standalone.py::TestInitStandalone::test_pre_commit_does_not_match_sk_substrings -q
- uv run --with pytest --with ./cli python -m pytest cli/tests/test_doctor.py::TestCheckHooksFreshness -q
- cd cli && uv run --with pytest --with . python -m pytest tests/