### PR TITLE
fix: prune stale concept aliases during ingest

### DIFF
--- a/cli/schist/ingest.py
+++ b/cli/schist/ingest.py
@@ -306,6 +306,13 @@ def _ingest_into(conn: sqlite3.Connection, vault: Path, schema_path: Path) -> No
             except sqlite3.IntegrityError:
                 pass
 
+    conn.execute(
+        """
+        DELETE FROM concept_aliases
+        WHERE duplicate_slug NOT IN (SELECT slug FROM concepts)
+           OR canonical_slug NOT IN (SELECT slug FROM concepts)
+        """
+    )
     conn.commit()
     print(f'Ingested: {doc_count} docs, {concept_count} concepts, {edge_count} edges')
 

--- a/cli/schist/sync.py
+++ b/cli/schist/sync.py
@@ -1119,6 +1119,25 @@ def _preserve_side_tables(backup: Path, new_db: Path) -> None:
             except sqlite3.OperationalError as e:
                 if "no such table" not in str(e).lower():
                     raise
+        # Prune aliases whose endpoints no longer exist in the freshly
+        # rebuilt concepts table. The backup may carry dangling rows (e.g.
+        # written before #198 FK enforcement, or orphaned when a concept was
+        # later deleted); copying them forward unchanged would reintroduce the
+        # dangling-FK rows that ingest.py prunes on the in-place commit path.
+        # Mirror that DELETE here so the rebuild / spoke-pull path converges to
+        # the same state and existing corruption is backfilled, not propagated.
+        # See issue #213.
+        try:
+            conn.execute(
+                """
+                DELETE FROM concept_aliases
+                WHERE duplicate_slug NOT IN (SELECT slug FROM concepts)
+                   OR canonical_slug NOT IN (SELECT slug FROM concepts)
+                """
+            )
+        except sqlite3.OperationalError as e:
+            if "no such table" not in str(e).lower():
+                raise
         conn.commit()
     finally:
         conn.close()

--- a/cli/tests/test_ingest.py
+++ b/cli/tests/test_ingest.py
@@ -178,6 +178,58 @@ def test_ingest_preserves_missing_status_as_null(tmp_path: Path) -> None:
     assert row == (None,)
 
 
+def test_ingest_prunes_concept_aliases_for_missing_concepts(tmp_path: Path) -> None:
+    """Aliases survive rebuild only while both referenced concepts still exist."""
+    from schist.ingest import ingest
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    concepts_dir = vault / "concepts"
+    concepts_dir.mkdir()
+    for slug in ("dupe", "stale", "canonical"):
+        (concepts_dir / f"{slug}.md").write_text(
+            f"---\nconcept: {slug}\ntitle: {slug.title()}\n---\n\n{slug}\n",
+            encoding="utf-8",
+        )
+    db = vault / ".schist" / "schist.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+
+    ingest(str(vault), str(db))
+    conn = sqlite3.connect(db)
+    try:
+        conn.executemany(
+            """
+            INSERT INTO concept_aliases
+              (duplicate_slug, canonical_slug, reason, created_by)
+            VALUES (?, ?, ?, ?)
+            """,
+            [
+                ("dupe", "canonical", "valid alias", "tester"),
+                ("stale", "canonical", "will become dangling", "tester"),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    (concepts_dir / "stale.md").unlink()
+    ingest(str(vault), str(db))
+
+    conn = sqlite3.connect(db)
+    try:
+        rows = conn.execute(
+            """
+            SELECT duplicate_slug, canonical_slug, reason
+            FROM concept_aliases
+            ORDER BY duplicate_slug
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert rows == [("dupe", "canonical", "valid alias")]
+
+
 def test_ingest_indexes_paper_metadata(tmp_path: Path) -> None:
     """Citation-grade paper frontmatter populates the paper_metadata side table."""
     from schist.ingest import ingest

--- a/cli/tests/test_sync.py
+++ b/cli/tests/test_sync.py
@@ -799,6 +799,52 @@ class TestRebuildIndexSideTablePreservation:
 
         assert rows == [("backprop", "backpropagation", "short form", "tester")]
 
+    def test_stale_concept_alias_pruned_on_rebuild(self, tmp_path):
+        """A dangling concept_alias (endpoint not in the rebuilt concepts
+        table) must NOT survive a rebuild — the rebuild/spoke-pull path must
+        prune it just like the in-place ingest commit path. Regression for
+        issue #213."""
+        import sqlite3
+        from schist.sync import _rebuild_index
+
+        vault, db_path = _init_vault_with_schema(tmp_path)
+        concepts = Path(vault) / "concepts"
+        concepts.mkdir(exist_ok=True)
+        # Only ONE endpoint exists as a concept; the alias below references a
+        # canonical_slug ("backpropagation") that has no concept file, so it is
+        # a dangling-FK row once the concepts table is rebuilt.
+        (concepts / "backprop.md").write_text(
+            "---\nconcept: backprop\ntitle: Backprop\n---\n\nShort form.\n"
+        )
+        _rebuild_index(vault, db_path)
+
+        # Insert a dangling alias directly (bypasses ingest's prune)
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                "INSERT INTO concept_aliases "
+                "(duplicate_slug, canonical_slug, reason, created_by) "
+                "VALUES (?, ?, ?, ?)",
+                ("backprop", "backpropagation", "dangling", "tester"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Rebuild (simulates spoke pull) — the dangling row must be pruned,
+        # not copied forward.
+        _rebuild_index(vault, db_path)
+
+        conn = sqlite3.connect(db_path)
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM concept_aliases"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+        assert count == 0, "dangling alias survived rebuild — #213 regression"
+
     def test_rebuild_ok_with_no_prior_db(self, tmp_path):
         """First rebuild (no backup) should succeed with no side-table data."""
         import sqlite3

--- a/cli/tests/test_sync.py
+++ b/cli/tests/test_sync.py
@@ -761,6 +761,15 @@ class TestRebuildIndexSideTablePreservation:
         from schist.sync import _rebuild_index
 
         vault, db_path = _init_vault_with_schema(tmp_path)
+        concepts = Path(vault) / "concepts"
+        concepts.mkdir(exist_ok=True)
+        (concepts / "backprop.md").write_text(
+            "---\nconcept: backprop\ntitle: Backprop\n---\n\nShort form.\n"
+        )
+        (concepts / "backpropagation.md").write_text(
+            "---\nconcept: backpropagation\ntitle: Backpropagation\n---\n\nCanonical.\n"
+        )
+        _rebuild_index(vault, db_path)
 
         # Insert a concept_alias row into the existing DB
         conn = sqlite3.connect(db_path)


### PR DESCRIPTION
## Summary
- prune concept_aliases rows whose duplicate or canonical slugs no longer exist after a fresh ingest
- keep valid alias rows across rebuilds
- add regressions for stale alias pruning and valid alias preservation

Closes #213.

## Tests
- uv run --with pytest --with ./cli python -m pytest cli/tests/test_ingest.py::test_ingest_prunes_concept_aliases_for_missing_concepts -q
- uv run --with pytest --with ./cli python -m pytest cli/tests/test_sync.py::TestRebuildIndexSideTablePreservation::test_concept_aliases_survive_rebuild -q
- uv run --with pytest --with ./cli python -m pytest cli/tests/test_ingest.py cli/tests/test_sync.py -q
- cd cli && uv run --with pytest --with . python -m pytest tests/