### PR TITLE
fix: harden SQL query guard and search (closes #222, #223, #224, #225, #228, #229)

### DIFF
--- a/cli/schist/sqlite_query.py
+++ b/cli/schist/sqlite_query.py
@@ -9,7 +9,10 @@ import sys
 # Keep in sync with the read/queryable tables defined in schema.sql.
 ALLOWED_TABLES = {'docs', 'concepts', 'edges', 'docs_fts', 'paper_metadata', 'concept_aliases'}
 # Keep in sync with mcp-server/src/sqlite-reader.ts REQUIRED_TABLES.
-REQUIRED_TABLES = {'docs', 'paper_metadata'}
+# concept_aliases is included so vaults upgraded from a pre-concept_aliases
+# schema (which still have docs + paper_metadata) re-trigger ingest instead of
+# failing later with "no such table: concept_aliases". See #224.
+REQUIRED_TABLES = {'docs', 'paper_metadata', 'concept_aliases'}
 
 
 def get_db(vault_path: str, db_path: str | None = None) -> sqlite3.Connection:
@@ -87,8 +90,8 @@ def fts_search(db: sqlite3.Connection, query: str, limit: int = 20,
 
     if tags:
         for tag in tags:
-            sql += " AND d.tags LIKE ?"
-            params.append(f'%"{tag}"%')
+            sql += " AND d.tags LIKE ? ESCAPE '\\'"
+            params.append(f'%"{_escape_like(tag)}"%')
 
     sql += ' ORDER BY rank LIMIT ?'
     params.append(limit)
@@ -101,6 +104,16 @@ def _sanitize_fts_query(query: str) -> str:
     """Quote each token so FTS5 treats user input as literal search text."""
     tokens = query.split()
     return " ".join(f'"{token.replace(chr(34), chr(34) * 2)}"' for token in tokens)
+
+
+def _escape_like(value: str) -> str:
+    """Escape SQL LIKE wildcards so a caller value matches literally.
+
+    Intended for embedding in a LIKE pattern used with `ESCAPE '\\'`; the
+    backslash is escaped first. Without this, a `_`/`%` in a tag name acts as a
+    wildcard and produces false-positive matches. See #225.
+    """
+    return value.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
 
 
 def raw_query(db: sqlite3.Connection, sql: str, params: tuple = ()) -> dict:
@@ -174,7 +187,9 @@ def _validate_sql(sql: str):
     cleaned = _mask_sql_literals_and_comments(sql)
     cleaned = cleaned.strip()
 
-    if not re.match(r'SELECT\b', cleaned, re.IGNORECASE):
+    # Accept WITH (CTEs) as well as SELECT — both are read-only and the MCP
+    # query_graph guard already allows them. See #223.
+    if not re.match(r'(SELECT|WITH)\b', cleaned, re.IGNORECASE):
         print('Error: only SELECT queries are allowed', file=sys.stderr)
         sys.exit(1)
 
@@ -185,9 +200,23 @@ def _validate_sql(sql: str):
             print(f'Error: {keyword} statements are not allowed', file=sys.stderr)
             sys.exit(1)
 
-    # Validate table references — find word after FROM/JOIN
-    table_refs = re.findall(r'\b(?:FROM|JOIN)\s+(\w+)', cleaned, re.IGNORECASE)
-    for table in table_refs:
-        if table.lower() not in ALLOWED_TABLES:
-            print(f'Error: table "{table}" is not allowed (allowed: {", ".join(sorted(ALLOWED_TABLES))})', file=sys.stderr)
-            sys.exit(1)
+    # CTE alias names are virtual tables defined by `WITH name AS (...)`; a
+    # reference like `FROM name` must not be checked against ALLOWED_TABLES.
+    # See #223.
+    cte_names = {m.lower() for m in re.findall(r'\b(\w+)\s+AS\s*\(', cleaned, re.IGNORECASE)}
+
+    # Validate table references — capture the identifier after FROM/JOIN whether
+    # bare, `backtick`-quoted, or [bracket]-quoted. `\w+` alone misses the quoted
+    # forms (the quote chars aren't word characters), silently skipping the
+    # allow-list check and letting e.g. `FROM \`sqlite_master\`` through. See #228.
+    table_refs = re.findall(
+        r'\b(?:FROM|JOIN)\s+(?:`([^`]+)`|\[([^\]]+)\]|(\w+))',
+        cleaned,
+        re.IGNORECASE,
+    )
+    for backtick, bracket, bare in table_refs:
+        table = backtick or bracket or bare
+        if table.lower() in ALLOWED_TABLES or table.lower() in cte_names:
+            continue
+        print(f'Error: table "{table}" is not allowed (allowed: {", ".join(sorted(ALLOWED_TABLES))})', file=sys.stderr)
+        sys.exit(1)

--- a/cli/tests/test_sqlite_query.py
+++ b/cli/tests/test_sqlite_query.py
@@ -43,6 +43,7 @@ def test_get_db_keeps_current_db_when_required_tables_exist(tmp_path: Path) -> N
     conn = sqlite3.connect(db_path)
     conn.execute("CREATE TABLE docs (id TEXT PRIMARY KEY)")
     conn.execute("CREATE TABLE paper_metadata (doc_id TEXT PRIMARY KEY)")
+    conn.execute("CREATE TABLE concept_aliases (duplicate_slug TEXT PRIMARY KEY)")
     conn.commit()
     conn.close()
 
@@ -51,6 +52,27 @@ def test_get_db_keeps_current_db_when_required_tables_exist(tmp_path: Path) -> N
         db.close()
 
     run_ingest.assert_not_called()
+
+
+def test_get_db_reingests_when_concept_aliases_missing(tmp_path: Path) -> None:
+    """Vaults upgraded past paper_metadata but before concept_aliases must
+    self-heal rather than fail later in add_concept_alias. See #224."""
+    vault = tmp_path / "vault"
+    db_path = vault / ".schist" / "schist.db"
+    db_path.parent.mkdir(parents=True)
+
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE docs (id TEXT PRIMARY KEY)")
+    conn.execute("CREATE TABLE paper_metadata (doc_id TEXT PRIMARY KEY)")
+    # concept_aliases intentionally absent
+    conn.commit()
+    conn.close()
+
+    with patch("schist.sqlite_query._run_ingest") as run_ingest:
+        db = get_db(str(vault), str(db_path))
+        db.close()
+
+    run_ingest.assert_called_once_with(str(vault), str(db_path))
 
 
 def test_validate_sql_allows_blocked_keywords_inside_string_literals() -> None:
@@ -173,3 +195,100 @@ def test_fts_search_matches_mcp_literal_operator_behavior() -> None:
     )
 
     assert fts_search(conn, "foo OR bar") == []
+
+
+def _docs_concepts_conn() -> sqlite3.Connection:
+    conn = _connect()
+    conn.execute("CREATE TABLE docs (id TEXT PRIMARY KEY, title TEXT)")
+    conn.execute("CREATE TABLE concepts (slug TEXT PRIMARY KEY, title TEXT)")
+    conn.execute("CREATE TABLE edges (id INTEGER PRIMARY KEY, target TEXT)")
+    return conn
+
+
+def test_raw_query_accepts_simple_cte() -> None:
+    """A WITH (CTE) query is read-only and must validate. See #223."""
+    conn = _docs_concepts_conn()
+    conn.execute("INSERT INTO concepts (slug, title) VALUES ('a', 'Alpha')")
+
+    result = raw_query(
+        conn,
+        "WITH ranked AS (SELECT slug, title FROM concepts) "
+        "SELECT title FROM ranked ORDER BY slug",
+    )
+
+    assert result == {"columns": ["title"], "rows": [["Alpha"]]}
+
+
+def test_raw_query_accepts_multiple_ctes() -> None:
+    conn = _docs_concepts_conn()
+    conn.execute("INSERT INTO concepts (slug, title) VALUES ('a', 'Alpha')")
+    conn.execute("INSERT INTO edges (id, target) VALUES (1, 'a')")
+
+    result = raw_query(
+        conn,
+        "WITH c AS (SELECT slug, title FROM concepts), "
+        "m AS (SELECT target AS slug, COUNT(*) AS n FROM edges GROUP BY target) "
+        "SELECT c.title, m.n FROM c JOIN m ON m.slug = c.slug",
+    )
+
+    assert result == {"columns": ["title", "n"], "rows": [["Alpha", 1]]}
+
+
+def test_raw_query_cte_referencing_disallowed_table_still_rejected(capsys) -> None:
+    """CTE syntax must not become an escape hatch around ALLOWED_TABLES."""
+    conn = _docs_concepts_conn()
+
+    with pytest.raises(SystemExit):
+        raw_query(
+            conn,
+            "WITH x AS (SELECT name FROM sqlite_master) SELECT * FROM x",
+        )
+
+    assert 'table "sqlite_master" is not allowed' in capsys.readouterr().err
+
+
+def test_raw_query_rejects_backtick_quoted_table() -> None:
+    """Backtick-quoted identifiers must not bypass ALLOWED_TABLES. See #228."""
+    conn = _docs_concepts_conn()
+
+    with pytest.raises(SystemExit):
+        raw_query(conn, "SELECT name FROM `sqlite_master`")
+
+
+def test_raw_query_rejects_bracket_quoted_table() -> None:
+    """Bracket-quoted identifiers must not bypass ALLOWED_TABLES either."""
+    conn = _docs_concepts_conn()
+
+    with pytest.raises(SystemExit):
+        raw_query(conn, "SELECT name FROM [sqlite_master]")
+
+
+def test_fts_search_tag_underscore_is_not_a_wildcard() -> None:
+    """A `_` in a tag filter must match literally, not as a wildcard. See #225."""
+    conn = _connect()
+    conn.execute("""
+        CREATE TABLE docs (
+            id TEXT PRIMARY KEY, title TEXT, date TEXT,
+            status TEXT, tags TEXT, body TEXT
+        )
+    """)
+    conn.execute("CREATE VIRTUAL TABLE docs_fts USING fts5(title, body, tags, scope UNINDEXED)")
+    # Note A: snake_case tag; Note B: differs only at the underscore position.
+    conn.execute(
+        "INSERT INTO docs (rowid, id, title, date, status, tags, body) "
+        "VALUES (1, 'notes/a.md', 'A', '2026-06-15', 'draft', '[\"machine_learning\"]', 'ml text')"
+    )
+    conn.execute(
+        "INSERT INTO docs (rowid, id, title, date, status, tags, body) "
+        "VALUES (2, 'notes/b.md', 'B', '2026-06-15', 'draft', '[\"machine-learning\"]', 'ml text')"
+    )
+    for rowid, tags in ((1, '["machine_learning"]'), (2, '["machine-learning"]')):
+        conn.execute(
+            "INSERT INTO docs_fts (rowid, title, body, tags, scope) "
+            "VALUES (?, 'x', 'ml text', ?, 'global')",
+            (rowid, tags),
+        )
+
+    rows = fts_search(conn, "ml", tags=["machine_learning"])
+
+    assert [row["id"] for row in rows] == ["notes/a.md"]

--- a/mcp-server/src/sqlite-reader.ts
+++ b/mcp-server/src/sqlite-reader.ts
@@ -80,7 +80,11 @@ const REQUIRED_DOCS_COLUMNS: ReadonlySet<string> = new Set([
   "id", "title", "date", "status", "tags", "concepts",
   "body", "scope", "source", "confidence", "file_ref",
 ]);
-const REQUIRED_TABLES: ReadonlySet<string> = new Set(["paper_metadata"]);
+// Keep in sync with cli/schist/sqlite_query.py REQUIRED_TABLES. concept_aliases
+// is included so vaults upgraded from a pre-concept_aliases schema (which still
+// have docs + paper_metadata, so the drift check would otherwise pass) trigger
+// an ingest rebuild before add_concept_alias hits "no such table". See #224.
+const REQUIRED_TABLES: ReadonlySet<string> = new Set(["paper_metadata", "concept_aliases"]);
 
 const verifiedVaults = new Set<string>();
 const requireForWorker = createRequire(import.meta.url);
@@ -94,6 +98,16 @@ function positiveIntEnv(name: string, fallback: number): number {
   if (raw === undefined || raw.trim() === "") return fallback;
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+// Escape SQL LIKE wildcards so caller-supplied values match literally. The
+// returned string is meant to be embedded in a LIKE pattern used with an
+// `ESCAPE '\'` clause; backslash itself is escaped first. Without this, a `_`
+// or `%` in a tag/scope/search term acts as a wildcard and produces
+// false-positive matches (e.g. tag "machine_learning" matching
+// "machine-learning"). See #225 / #229.
+function escapeLike(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
 }
 
 function maskSqlLiteralsAndComments(sql: string): string {
@@ -295,8 +309,8 @@ export function searchNotes(
 
     if (opts?.tags && opts.tags.length > 0) {
       for (const tag of opts.tags) {
-        sql += ` AND docs.tags LIKE ?`;
-        params.push(`%"${tag}"%`);
+        sql += ` AND docs.tags LIKE ? ESCAPE '\\'`;
+        params.push(`%"${escapeLike(tag)}"%`);
       }
     }
 
@@ -323,8 +337,12 @@ export function searchNotes(
         const agentName =
           opts.owner ?? process.env.SCHIST_AGENT_NAME ?? process.env.SCHIST_AGENT_ID;
         const callingScope = scopeMap.get(agentName ?? "") ?? "global";
-        sql += ` AND (docs.scope = 'global' OR docs.scope = ? OR docs.scope LIKE ? || '/%')`;
-        params.push(callingScope, callingScope);
+        // The LIKE branch matches sub-scopes (`callingScope/...`); escape the
+        // value so a `_`/`%` in the scope name can't act as a wildcard and pull
+        // in a sibling scope (e.g. "my_project" matching "my-project"). The two
+        // `= ?` comparisons are exact equality and need no escaping. See #229.
+        sql += ` AND (docs.scope = 'global' OR docs.scope = ? OR docs.scope LIKE ? || '/%' ESCAPE '\\')`;
+        params.push(callingScope, escapeLike(callingScope));
         orderClauses.push(`CASE WHEN docs.scope = ? THEN 0 ELSE 1 END`);
         params.push(callingScope);
       } else {
@@ -415,14 +433,15 @@ export function listConcepts(
     const where: string[] = [];
 
     if (opts?.search) {
-      where.push(`(c.title LIKE ? OR c.description LIKE ?)`);
-      params.push(`%${opts.search}%`, `%${opts.search}%`);
+      where.push(`(c.title LIKE ? ESCAPE '\\' OR c.description LIKE ? ESCAPE '\\')`);
+      const escaped = `%${escapeLike(opts.search)}%`;
+      params.push(escaped, escaped);
     }
 
     if (opts?.tags && opts.tags.length > 0) {
       for (const tag of opts.tags) {
-        where.push(`c.tags LIKE ?`);
-        params.push(`%"${tag}"%`);
+        where.push(`c.tags LIKE ? ESCAPE '\\'`);
+        params.push(`%"${escapeLike(tag)}"%`);
       }
     }
 
@@ -589,7 +608,12 @@ export async function queryGraph(
   // common ergonomic affordance and remove it. Multi-statement input is still
   // rejected by `better-sqlite3.prepare()`.
   const trimmed = sql.trim().replace(/;+\s*$/, "");
-  const guardSql = maskSqlLiteralsAndComments(trimmed);
+  // trimStart() after masking: a leading SQL comment (e.g. an LLM's reasoning
+  // `-- ...` line) is blanked to spaces by the masker, which would otherwise
+  // push the SELECT/WITH keyword off the `^` anchor and get the query wrongly
+  // rejected as non-SELECT. The blocked-keyword scan below is unanchored, so
+  // trimming doesn't affect it. See #222.
+  const guardSql = maskSqlLiteralsAndComments(trimmed).trimStart();
   if (
     !guardSql.match(/^(SELECT|WITH)\b/i) ||
     guardSql.match(/\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE)\b/i)

--- a/mcp-server/tests/list-concepts-sql.test.ts
+++ b/mcp-server/tests/list-concepts-sql.test.ts
@@ -96,6 +96,16 @@ describe("listConcepts — cursor pagination", () => {
     expect(slugs).toContain("beta");
   });
 
+  // #225: search term with `_` must match titles literally, not as a wildcard
+  it("search escapes LIKE wildcards: `_` does not match a sibling title", async () => {
+    const vault = await makeConceptVault([
+      { slug: "dl-snake", title: "deep_learning" },
+      { slug: "dl-kebab", title: "deep-learning" },
+    ]);
+    const results = listConcepts(vault, { search: "deep_learning" });
+    expect(results.map((r) => r.slug)).toEqual(["dl-snake"]);
+  });
+
   // Case 2: offset N pagination — union of two pages = full set, no overlap
   it("offset pagination: two pages cover all 10 concepts without overlap", async () => {
     const concepts = Array.from({ length: 10 }, (_, i) => ({

--- a/mcp-server/tests/query-graph-tool.test.ts
+++ b/mcp-server/tests/query-graph-tool.test.ts
@@ -348,6 +348,35 @@ describe("query_graph tool — subquery wrap is structurally safe against commen
     if (!("rows" in r)) throw new Error("expected rows");
     expect(r.rows.length).toBe(5);
   });
+
+  it("leading `--` line comment must not be falsely rejected (#222)", async () => {
+    vaultRoot = await makeVault(5);
+    // LLMs routinely prefix a reasoning comment before the SELECT; the masker
+    // blanks it to spaces, so without trimStart the ^SELECT anchor fails.
+    const r = await query_graph(vaultRoot, {
+      sql: "-- most-connected concepts\nSELECT id, title FROM docs",
+    });
+    if (!("rows" in r)) throw new Error(`expected rows, got ${JSON.stringify(r)}`);
+    expect(r.rows.length).toBe(5);
+  });
+
+  it("leading `/* ... */` block comment must not be falsely rejected (#222)", async () => {
+    vaultRoot = await makeVault(5);
+    const r = await query_graph(vaultRoot, {
+      sql: "/* describe the query */ SELECT id, title FROM docs",
+    });
+    if (!("rows" in r)) throw new Error(`expected rows, got ${JSON.stringify(r)}`);
+    expect(r.rows.length).toBe(5);
+  });
+
+  it("leading comment before WITH (CTE) must not be falsely rejected (#222)", async () => {
+    vaultRoot = await makeVault(5);
+    const r = await query_graph(vaultRoot, {
+      sql: "-- rank notes\nWITH r AS (SELECT id, title FROM docs) SELECT * FROM r",
+    });
+    if (!("rows" in r)) throw new Error(`expected rows, got ${JSON.stringify(r)}`);
+    expect(r.rows.length).toBe(5);
+  });
 });
 
 // ── pagination math: caller LIMIT > effectiveLimit ─────────────────────────

--- a/mcp-server/tests/search-notes-tool.test.ts
+++ b/mcp-server/tests/search-notes-tool.test.ts
@@ -416,3 +416,80 @@ describe("search_notes tool — id-ASC tiebreaker stability", () => {
     expect(seen.size).toBe(10);
   });
 });
+
+// ── LIKE wildcard escaping in tag and scope filters ────────────────────────
+
+describe("search_notes tool — LIKE wildcards are escaped (#225 / #229)", () => {
+  it("tag filter with `_` matches literally, not as a wildcard (#225)", async () => {
+    // Two notes whose tags differ only at the underscore position. Filtering on
+    // the snake_case tag must NOT pull in the kebab-case note.
+    const db = new Database(path.join(vaultRoot, ".schist", "schist.db"));
+    try {
+      const stmt = db.prepare(
+        `INSERT INTO docs (id, title, body, tags, scope) VALUES (?, ?, 'haystack body', ?, 'global')`,
+      );
+      stmt.run("notes/snake.md", "Snake", '["machine_learning"]');
+      stmt.run("notes/kebab.md", "Kebab", '["machine-learning"]');
+    } finally {
+      db.close();
+    }
+
+    const r = await search_notes(vaultRoot, {
+      query: "haystack",
+      tags: ["machine_learning"],
+    });
+    if (!("results" in r)) throw new Error(`unexpected error: ${JSON.stringify(r)}`);
+    expect(r.results.map((row) => row.id)).toEqual(["notes/snake.md"]);
+  });
+
+  it("scope=inherit sub-scope match escapes `_` so a sibling scope can't leak (#229)", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "schist-sn-scopeesc-test-"));
+    try {
+      const dbDir = path.join(dir, ".schist");
+      await fs.mkdir(dbDir, { recursive: true });
+      const db = new Database(path.join(dbDir, "schist.db"));
+      db.exec(`
+        CREATE TABLE docs (
+          id TEXT PRIMARY KEY, title TEXT NOT NULL, date TEXT,
+          status TEXT DEFAULT 'draft', tags TEXT, concepts TEXT,
+          body TEXT NOT NULL DEFAULT '', scope TEXT DEFAULT 'global',
+          source TEXT, confidence TEXT,
+          created_at TEXT DEFAULT (datetime('now')),
+          updated_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE VIRTUAL TABLE docs_fts USING fts5(
+          title, body, tags, scope UNINDEXED,
+          content='docs', content_rowid='rowid'
+        );
+        CREATE TRIGGER docs_ai AFTER INSERT ON docs BEGIN
+          INSERT INTO docs_fts(rowid, title, body, tags, scope)
+          VALUES (new.rowid, new.title, new.body, new.tags, new.scope);
+        END;
+      `);
+      const stmt = db.prepare(
+        `INSERT INTO docs (id, title, body, scope) VALUES (?, ?, 'haystack body', ?)`,
+      );
+      // callingScope is "my_project"; the sub-scope note must match, the
+      // sibling "my-project/..." must NOT (it only matches if `_` is a wildcard).
+      stmt.run("notes/own.md", "Own", "my_project/sub");
+      stmt.run("notes/sibling.md", "Sibling", "my-project/sub");
+      db.close();
+
+      await fs.writeFile(
+        path.join(dir, "vault.yaml"),
+        "name: esc-test\nparticipants:\n  - { name: myagent, default_scope: my_project }\n",
+      );
+
+      const r = await search_notes(dir, {
+        query: "haystack",
+        scope: "inherit",
+        owner: "myagent",
+      });
+      if (!("results" in r)) throw new Error(`unexpected error: ${JSON.stringify(r)}`);
+      const ids = r.results.map((row) => row.id).sort();
+      expect(ids).toEqual(["notes/own.md"]);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes the six-issue query-guard cluster — all in the SQLite query/guard/search path, spanning the MCP reader (TS) and CLI helpers (Python). Grouped into one PR because they interleave within just two files (`mcp-server/src/sqlite-reader.ts`, `cli/schist/sqlite_query.py`); splitting would mean repeated rebases between them.

### Fixes

| # | Bug | Fix |
|---|-----|-----|
| **#222** | `query_graph` rejected SELECT/WITH opening with a `--`/`/*` comment (masker blanks it → `^SELECT` anchor fails) | `trimStart()` the masked string before the anchor check |
| **#223** | CLI `raw_query` rejected valid `WITH` (CTE) queries | Accept `SELECT|WITH`; exclude CTE alias names from the `ALLOWED_TABLES` check |
| **#224** | `concept_aliases` missing from `REQUIRED_TABLES` → upgraded vaults skip rebuild, then `add_concept_alias` hits "no such table" | Added to `REQUIRED_TABLES` in both TS + Python |
| **#225** | tag/concept `LIKE` filters didn't escape `_`/`%` (e.g. `machine_learning` matched `machine-learning`) | `escapeLike`/`_escape_like` + `ESCAPE '\'` at every tag/search LIKE site |
| **#228** | CLI `ALLOWED_TABLES` check missed `` `backtick` ``/`[bracket]`-quoted tables (bypass via `FROM \`sqlite_master\``) | Extended FROM/JOIN extraction to capture both quoted forms |
| **#229** | `searchNotes` `scope=inherit` built `callingScope || '/%'` unescaped → sibling scope leak (`my-project` into `my_project`) | Escape the LIKE value + `ESCAPE '\'`; exact `= ?` comparisons unchanged |

### Tests
Added regression tests in `query-graph-tool`, `search-notes-tool`, `list-concepts-sql` (TS) and `test_sqlite_query.py` (Python). Full suites pass: **TS 469/469, Python 472 (+1 skip)**.

**Note on #224 TS coverage:** the TS `REQUIRED_TABLES` change is verified by the cross-language Python drift test plus the build. The TS reader only re-ingests on real vaults (those with `schist.yaml`); a unit test there would require spawning a real `schist-ingest`, so the behavior is asserted on the Python side where it's directly unit-testable.

### Notes
- `escapeLike`/`_escape_like` escape backslash first, then `%` and `_`, paired with `ESCAPE '\'` on every affected fragment.
- Backtick + bracket identifier-quoting are now covered for the table allow-list. (Double-quoted identifiers are masked as string literals by the shared masker — a separate, deeper concern not in scope here.)