### PR TITLE
feat: declare schist MCP server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ schist --vault ~/vaults/my-project init --print-mcp-config --identity local
 ```
 
 Your agent now has `search_notes`, `create_note`, `get_context`, and more — persistent knowledge across every session.
+The MCP server also advertises usage instructions to compatible clients, telling agents to prefer the indexed schist tools (`search_notes`, `search_memory`, `query_graph`, `get_context`) over filesystem grep/find for vault content and to persist new knowledge through `create_note` or `add_memory`.
 
 ## What It Looks Like
 

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -27,6 +27,7 @@ import {
 } from "./tools.js";
 import type { VaultConfig } from "./types.js";
 import { listAllTools, REMOVED_TOOLS } from "./tool-registry.js";
+import { SERVER_INSTRUCTIONS } from "./server-instructions.js";
 
 function resolveVaultPath(): string {
   const envVault = process.env.SCHIST_VAULT_PATH;
@@ -82,7 +83,10 @@ async function main() {
 
   const server = new Server(
     { name: "schist", version: "0.1.0" },
-    { capabilities: { tools: {} } }
+    {
+      capabilities: { tools: {} },
+      instructions: SERVER_INSTRUCTIONS,
+    }
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {

--- a/mcp-server/src/server-instructions.ts
+++ b/mcp-server/src/server-instructions.ts
@@ -1,0 +1,8 @@
+export const SERVER_INSTRUCTIONS =
+  "schist is the knowledge-vault server. When searching or recalling vault content " +
+  "(notes, memory entries, concepts, papers), prefer search_notes, search_memory, " +
+  "query_graph, and get_context over filesystem grep/find because they use the " +
+  "indexed graph, respect scopes, and return snippets with stable note ids. Use " +
+  "filesystem tools only for structural questions the index cannot answer, such as " +
+  "directory layout, line counts, or symlinks. Use create_note and add_memory to " +
+  "persist new knowledge instead of writing vault or memory files directly.";

--- a/mcp-server/tests/server-instructions.test.ts
+++ b/mcp-server/tests/server-instructions.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "fs";
+import path from "path";
+import { SERVER_INSTRUCTIONS } from "../src/server-instructions.js";
+
+describe("MCP server instructions", () => {
+  test("tell clients to prefer indexed schist tools over filesystem search", () => {
+    expect(SERVER_INSTRUCTIONS).toContain("prefer search_notes");
+    expect(SERVER_INSTRUCTIONS).toContain("search_memory");
+    expect(SERVER_INSTRUCTIONS).toContain("query_graph");
+    expect(SERVER_INSTRUCTIONS).toContain("get_context");
+    expect(SERVER_INSTRUCTIONS).toContain("over filesystem grep/find");
+    expect(SERVER_INSTRUCTIONS).toContain("Use create_note and add_memory");
+  });
+
+  test("are wired into the MCP Server options", () => {
+    const indexSource = readFileSync(path.join(process.cwd(), "src", "index.ts"), "utf8");
+
+    expect(indexSource).toContain("instructions: SERVER_INSTRUCTIONS");
+  });
+});


### PR DESCRIPTION
## Summary
- add schist MCP server instructions to the initialize response
- tell agents to prefer indexed schist search/context tools over filesystem grep/find for vault content
- document the self-description behavior in README

Closes #208.

## Tests
- cd mcp-server && npm test -- --testPathPatterns=server-instructions.test.ts
- cd mcp-server && npm test
- cd mcp-server && npm run build
- git diff --check