### PR TITLE
fix: harden compose_brief annotation, scope, and seed bounds (closes #230, #231, #232)

### DIFF
--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -644,8 +644,12 @@ function ensureStringArray(value: unknown, field: string): string[] | ToolError 
 }
 
 function oneLine(text: string, cap = 180): string {
+  // No frontmatter strip here: bodies stored in SQLite are already
+  // frontmatter-free (Python ingest stores post.content), and FTS snippets
+  // never carry a YAML block. A `/m`-flagged `^---...---` strip would instead
+  // match Markdown horizontal rules in the body and silently delete content
+  // between them (see #230).
   const cleaned = text
-    .replace(/^---[\s\S]*?---\s*/m, "")
     .replace(/[#>*_`[\]()-]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
@@ -1516,7 +1520,13 @@ export async function compose_brief(
   const tagCounts = new Map<string, number>();
 
   try {
-    const searchRows = sqliteReader.searchNotes(vaultRoot, args.topic, { limit: 12 });
+    // searchNotes ranks globally; scope is applied in-memory below via
+    // matchesScopePath (a path-prefix test, not the exact docs.scope column
+    // searchNotes filters on). When a scope is requested, over-fetch so the
+    // top window isn't fully consumed by higher-ranked out-of-scope notes,
+    // which would otherwise leave the brief with zero topic matches (see #232).
+    const searchLimit = scope.length > 0 ? Math.min(60, 12 * (scope.length + 4)) : 12;
+    const searchRows = sqliteReader.searchNotes(vaultRoot, args.topic, { limit: searchLimit });
     for (const row of searchRows) {
       if (!matchesScopePath(row.id, scope)) continue;
       if (!byId.has(row.id)) byId.set(row.id, briefNoteFromSearch(row, "topic search"));
@@ -1532,7 +1542,16 @@ export async function compose_brief(
       addTags(tagCounts, note.tags);
     }
 
-    const seedIds = [...byId.keys()];
+    // Cap the graph-expansion seeds. queryGraph binds the seed list three
+    // times plus its own LIMIT/OFFSET (3 × seeds + 2 parameters); past ~332
+    // seeds that exceeds SQLite's default 999-variable limit and surfaces as
+    // an opaque INGEST_ERROR ("too many SQL variables"). A large related_notes
+    // list (each added to byId above) is the usual trigger. Bounding the seeds
+    // here loses nothing: the final brief is sliced to 10 notes regardless, and
+    // pinned notes already sit in byId whether or not they seed graph lookups
+    // (see #231).
+    const MAX_GRAPH_SEEDS = 200;
+    const seedIds = [...byId.keys()].slice(0, MAX_GRAPH_SEEDS);
     if (seedIds.length > 0) {
       const placeholders = seedIds.map(() => "?").join(", ");
       const graph = await sqliteReader.queryGraph(

--- a/mcp-server/tests/compose-brief-tool.test.ts
+++ b/mcp-server/tests/compose-brief-tool.test.ts
@@ -126,6 +126,162 @@ describe("compose_brief tool", () => {
     ]);
   });
 
+  it("keeps body content around Markdown horizontal rules in annotations (#230)", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "schist-compose-brief-hr-"));
+    const dbDir = path.join(dir, ".schist");
+    await fs.mkdir(dbDir, { recursive: true });
+    const db = new Database(path.join(dbDir, "schist.db"));
+    db.exec(`
+      CREATE TABLE docs (
+        id TEXT PRIMARY KEY, title TEXT NOT NULL, date TEXT,
+        status TEXT DEFAULT 'draft', tags TEXT, concepts TEXT,
+        body TEXT NOT NULL DEFAULT '', scope TEXT DEFAULT 'global',
+        source TEXT, confidence TEXT,
+        created_at TEXT DEFAULT (datetime('now')), updated_at TEXT DEFAULT (datetime('now'))
+      );
+      CREATE TABLE edges (id INTEGER PRIMARY KEY AUTOINCREMENT, source TEXT NOT NULL, target TEXT NOT NULL, type TEXT NOT NULL, context TEXT);
+      CREATE VIRTUAL TABLE docs_fts USING fts5(title, body, tags, scope UNINDEXED, content='docs', content_rowid='rowid');
+      CREATE TRIGGER docs_ai AFTER INSERT ON docs BEGIN
+        INSERT INTO docs_fts(rowid, title, body, tags, scope) VALUES (new.rowid, new.title, new.body, new.tags, new.scope);
+      END;
+    `);
+    // Body uses Markdown horizontal rules. The old /m frontmatter strip would
+    // eat everything between the first and second `---`, dropping the rationale.
+    const body = [
+      "## Context",
+      "Background about transformer scaling laws.",
+      "",
+      "---",
+      "",
+      "Critical rationale that must reach the brief annotation.",
+      "",
+      "---",
+      "",
+      "Further detail.",
+    ].join("\n");
+    db.prepare(`INSERT INTO docs (id, title, date, tags, body, scope) VALUES (?, ?, ?, ?, ?, ?)`)
+      .run("research/hr.md", "Horizontal Rule Note", "2026-06-16", JSON.stringify(["scaling"]), body, "global");
+    db.close();
+    execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: dir });
+
+    // Pin the note so its annotation is built from the full body (oneLine(body)),
+    // which is where the HR-strip bug deletes content; search results annotate
+    // from a truncated FTS snippet instead.
+    const result = await compose_brief(dir, {
+      topic: "transformer scaling rationale",
+      related_notes: ["research/hr.md"],
+    });
+    if ("error" in result) throw new Error(result.message);
+    expect(result.related_notes.map((n) => n.id)).toContain("research/hr.md");
+    // The annotation is rendered into the markdown brief. With the old /m
+    // frontmatter strip, the "Critical rationale" line (between two `---`
+    // rules) was silently dropped from the annotation.
+    expect(result.markdown).toContain("Critical rationale");
+
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns scope-matching topic results even when out-of-scope notes rank higher (#232)", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "schist-compose-brief-scope-"));
+    const dbDir = path.join(dir, ".schist");
+    await fs.mkdir(dbDir, { recursive: true });
+    const db = new Database(path.join(dbDir, "schist.db"));
+    db.exec(`
+      CREATE TABLE docs (
+        id TEXT PRIMARY KEY, title TEXT NOT NULL, date TEXT,
+        status TEXT DEFAULT 'draft', tags TEXT, concepts TEXT,
+        body TEXT NOT NULL DEFAULT '', scope TEXT DEFAULT 'global',
+        source TEXT, confidence TEXT,
+        created_at TEXT DEFAULT (datetime('now')), updated_at TEXT DEFAULT (datetime('now'))
+      );
+      CREATE TABLE edges (id INTEGER PRIMARY KEY AUTOINCREMENT, source TEXT NOT NULL, target TEXT NOT NULL, type TEXT NOT NULL, context TEXT);
+      CREATE VIRTUAL TABLE docs_fts USING fts5(title, body, tags, scope UNINDEXED, content='docs', content_rowid='rowid');
+      CREATE TRIGGER docs_ai AFTER INSERT ON docs BEGIN
+        INSERT INTO docs_fts(rowid, title, body, tags, scope) VALUES (new.rowid, new.title, new.body, new.tags, new.scope);
+      END;
+    `);
+    const insertDoc = db.prepare(`INSERT INTO docs (id, title, date, tags, body, scope) VALUES (?, ?, ?, ?, ?, ?)`);
+    // 30 highly-relevant research/ notes outrank a handful of ops/ notes.
+    for (let i = 0; i < 30; i++) {
+      insertDoc.run(
+        `research/nn-${i}.md`, `Research ${i}`, "2026-06-16",
+        JSON.stringify(["research"]),
+        "neural network training neural network training neural network training",
+        "global",
+      );
+    }
+    insertDoc.run(
+      "ops/runbook.md", "Ops Runbook", "2026-06-16",
+      JSON.stringify(["ops"]),
+      "neural network training runbook for the ops cluster",
+      "global",
+    );
+    db.close();
+    execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: dir });
+
+    const result = await compose_brief(dir, { topic: "neural network training", scope: ["ops"] });
+    if ("error" in result) throw new Error(result.message);
+    expect(result.related_notes.map((n) => n.id)).toContain("ops/runbook.md");
+
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("does not overflow SQLite variable limit with a large related_notes list (#231)", async () => {
+    // Real pinned notes all land in byId and become graph seeds. The graph
+    // query binds 3 × seeds + 2 parameters; once that exceeds SQLite's
+    // variable limit it crashes with INGEST_ERROR "too many SQL variables".
+    // The bundled SQLite uses the modern 32766 default (older builds use 999),
+    // so we seed >10922 notes to cross it without the cap. The fix slices seeds
+    // to 200 regardless of build, so this stays well clear on any deployment.
+    const COUNT = 11_000;
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "schist-compose-brief-overflow-"));
+    const dbDir = path.join(dir, ".schist");
+    await fs.mkdir(dbDir, { recursive: true });
+    const db = new Database(path.join(dbDir, "schist.db"));
+    db.exec(`
+      CREATE TABLE docs (
+        id TEXT PRIMARY KEY, title TEXT NOT NULL, date TEXT,
+        status TEXT DEFAULT 'draft', tags TEXT, concepts TEXT,
+        body TEXT NOT NULL DEFAULT '', scope TEXT DEFAULT 'global',
+        source TEXT, confidence TEXT,
+        created_at TEXT DEFAULT (datetime('now')), updated_at TEXT DEFAULT (datetime('now'))
+      );
+      CREATE TABLE edges (id INTEGER PRIMARY KEY AUTOINCREMENT, source TEXT NOT NULL, target TEXT NOT NULL, type TEXT NOT NULL, context TEXT);
+      CREATE VIRTUAL TABLE docs_fts USING fts5(title, body, tags, scope UNINDEXED, content='docs', content_rowid='rowid');
+      CREATE TRIGGER docs_ai AFTER INSERT ON docs BEGIN
+        INSERT INTO docs_fts(rowid, title, body, tags, scope) VALUES (new.rowid, new.title, new.body, new.tags, new.scope);
+      END;
+    `);
+    const insertDoc = db.prepare(`INSERT INTO docs (id, title, date, tags, body, scope) VALUES (?, ?, ?, ?, ?, ?)`);
+    const pinned: string[] = [];
+    const insertMany = db.transaction(() => {
+      for (let i = 0; i < COUNT; i++) {
+        const id = `decisions/pinned-${i}.md`;
+        insertDoc.run(id, `Decision ${i}`, "2026-06-16", JSON.stringify(["decision"]), `Pinned body ${i}.`, "global");
+        pinned.push(id);
+      }
+    });
+    insertMany();
+    db.close();
+    execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: dir });
+
+    const result = await compose_brief(dir, { topic: "decision", related_notes: pinned });
+    expect(result).not.toHaveProperty("error");
+    const brief = result as Awaited<ReturnType<typeof compose_brief>>;
+    if ("error" in brief) throw new Error(brief.message);
+    // The brief is capped at 10 notes regardless, and pinned notes still appear.
+    expect(brief.related_notes.length).toBeGreaterThan(0);
+    expect(brief.related_notes.every((n) => n.id.startsWith("decisions/pinned-"))).toBe(true);
+
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
   it("validates topic and array arguments", async () => {
     await expect(compose_brief(vaultRoot, { topic: "" })).resolves.toMatchObject({
       error: "VALIDATION_ERROR",


### PR DESCRIPTION
Three bugs in the `compose_brief` MCP tool, all in the SQLite query/brief path (`mcp-server/src/tools.ts`). Grouped into one PR — same pattern as the query-guard cluster (#234) — because they interleave in one function and one test file.

### Fixes

| # | Bug | Fix |
|---|-----|-----|
| **#230** | `oneLine()` silently dropped body content between Markdown horizontal rules — the `/m`-flagged `^---...---` strip matched any `---` line in the body and deleted everything up to the next one | Removed the frontmatter strip entirely; SQLite bodies are already frontmatter-free, so it was unnecessary and harmful |
| **#231** | A large `related_notes` list overflowed SQLite's bound-variable limit (`queryGraph` binds 3 × seeds + 2; crashed with opaque `INGEST_ERROR` past 999 on older builds / 32766 on modern) | Cap graph seeds at 200 — the brief is sliced to 10 notes regardless, so nothing is lost |
| **#232** | Scoped topic search silently returned zero matches when the top-12 global FTS results were all out of scope | Over-fetch the FTS window when a scope filter is set, so scope-matching notes survive the in-memory filter |

### Tests

Three regression tests added to `compose-brief-tool.test.ts`, **each verified to fail without its fix** (reverted src → all three red; restored → green). Full `mcp-server` suite: **472 passing** (was 469). `tsc --noEmit` clean.

Closes #230
Closes #231
Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)