### PR TITLE
ci: fix Dependabot auto-merge and skip Claude review on bot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Dependabot PRs: their runs execute with a restricted token and have
+    # no access to repo secrets, so CLAUDE_CODE_OAUTH_TOKEN is empty and the
+    # action fails on the installation-token exchange. Dependency bumps are
+    # handled by the dependabot-auto-merge workflow instead.
+    if: github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,15 +21,11 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Approve PR
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      # No "Approve PR" step: GitHub blocks the Actions bot from approving PRs
+      # (addPullRequestReview → "GitHub Actions is not permitted to approve
+      # pull requests"), and main enforces no required reviews — only status
+      # checks — so an approval is unnecessary. `--auto` merges once the
+      # required checks pass.
       - name: Enable auto-merge (squash)
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||


### PR DESCRIPTION
Fixes the two CI infra failures observed during the PR-backlog drain — both Dependabot-specific:

**1. `dependabot-auto-merge` → "Approve PR" step**
Failed with `GraphQL: GitHub Actions is not permitted to approve pull requests. (addPullRequestReview)`. The Actions bot cannot self-approve PRs, and `main` enforces **no required reviews** (only the two required status checks). The approval was never needed — `gh pr merge --auto --squash` merges once checks pass. Step removed.

**2. `claude-code-review` on Dependabot PRs**
Failed because Dependabot-triggered runs execute with a restricted token and **no access to repo secrets**, so `CLAUDE_CODE_OAUTH_TOKEN` was empty and the action died on the installation-token exchange (`/installation/token` returned 0 bytes). Skip the job for the `dependabot[bot]` actor — dependency bumps are covered by the auto-merge workflow.

Verified: `claude-review` already succeeds on all human/codex PRs; this only affects the Dependabot path. Repo has `allow_auto_merge: true`.

Note: this PR changes `claude-code-review.yml`, so its own Claude review step self-skips via the existing "Detect review workflow self-change" guard (expected).