### PR TITLE
fix: make agent state ownership upsert atomic

### DIFF
--- a/mcp-server/src/sqlite-reader.ts
+++ b/mcp-server/src/sqlite-reader.ts
@@ -886,18 +886,21 @@ export function setAgentState(key: string, value: unknown, owner: string, ttl_ho
   assertKeyPrefix(key, owner);
   const db = openMemoryDb();
   try {
-    // H4 fix: prevent silent ownership hijack — check existing key owner before upsert
-    const existing = db.prepare("SELECT owner FROM agent_state WHERE key = ?").get(key) as { owner: string } | undefined;
-    if (existing && existing.owner !== owner) {
-      throw Object.assign(new Error("Cannot overwrite state key owned by another agent"), { error: "OWNERSHIP_ERROR" });
-    }
-    db.prepare(`
+    const row = db.prepare(`
       INSERT INTO agent_state (key, value, owner, ttl_hours)
       VALUES (?, ?, ?, ?)
       ON CONFLICT(key) DO UPDATE SET value=excluded.value,
         ttl_hours=excluded.ttl_hours, updated_at=datetime('now')
-    `).run(key, JSON.stringify(value), owner, ttl_hours ?? null);
-    const row = db.prepare("SELECT updated_at FROM agent_state WHERE key = ?").get(key) as { updated_at: string };
+      WHERE agent_state.owner = excluded.owner
+      RETURNING updated_at
+    `).get(key, JSON.stringify(value), owner, ttl_hours ?? null) as { updated_at: string } | undefined;
+    if (!row) {
+      const existing = db.prepare("SELECT owner FROM agent_state WHERE key = ?").get(key) as { owner: string } | undefined;
+      if (existing && existing.owner !== owner) {
+        throw Object.assign(new Error("Cannot overwrite state key owned by another agent"), { error: "OWNERSHIP_ERROR" });
+      }
+      throw new Error("Failed to set agent state");
+    }
     return { key, updated_at: row.updated_at };
   } finally {
     db.close();

--- a/mcp-server/tests/memory.test.ts
+++ b/mcp-server/tests/memory.test.ts
@@ -325,6 +325,31 @@ describe("setAgentState", () => {
       expect((e as Record<string, unknown>).error).toBe("OWNERSHIP_ERROR");
     }
   });
+
+  it("does not overwrite a row inserted between ownership check and upsert", () => {
+    getAgentState("team.shared"); // initialize schema
+    const db = new Database(process.env.SCHIST_MEMORY_DB!);
+    db.exec(`
+      CREATE TRIGGER simulate_concurrent_owner
+      BEFORE INSERT ON agent_state
+      WHEN NEW.key = 'team.shared' AND NEW.owner = 'orchestrator'
+      BEGIN
+        INSERT INTO agent_state (key, value, owner)
+        VALUES (NEW.key, '"ninjia_data"', 'ninjia');
+      END;
+    `);
+    db.close();
+
+    process.env.SCHIST_TEAM_OWNER = "orchestrator";
+    process.env.SCHIST_AGENT_ID = "orchestrator";
+    expect(() => setAgentState("team.shared", "hijack", "orchestrator"))
+      .toThrow(/owned by another agent/);
+
+    const entry = getAgentState("team.shared");
+    expect(entry).not.toBeNull();
+    expect(entry!.owner).toBe("ninjia");
+    expect(entry!.value).toBe("ninjia_data");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- replace the split owner-check/upsert in setAgentState with one conditional atomic upsert
- preserve OWNERSHIP_ERROR behavior when another owner wins the key
- add a trigger-based regression that simulates an interleaving owner insert

Closes #212.

## Tests
- cd mcp-server && npm test -- --testPathPatterns=memory.test.ts
- cd mcp-server && npm test
- cd mcp-server && npm run build