### PR TITLE
feat: add compose_brief MCP tool

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -3,6 +3,19 @@
 This document describes recommended authoring patterns on top of the canonical
 vault schema in `schema/SCHEMA.md`.
 
+## External Briefs And Issue Filing
+
+When an agent notices a schist gap or needs to file an external report, use the
+MCP `compose_brief` tool to pack vault context first. The tool is a read-only
+composer: it searches indexed notes, follows nearby graph edges, includes
+optional pinned refs, and can list recent git-added paths. It returns markdown
+plus suggested tags and cross-references.
+
+After reviewing and editing the generated markdown, file it with the appropriate
+external tool (`gh`, Linear, Jira, a lab notebook, or similar). Do not use
+schist as the filing client for those systems; schist's role is to supply
+vault-grounded context.
+
 ## Paper Notes: Citation-Grade Frontmatter
 
 Use citation-grade paper notes when a `papers/` entry should act as an

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ This gives the agent a snapshot of graph stats, recent notes, and hot concepts.
 | `add_connection` | Add a typed edge between two nodes |
 | `list_concepts` | List all concept nodes |
 | `query_graph` | Run read-only SQL against the graph database |
+| `compose_brief` | Compose a context-rich markdown brief for external filing |
 | `get_context` | Dump graph context for agent session init |
 | `search_memory` | Search cross-project agent memory |
 | `add_memory` | Add a memory entry (decision, lesson, blocker, etc.) |

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -16,6 +16,7 @@ import {
   get_context,
   sync_status,
   sync_retry,
+  compose_brief,
   loadVaultConfig,
   // Memory V2
   add_memory,
@@ -114,6 +115,9 @@ async function main() {
           break;
         case "query_graph":
           result = await query_graph(vaultRoot, toolArgs as Parameters<typeof query_graph>[1]);
+          break;
+        case "compose_brief":
+          result = await compose_brief(vaultRoot, toolArgs as Parameters<typeof compose_brief>[1]);
           break;
         case "get_context":
           result = await get_context(vaultRoot, toolArgs as Parameters<typeof get_context>[1]);

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -250,6 +250,36 @@ export function makeWriteTools(config: VaultConfig) {
         required: ["sql"],
       },
     },
+    {
+      name: "compose_brief",
+      description: "Compose a context-rich markdown brief from indexed vault notes, graph neighbors, optional pinned refs, and recent git-added paths. Read-only: does not file issues, call external APIs, or write files.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          topic: { type: "string", description: "Free-text description of what the brief is about." },
+          scope: {
+            type: "array",
+            items: { type: "string" },
+            description: "Optional path-prefix filter, such as ['concepts', 'ops', 'decisions'].",
+          },
+          related_notes: {
+            type: "array",
+            items: { type: "string" },
+            description: "Optional explicit note ids to pin into the brief.",
+          },
+          related_external: {
+            type: "array",
+            items: { type: "string" },
+            description: "Optional external cross-references, such as GitHub issue ids.",
+          },
+          session_paths: {
+            type: "boolean",
+            description: "When true, include files added in recent local git history. Defaults to true.",
+          },
+        },
+        required: ["topic"],
+      },
+    },
   ];
 }
 

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -8,7 +8,7 @@ import * as sqliteReader from "./sqlite-reader.js";
 import { writeNote } from "./git-writer.js";
 import { buildNote, buildConnectionLine } from "./markdown-parser.js";
 import { validateOwner, resolveActiveOwner } from "./agent-identity.js";
-import type { VaultConfig, ToolError, SearchMemoryResponse, SearchNotesResponse, QueryGraphResponse, ListConceptsResponse, GetContextResponse, SyncRetryResponse, SyncStatusResponse } from "./types.js";
+import type { VaultConfig, ToolError, SearchMemoryResponse, SearchNotesResponse, QueryGraphResponse, ListConceptsResponse, GetContextResponse, SyncRetryResponse, SyncStatusResponse, ComposeBriefResponse, Note, SearchResult } from "./types.js";
 import { loadVaultAcl, canWrite, deriveScope, resolveAclIdentity } from "./vault-acl.js";
 import {
   canonicalizeQueryHash,
@@ -633,6 +633,94 @@ function outcomeMessage(outcome: SyncCommandOutcome): string {
   if (outcome.timedOut) return "command timed out";
   if (outcome.signal) return `command killed by signal ${outcome.signal}`;
   return `command exited with code ${outcome.code ?? "unknown"}`;
+}
+
+function ensureStringArray(value: unknown, field: string): string[] | ToolError {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    return { error: "VALIDATION_ERROR", message: `${field} must be an array of strings` };
+  }
+  return value;
+}
+
+function oneLine(text: string, cap = 180): string {
+  const cleaned = text
+    .replace(/^---[\s\S]*?---\s*/m, "")
+    .replace(/[#>*_`[\]()-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!cleaned) return "";
+  return cleaned.length > cap ? cleaned.slice(0, cap - 1).trimEnd() + "…" : cleaned;
+}
+
+function matchesScopePath(id: string, scope: string[]): boolean {
+  if (scope.length === 0) return true;
+  return scope.some((prefix) => id === prefix || id.startsWith(`${prefix.replace(/\/$/, "")}/`));
+}
+
+function addTags(acc: Map<string, number>, tags: unknown): void {
+  let parsed: unknown;
+  try {
+    parsed = typeof tags === "string" ? JSON.parse(tags) : tags;
+  } catch {
+    return;
+  }
+  if (!Array.isArray(parsed)) return;
+  for (const tag of parsed) {
+    if (typeof tag === "string" && tag.trim()) {
+      acc.set(tag, (acc.get(tag) ?? 0) + 1);
+    }
+  }
+}
+
+type BriefNote = ComposeBriefResponse["related_notes"][number] & {
+  tags: string[];
+  annotation: string;
+};
+
+function briefNoteFromSearch(note: SearchResult, reason: string): BriefNote {
+  return {
+    id: note.id,
+    title: note.title,
+    reason,
+    tags: note.tags,
+    annotation: oneLine(note.snippet) || note.title,
+  };
+}
+
+function briefNoteFromNote(note: Note, reason: string): BriefNote {
+  return {
+    id: note.id,
+    title: note.title,
+    reason,
+    tags: note.tags,
+    annotation: oneLine(note.body) || note.title,
+  };
+}
+
+async function recentAddedPaths(vaultRoot: string, scope: string[]): Promise<Array<{ path: string; commit: string }>> {
+  const outcome = await runGit(vaultRoot, [
+    "log",
+    "--since=24 hours ago",
+    "--diff-filter=A",
+    "--name-only",
+    "--pretty=format:commit:%h",
+  ], 2_000);
+  if (!outcome.ok || !outcome.stdout) return [];
+
+  const rows: Array<{ path: string; commit: string }> = [];
+  let commit = "";
+  for (const raw of outcome.stdout.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line.startsWith("commit:")) {
+      commit = line.slice("commit:".length);
+      continue;
+    }
+    if (matchesScopePath(line, scope)) rows.push({ path: line, commit });
+    if (rows.length >= 8) break;
+  }
+  return rows;
 }
 
 function isAclRejection(outcome: SyncCommandOutcome): boolean {
@@ -1393,6 +1481,139 @@ export async function query_graph(
   };
   if (cursor !== undefined) response.cursor = cursor;
   return response;
+}
+
+/**
+ * compose_brief is a read-only context packer for external filing workflows.
+ * It does not create GitHub/Jira/etc. issues; it returns markdown plus metadata
+ * for the caller to edit and file with their preferred tool.
+ */
+export async function compose_brief(
+  vaultRoot: string,
+  args: {
+    topic: string;
+    scope?: string[];
+    related_notes?: string[];
+    related_external?: string[];
+    session_paths?: boolean;
+  }
+): Promise<ComposeBriefResponse | ToolError> {
+  if (typeof args.topic !== "string" || args.topic.trim().length === 0) {
+    return { error: "VALIDATION_ERROR", message: "topic is required" };
+  }
+  if (args.session_paths !== undefined && typeof args.session_paths !== "boolean") {
+    return { error: "VALIDATION_ERROR", message: "session_paths must be a boolean" };
+  }
+
+  const scope = ensureStringArray(args.scope, "scope");
+  if (!Array.isArray(scope)) return scope;
+  const pinned = ensureStringArray(args.related_notes, "related_notes");
+  if (!Array.isArray(pinned)) return pinned;
+  const relatedExternal = ensureStringArray(args.related_external, "related_external");
+  if (!Array.isArray(relatedExternal)) return relatedExternal;
+
+  const byId = new Map<string, BriefNote>();
+  const tagCounts = new Map<string, number>();
+
+  try {
+    const searchRows = sqliteReader.searchNotes(vaultRoot, args.topic, { limit: 12 });
+    for (const row of searchRows) {
+      if (!matchesScopePath(row.id, scope)) continue;
+      if (!byId.has(row.id)) byId.set(row.id, briefNoteFromSearch(row, "topic search"));
+      addTags(tagCounts, row.tags);
+      if (byId.size >= 5) break;
+    }
+
+    for (const id of pinned) {
+      if (!matchesScopePath(id, scope)) continue;
+      const note = sqliteReader.getNote(vaultRoot, id);
+      if (!note) continue;
+      byId.set(id, briefNoteFromNote(note, "pinned"));
+      addTags(tagCounts, note.tags);
+    }
+
+    const seedIds = [...byId.keys()];
+    if (seedIds.length > 0) {
+      const placeholders = seedIds.map(() => "?").join(", ");
+      const graph = await sqliteReader.queryGraph(
+        vaultRoot,
+        `
+          SELECT e.source, e.target, e.type, d.id, d.title, d.tags, d.body
+          FROM edges e
+          JOIN docs d
+            ON d.id = CASE WHEN e.source IN (${placeholders}) THEN e.target ELSE e.source END
+          WHERE e.source IN (${placeholders}) OR e.target IN (${placeholders})
+          ORDER BY d.date DESC, d.id ASC
+        `,
+        [...seedIds, ...seedIds, ...seedIds],
+        { limit: 10 },
+      );
+      const idx = Object.fromEntries(graph.columns.map((col, i) => [col, i]));
+      for (const row of graph.rows) {
+        const id = row[idx.id] as string;
+        if (!id || byId.has(id) || !matchesScopePath(id, scope)) continue;
+        const title = (row[idx.title] as string) || id;
+        const body = (row[idx.body] as string) || "";
+        const edgeType = (row[idx.type] as string) || "related";
+        byId.set(id, {
+          id,
+          title,
+          reason: `graph ${edgeType}`,
+          tags: typeof row[idx.tags] === "string" ? JSON.parse(row[idx.tags] as string) : [],
+          annotation: oneLine(body) || title,
+        });
+        addTags(tagCounts, row[idx.tags]);
+      }
+    }
+  } catch (e: unknown) {
+    return normalizeError(e, "INGEST_ERROR");
+  }
+
+  const relatedNotes = [...byId.values()].slice(0, 10);
+  const recent = args.session_paths === false ? [] : await recentAddedPaths(vaultRoot, scope);
+  const suggestedTags = [...tagCounts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 8)
+    .map(([tag]) => tag);
+  const crossRefs = [...new Set([...relatedExternal, ...relatedNotes.map((note) => note.id)])];
+
+  const noteLines = relatedNotes.length > 0
+    ? relatedNotes.map((note) => `- \`${note.id}\` — ${note.title}: ${note.annotation} (${note.reason})`)
+    : ["- None found."];
+  const pathLines = recent.length > 0
+    ? recent.map((entry) => `- Added: \`${entry.path}\` @ \`${entry.commit || "unknown"}\``)
+    : ["- None found in recent local git history."];
+  const refLines = crossRefs.length > 0
+    ? crossRefs.map((ref) => `- ${ref}`)
+    : ["- None identified."];
+
+  const markdown = [
+    "## Summary",
+    args.topic.trim(),
+    "",
+    "## Related vault notes",
+    ...noteLines,
+    "",
+    "## Recent session context",
+    ...pathLines,
+    "",
+    "## Suggested cross-references",
+    ...refLines,
+    "",
+    "## Acceptance criteria",
+    "- [ ] Fill in the concrete acceptance criteria before filing.",
+    "",
+    "## Repro / evidence",
+    "- Fill in commands, paths, logs, or screenshots before filing.",
+  ].join("\n");
+
+  return {
+    markdown,
+    suggested_tags: suggestedTags,
+    cross_refs: crossRefs,
+    related_notes: relatedNotes.map(({ id, title, reason }) => ({ id, title, reason })),
+    recent_paths: recent,
+  };
 }
 
 /**

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -110,6 +110,21 @@ export interface SyncRetryResponse {
   awaited_in_flight?: boolean;
 }
 
+export interface ComposeBriefResponse {
+  markdown: string;
+  suggested_tags: string[];
+  cross_refs: string[];
+  related_notes: Array<{
+    id: string;
+    title: string;
+    reason: string;
+  }>;
+  recent_paths: Array<{
+    path: string;
+    commit: string;
+  }>;
+}
+
 export interface VaultConfig {
   name: string;
   path: string;

--- a/mcp-server/tests/compose-brief-tool.test.ts
+++ b/mcp-server/tests/compose-brief-tool.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, beforeEach, afterEach } from "@jest/globals";
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs/promises";
+import { execFileSync } from "child_process";
+import Database from "better-sqlite3";
+import { compose_brief } from "../src/tools.js";
+
+async function makeVault(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "schist-compose-brief-test-"));
+  const dbDir = path.join(dir, ".schist");
+  await fs.mkdir(dbDir, { recursive: true });
+  const dbPath = path.join(dbDir, "schist.db");
+
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE docs (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      date TEXT,
+      status TEXT DEFAULT 'draft',
+      tags TEXT,
+      concepts TEXT,
+      body TEXT NOT NULL DEFAULT '',
+      scope TEXT DEFAULT 'global',
+      source TEXT,
+      confidence TEXT,
+      created_at TEXT DEFAULT (datetime('now')),
+      updated_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE TABLE edges (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source TEXT NOT NULL,
+      target TEXT NOT NULL,
+      type TEXT NOT NULL,
+      context TEXT
+    );
+    CREATE VIRTUAL TABLE docs_fts USING fts5(
+      title, body, tags, scope UNINDEXED,
+      content='docs', content_rowid='rowid'
+    );
+    CREATE TRIGGER docs_ai AFTER INSERT ON docs BEGIN
+      INSERT INTO docs_fts(rowid, title, body, tags, scope)
+      VALUES (new.rowid, new.title, new.body, new.tags, new.scope);
+    END;
+  `);
+  const insertDoc = db.prepare(
+    `INSERT INTO docs (id, title, date, tags, body, scope) VALUES (?, ?, ?, ?, ?, ?)`,
+  );
+  insertDoc.run(
+    "research/topic.md",
+    "Paper Catalog",
+    "2026-06-12",
+    JSON.stringify(["papers", "catalog"]),
+    "Paper catalog metadata extraction should pack useful filing context.",
+    "global",
+  );
+  insertDoc.run(
+    "decisions/pinned.md",
+    "Pinned Decision",
+    "2026-06-11",
+    JSON.stringify(["decision"]),
+    "Pinned decision explains why brief composition should not file issues directly.",
+    "global",
+  );
+  insertDoc.run(
+    "ops/neighbor.md",
+    "Neighbor Note",
+    "2026-06-10",
+    JSON.stringify(["ops"]),
+    "Neighbor note is connected through the graph for context.",
+    "global",
+  );
+  db.prepare(`INSERT INTO edges (source, target, type) VALUES (?, ?, ?)`)
+    .run("research/topic.md", "ops/neighbor.md", "supports");
+  db.close();
+
+  execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir });
+  execFileSync("git", ["config", "user.name", "Test User"], { cwd: dir });
+  await fs.mkdir(path.join(dir, "research"), { recursive: true });
+  await fs.writeFile(path.join(dir, "research", "new-note.md"), "# New note\n");
+  execFileSync("git", ["add", "research/new-note.md"], { cwd: dir });
+  execFileSync("git", ["commit", "-m", "add recent note"], { cwd: dir, stdio: "ignore" });
+
+  return dir;
+}
+
+let vaultRoot: string;
+
+beforeEach(async () => {
+  vaultRoot = await makeVault();
+});
+
+afterEach(async () => {
+  await fs.rm(vaultRoot, { recursive: true, force: true });
+});
+
+describe("compose_brief tool", () => {
+  it("packs topic results, pinned notes, graph neighbors, external refs, and recent paths", async () => {
+    const result = await compose_brief(vaultRoot, {
+      topic: "paper catalog metadata",
+      related_notes: ["decisions/pinned.md"],
+      related_external: ["github:schist#119"],
+    });
+
+    expect(result).not.toHaveProperty("error");
+    const brief = result as Awaited<ReturnType<typeof compose_brief>>;
+    if ("error" in brief) throw new Error(brief.message);
+
+    expect(brief.markdown).toContain("## Related vault notes");
+    expect(brief.markdown).toContain("`research/topic.md`");
+    expect(brief.markdown).toContain("`decisions/pinned.md`");
+    expect(brief.markdown).toContain("`ops/neighbor.md`");
+    expect(brief.markdown).toContain("github:schist#119");
+    expect(brief.markdown).toContain("research/new-note.md");
+    expect(brief.suggested_tags).toEqual(expect.arrayContaining(["papers", "catalog", "decision", "ops"]));
+    expect(brief.cross_refs).toEqual(expect.arrayContaining(["github:schist#119", "research/topic.md"]));
+    expect(brief.related_notes.map((note) => note.id)).toEqual(expect.arrayContaining([
+      "research/topic.md",
+      "decisions/pinned.md",
+      "ops/neighbor.md",
+    ]));
+    expect(brief.recent_paths).toEqual([
+      expect.objectContaining({ path: "research/new-note.md" }),
+    ]);
+  });
+
+  it("validates topic and array arguments", async () => {
+    await expect(compose_brief(vaultRoot, { topic: "" })).resolves.toMatchObject({
+      error: "VALIDATION_ERROR",
+    });
+    await expect(compose_brief(vaultRoot, {
+      topic: "x",
+      related_notes: [123],
+    } as never)).resolves.toMatchObject({
+      error: "VALIDATION_ERROR",
+      message: expect.stringContaining("related_notes"),
+    });
+  });
+});

--- a/mcp-server/tests/tool-listing.test.ts
+++ b/mcp-server/tests/tool-listing.test.ts
@@ -20,6 +20,7 @@ describe("listAllTools — unconditional tool exposure", () => {
       "add_concept_alias",
       "add_connection",
       "add_memory",
+      "compose_brief",
       "create_note",
       "delete_agent_state",
       "get_agent_state",


### PR DESCRIPTION
## Summary
- add read-only compose_brief MCP tool for context-rich markdown brief generation
- pack topic search results, pinned related notes, graph neighbors, external refs, and recent git-added paths
- document the external-brief convention and list the tool in README

Closes #134.

## Tests
- cd mcp-server && npm test -- --testPathPatterns=compose-brief-tool.test.ts
- cd mcp-server && npm test -- --testPathPatterns=tool-listing.test.ts
- cd mcp-server && npm test
- cd mcp-server && npm run build
- git diff --check